### PR TITLE
fix: avoid empty-directory block in directory CAR

### DIFF
--- a/src/core/unixfs/car-builder.ts
+++ b/src/core/unixfs/car-builder.ts
@@ -190,8 +190,9 @@ async function createCarFromDirectory(dirPath: string, options: CreateCarOptions
 
     // Use globSource with the parent directory as base and include the directory name in the pattern
     // This ensures the directory name is part of the UnixFS structure
-    // We use {,/**/*} to match both the directory itself and everything under it
-    const pattern = `${dirName}{,/**/*}`
+    // We match only the directory contents (/**/*), not the directory itself
+    // addAll will automatically create the root directory entry with proper links
+    const pattern = `${dirName}/**/*`
     logger?.info({ absolutePath, parentDir, dirName, pattern }, 'Directory structure for UnixFS')
 
     const candidates = globSource(parentDir, pattern, {

--- a/src/test/unit/unixfs-car.test.ts
+++ b/src/test/unit/unixfs-car.test.ts
@@ -473,5 +473,30 @@ describe('UnixFS CAR Creation', () => {
       await rm(carPath, { force: true })
       await rm(basePath, { recursive: true, force: true })
     })
+
+    it('should create exactly 3 blocks for simple directory with 2 small files', async () => {
+      // Create a simple directory with 2 small files
+      const simpleDir = join(testDir, 'simple-dir')
+      await mkdir(simpleDir, { recursive: true })
+
+      // Create 2 small files (small enough to be single blocks each)
+      await writeFile(join(simpleDir, 'file1.txt'), 'content of file 1')
+      await writeFile(join(simpleDir, 'file2.txt'), 'content of file 2')
+
+      const { carPath, rootCid } = await createCarFromPath(simpleDir)
+
+      expect(rootCid).toBeDefined()
+
+      // Expected blocks:
+      // 1. file1.txt data block (raw)
+      // 2. file2.txt data block (raw)
+      // 3. directory block (dag-pb) linking to file1 and file2
+      const blockCount = await countBlocks(carPath)
+      expect(blockCount).toBe(3)
+
+      // Clean up
+      await rm(carPath, { force: true })
+      await rm(simpleDir, { recursive: true, force: true })
+    })
   })
 })


### PR DESCRIPTION
The wrong use of glob pattern was leading to an unlinked empty directory block (bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354) at the start of every CAR produced by createCarFromDirectory. This isn't harmful, but it's also not right.

Ref: https://github.com/filecoin-project/filecoin-pin/pull/83#discussion_r2415372437