### PR TITLE
fix: createStorageContext supports multi-tenancy

### DIFF
--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -152,18 +152,20 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
     spinner.start('Creating storage context...')
 
     const { storage, providerInfo } = await createStorageContext(synapse, logger, {
-      onProviderSelected: (provider) => {
-        spinner.message(`Connecting to storage provider: ${provider.name || provider.serviceProvider}...`)
-      },
-      onDataSetCreationStarted: (transaction) => {
-        spinner.message(`Creating data set (tx: ${transaction.hash.slice(0, 10)}...)`)
-      },
-      onDataSetResolved: (info) => {
-        if (info.isExisting) {
-          spinner.message(`Using existing data set #${info.dataSetId}`)
-        } else {
-          spinner.message(`Created new data set #${info.dataSetId}`)
-        }
+      callbacks: {
+        onProviderSelected: (provider) => {
+          spinner.message(`Connecting to storage provider: ${provider.name || provider.serviceProvider}...`)
+        },
+        onDataSetCreationStarted: (transaction) => {
+          spinner.message(`Creating data set (tx: ${transaction.hash.slice(0, 10)}...)`)
+        },
+        onDataSetResolved: (info) => {
+          if (info.isExisting) {
+            spinner.message(`Using existing data set #${info.dataSetId}`)
+          } else {
+            spinner.message(`Created new data set #${info.dataSetId}`)
+          }
+        },
       },
     })
 

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -196,18 +196,20 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
     spinner.start('Creating storage context...')
 
     const { storage, providerInfo } = await createStorageContext(synapse, logger, {
-      onProviderSelected: (provider) => {
-        spinner.message(`Connecting to storage provider: ${provider.name || provider.serviceProvider}...`)
-      },
-      onDataSetCreationStarted: (transaction) => {
-        spinner.message(`Creating data set (tx: ${transaction.hash.slice(0, 10)}...)`)
-      },
-      onDataSetResolved: (info) => {
-        if (info.isExisting) {
-          spinner.message(`Using existing data set #${info.dataSetId}`)
-        } else {
-          spinner.message(`Created new data set #${info.dataSetId}`)
-        }
+      callbacks: {
+        onProviderSelected: (provider) => {
+          spinner.message(`Connecting to storage provider: ${provider.name || provider.serviceProvider}...`)
+        },
+        onDataSetCreationStarted: (transaction) => {
+          spinner.message(`Creating data set (tx: ${transaction.hash.slice(0, 10)}...)`)
+        },
+        onDataSetResolved: (info) => {
+          if (info.isExisting) {
+            spinner.message(`Using existing data set #${info.dataSetId}`)
+          } else {
+            spinner.message(`Created new data set #${info.dataSetId}`)
+          }
+        },
       },
     })
 

--- a/src/test/unit/dataset-management.test.ts
+++ b/src/test/unit/dataset-management.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for dataset management in multi-tenant scenarios
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createConfig } from '../../config.js'
+import {
+  createStorageContext,
+  initializeSynapse,
+  resetSynapseService,
+  type SynapseSetupConfig,
+  setupSynapse,
+} from '../../core/synapse/index.js'
+import { createLogger } from '../../logger.js'
+
+// Mock the Synapse SDK
+vi.mock('@filoz/synapse-sdk', async () => await import('../mocks/synapse-sdk.js'))
+
+describe('Dataset Management', () => {
+  let config: SynapseSetupConfig
+  let logger: ReturnType<typeof createLogger>
+
+  beforeEach(() => {
+    config = {
+      ...createConfig(),
+      privateKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+      rpcUrl: 'wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1',
+    }
+    logger = createLogger(config)
+    resetSynapseService()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Default behavior (reuse dataset)', () => {
+    it('should reuse existing dataset by default', async () => {
+      const service = await setupSynapse(config, logger)
+
+      expect(service.storage).toBeDefined()
+      expect(service.storage.dataSetId).toBeDefined()
+    })
+
+    it('should not force create dataset without explicit option', async () => {
+      const synapse = await initializeSynapse(config, logger)
+      const createContextSpy = vi.spyOn(synapse.storage, 'createContext')
+
+      await createStorageContext(synapse, logger)
+
+      // Should NOT have forceCreateDataSet or dataSetId set
+      const callArgs = createContextSpy.mock.calls[0]?.[0]
+      expect(callArgs).toBeDefined()
+      expect(callArgs?.forceCreateDataSet).toBeUndefined()
+      expect(callArgs?.dataSetId).toBeUndefined()
+    })
+  })
+
+  describe('Create new dataset (multi-user scenario)', () => {
+    it('should force create new dataset when createNew is true', async () => {
+      const synapse = await initializeSynapse(config, logger)
+      const createContextSpy = vi.spyOn(synapse.storage, 'createContext')
+
+      await createStorageContext(synapse, logger, {
+        dataset: { createNew: true },
+      })
+
+      expect(createContextSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          forceCreateDataSet: true,
+        })
+      )
+    })
+
+    it('should create new dataset via setupSynapse', async () => {
+      const service = await setupSynapse(config, logger, {
+        dataset: { createNew: true },
+      })
+
+      expect(service.storage).toBeDefined()
+      expect(service.storage.dataSetId).toBeDefined()
+    })
+
+    it('should log dataset creation', async () => {
+      const infoSpy = vi.spyOn(logger, 'info')
+      const synapse = await initializeSynapse(config, logger)
+
+      await createStorageContext(synapse, logger, {
+        dataset: { createNew: true },
+      })
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'synapse.storage.dataset.create_new',
+        }),
+        'Forcing creation of new dataset'
+      )
+    })
+
+    it('should support custom metadata for new datasets', async () => {
+      const synapse = await initializeSynapse(config, logger)
+      const createContextSpy = vi.spyOn(synapse.storage, 'createContext')
+
+      await createStorageContext(synapse, logger, {
+        dataset: {
+          createNew: true,
+          metadata: {
+            userId: 'user-123',
+            sessionId: 'session-456',
+          },
+        },
+      })
+
+      expect(createContextSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            userId: 'user-123',
+            sessionId: 'session-456',
+          }),
+        })
+      )
+    })
+  })
+
+  describe('Connect to existing dataset', () => {
+    it('should connect to specific dataset by ID', async () => {
+      const synapse = await initializeSynapse(config, logger)
+      const createContextSpy = vi.spyOn(synapse.storage, 'createContext')
+      const datasetId = 456
+
+      await createStorageContext(synapse, logger, {
+        dataset: { useExisting: datasetId },
+      })
+
+      expect(createContextSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dataSetId: datasetId,
+        })
+      )
+    })
+
+    it('should log connection to existing dataset', async () => {
+      const infoSpy = vi.spyOn(logger, 'info')
+      const synapse = await initializeSynapse(config, logger)
+      const datasetId = 789
+
+      await createStorageContext(synapse, logger, {
+        dataset: { useExisting: datasetId },
+      })
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'synapse.storage.dataset.existing',
+          dataSetId: datasetId,
+        }),
+        'Connecting to existing dataset'
+      )
+    })
+
+    it('useExisting should take precedence over createNew', async () => {
+      const synapse = await initializeSynapse(config, logger)
+      const createContextSpy = vi.spyOn(synapse.storage, 'createContext')
+      const datasetId = 999
+
+      await createStorageContext(synapse, logger, {
+        dataset: {
+          useExisting: datasetId,
+          createNew: true, // This should be ignored
+        },
+      })
+
+      // Should have dataSetId set but NOT forceCreateDataSet
+      const callArgs = createContextSpy.mock.calls[0]?.[0]
+      expect(callArgs).toBeDefined()
+      expect(callArgs?.dataSetId).toBe(datasetId)
+      expect(callArgs?.forceCreateDataSet).toBeUndefined()
+    })
+  })
+
+  describe('Progress callbacks', () => {
+    it('should call onDataSetResolved callback', async () => {
+      const onDataSetResolved = vi.fn()
+      const synapse = await initializeSynapse(config, logger)
+
+      await createStorageContext(synapse, logger, {
+        callbacks: { onDataSetResolved },
+      })
+
+      // Mock SDK fires this callback, our wrapper should pass it through
+      expect(onDataSetResolved).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dataSetId: expect.any(Number),
+          isExisting: expect.any(Boolean),
+        })
+      )
+    })
+
+    it('should call onProviderSelected callback', async () => {
+      const onProviderSelected = vi.fn()
+      const synapse = await initializeSynapse(config, logger)
+
+      await createStorageContext(synapse, logger, {
+        callbacks: { onProviderSelected },
+      })
+
+      expect(onProviderSelected).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expect.any(Number),
+          serviceProvider: expect.any(String),
+        })
+      )
+    })
+  })
+})

--- a/src/test/unit/import.test.ts
+++ b/src/test/unit/import.test.ts
@@ -89,14 +89,14 @@ vi.mock('../../core/synapse/index.js', async () => {
       const mockSynapse = new MockSynapse()
       return mockSynapse
     }),
-    createStorageContext: vi.fn(async (_synapse: any, _logger: any, progressCallbacks?: any) => {
+    createStorageContext: vi.fn(async (_synapse: any, _logger: any, options?: any) => {
       const mockSynapse = new MockSynapse()
 
       // Simulate progress callbacks
-      if (progressCallbacks) {
+      if (options?.callbacks) {
         // Simulate provider selection
         setTimeout(() => {
-          progressCallbacks.onProviderSelected?.({
+          options.callbacks.onProviderSelected?.({
             id: 1,
             name: 'Mock Provider',
             serviceProvider: '0x1234567890123456789012345678901234567890',
@@ -105,7 +105,7 @@ vi.mock('../../core/synapse/index.js', async () => {
 
         // Simulate dataset resolution
         setTimeout(() => {
-          progressCallbacks.onDataSetResolved?.({
+          options.callbacks.onDataSetResolved?.({
             dataSetId: 123,
             isExisting: false,
           })
@@ -345,9 +345,11 @@ describe('CAR Import', () => {
         expect.any(Object), // synapse
         expect.any(Object), // logger
         expect.objectContaining({
-          onProviderSelected: expect.any(Function),
-          onDataSetCreationStarted: expect.any(Function),
-          onDataSetResolved: expect.any(Function),
+          callbacks: expect.objectContaining({
+            onProviderSelected: expect.any(Function),
+            onDataSetCreationStarted: expect.any(Function),
+            onDataSetResolved: expect.any(Function),
+          }),
         })
       )
     })


### PR DESCRIPTION
## Summary of Changes to `createStorageContext`

### API Changes

**Added structured options object:**
- Introduced `CreateStorageContextOptions` interface as third parameter
- Replaced top-level callback parameters with nested structure
- Added `dataset` options for multi-tenant use cases

**New interface:**
```typescript
interface CreateStorageContextOptions {
  dataset?: {
    createNew?: boolean        // Force creation of new dataset
    useExisting?: number       // Connect to specific dataset by ID
    metadata?: Record<string, string>  // Custom metadata
  }
  callbacks?: {
    onProviderSelected?: (provider: ProviderInfo) => void
    onDataSetCreationStarted?: (transaction: { hash: string }) => void
    onDataSetResolved?: (info: { dataSetId: number; isExisting: boolean }) => void
  }
}
```

### Multi-Tenant Dataset Support

- `dataset.createNew: true` - Forces creation of new dataset (for shared wallet scenarios)
- `dataset.useExisting: number` - Connects to specific dataset by ID
- Enables per-user dataset isolation when multiple users share same wallet

### Breaking Changes

but we're in alpha, so no ! or "breaking change" release yet.

**Before:**
```typescript
await createStorageContext(synapse, logger, progressCallbacks)
```

**After:**
```typescript
await createStorageContext(synapse, logger, {
  callbacks: {
    onProviderSelected: (provider) => { ... },
    onDataSetResolved: (info) => { ... }
  },
  dataset: { createNew: true }
})
```

### Files Modified

- `src/core/synapse/index.ts` - Added options interface and dataset handling
- `src/add/add.ts` - Updated to use nested callbacks structure
- `src/import/import.ts` - Updated to use nested callbacks structure
- `src/test/unit/*.ts` - Updated tests for new API structure

### Related

Related https://github.com/filecoin-project/filecoin-pin-website/issues/11
Related https://github.com/filecoin-project/filecoin-pin/issues/91
