### PR TITLE
ci: create add-issues-and-prs-to-fs-project-board.yml

### DIFF
--- a/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -1,0 +1,35 @@
+######################################################################################
+# READ THIS FIRST
+# This file is authored in filecoin-project/github-mgmt repository and MANUALLY copied to other repos.
+# See https://github.com/filecoin-project/github-mgmt/blob/master/files/workflows/add-issues-and-prs-to-fs-project-board.yml for more info.
+######################################################################################
+
+# This action adds all issues and PRs with a "team/fs-wg" label to the FS project board.
+# It is used to keep the FS project board up to date with the issues and PRs.
+# It is triggered by the issue and PR events.
+# It assumes a `FILOZZY_CI_ADD_TO_PROJECT` secret is set in the repo.
+# This secret should have the permissions outlined in https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository
+name: Add issues and PRs to FS project board
+
+on:
+  issues:
+    types:
+      - labeled
+  # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
+  # Workflow runs triggered on PRs from forks do not have access to secrets, so "github-token" input below would otherwise be empty.
+  # This action does not check out nor execute user code so we should be safe.
+  # We also hardcode to specific hash to ensure no unintended changes underneath us.  
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add all "team/fs-wg" issues and PRs to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        with:
+          project-url: https://github.com/orgs/FilOzone/projects/14
+          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}
+          labeled: team/fs-wg


### PR DESCRIPTION
Followup to https://github.com/FilOzone/github-mgmt/issues/10

The repo has access to the secret:
<img width="534" height="324" alt="image" src="https://github.com/user-attachments/assets/56572772-c778-46b6-bbee-2f4bd30f0dc4" />
