### PR TITLE
fix: payments setup script exits when done

### DIFF
--- a/src/payments/auto.ts
+++ b/src/payments/auto.ts
@@ -283,8 +283,9 @@ export async function runAutoSetup(options: PaymentSetupOptions): Promise<void> 
     console.error(pc.red('✗ Setup failed'))
     console.error(pc.red('Error:'), error instanceof Error ? error.message : error)
 
+    process.exitCode = 1
+  } finally {
     await cleanupProvider(provider)
-
-    process.exit(1)
+    process.exit()
   }
 }

--- a/src/payments/interactive.ts
+++ b/src/payments/interactive.ts
@@ -442,9 +442,9 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
     outro('Payment setup completed successfully')
   } catch (error) {
     console.error(`\n${pc.red('Error:')}`, error instanceof Error ? error.message : error)
-
+    process.exitCode = 1
+  } finally {
     await cleanupProvider(provider)
-
-    process.exit(1)
+    process.exit()
   }
 }


### PR DESCRIPTION
`npx filecoin-pin payments setup` used to hang after completing because `cleanupProvider` was only being called in the catch block.

This pr updates the auto and interactive scripts to:

1. set process.exitCode = 1 in error case
2. add a finally block that calls `await cleanupProvider(provider)`
3. and then calls `process.exit()`
