### PR TITLE
ci: add-issues-and-prs-to-fs-project-board.yml

### DIFF
--- a/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -1,0 +1,30 @@
+######################################################################################
+# READ THIS FIRST
+# This file is authored in FilOzone/github-mgmt repository and MANUALLY copied to other repos.
+# See https://github.com/FilOzone/github-mgmt/blob/master/files/workflows/add-issues-and-prs-to-fs-project-board.yml for more info.
+######################################################################################
+
+# This action adds all issues and PRs to the FS project board.
+# It is used to keep the project board up to date with the issues and PRs.
+# It is triggered by the issue and PR events.
+# It assumes a `FILOZZY_CI_ADD_TO_PROJECT` secret is set in the repo.
+# This secret should have the permissions outlined in https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository
+name: Add issues and PRs to FS project board
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add all issues and prs to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/FilOzone/projects/14
+          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}


### PR DESCRIPTION
Adds https://github.com/FilOzone/github-mgmt/blob/master/files/workflows/add-issues-and-prs-to-fs-project-board.yml

Note: this shouldn't be merged until this repo is made public since our organizational secret for `FILOZZY_CI_ADD_TO_PROJECT` can only be shared with public repos (because of our organizational plan)

<img width="633" height="532" alt="image" src="https://github.com/user-attachments/assets/384db096-b5dd-40be-95e6-18ae0c439450" />

_[screenshot source](https://github.com/organizations/FilOzone/settings/secrets/actions/FILOZZY_CI_ADD_TO_PROJECT)_

Alternatively, we can setup a local `FILOZZY_CI_ADD_TO_PROJECT` to this repo if we want to keep this private for awhile.