### PR TITLE
deps: @filoz/synapse-sdk@0.30.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "homepage": "https://github.com/FilOzone/filecoin-pin#readme",
   "dependencies": {
     "@clack/prompts": "^0.11.0",
-    "@filoz/synapse-sdk": "^0.29.3",
+    "@filoz/synapse-sdk": "^0.30.1",
     "@helia/unixfs": "^5.1.0",
     "@ipld/car": "^5.4.2",
     "commander": "^14.0.1",


### PR DESCRIPTION
we need the wallet fix for the filecoin-pin-website inbrowser usage (without metamask blocking when we're setting private key explicitly)

see https://github.com/FilOzone/synapse-sdk/pull/290