### PR TITLE
fix: prevent some checks when using session key

### DIFF
--- a/src/core/synapse/address-only-signer.ts
+++ b/src/core/synapse/address-only-signer.ts
@@ -11,8 +11,15 @@ import { AbstractSigner, type Provider, type TransactionRequest } from 'ethers'
 const cannotSign = (thing: string) =>
   `Cannot sign ${thing} - this is an address-only signer for session key authentication. Signing operations should be performed by the session key.`
 
+/**
+ * Symbol used to identify AddressOnlySigner instances
+ * This is more reliable than instanceof checks across module boundaries
+ */
+export const ADDRESS_ONLY_SIGNER_SYMBOL = Symbol.for('filecoin-pin.AddressOnlySigner')
+
 export class AddressOnlySigner extends AbstractSigner {
   readonly address: string
+  readonly [ADDRESS_ONLY_SIGNER_SYMBOL] = true
 
   constructor(address: string, provider?: Provider) {
     super(provider)

--- a/src/test/unit/import.test.ts
+++ b/src/test/unit/import.test.ts
@@ -85,6 +85,7 @@ vi.mock('../../core/synapse/index.js', async () => {
   const { MockSynapse } = await import('../mocks/synapse-mocks.js')
 
   return {
+    isSessionKeyMode: vi.fn(() => false),
     initializeSynapse: vi.fn(async (_config: any, _logger: any) => {
       const mockSynapse = new MockSynapse()
       return mockSynapse

--- a/src/test/unit/payments-setup.test.ts
+++ b/src/test/unit/payments-setup.test.ts
@@ -50,6 +50,12 @@ vi.mock('@filoz/synapse-sdk', () => {
     SIZE_CONSTANTS: {
       MIN_UPLOAD_SIZE: 127,
     },
+    METADATA_KEYS: {
+      WITH_IPFS_INDEXING: 'withIPFSIndexing',
+      IPFS_ROOT_CID: 'ipfsRootCid',
+    },
+    ADD_PIECES_TYPEHASH: '0x1234567890abcdef',
+    CREATE_DATA_SET_TYPEHASH: '0xabcdef1234567890',
   }
 })
 


### PR DESCRIPTION
When calling `checkUploadReadiness` with a filecoin-pin session key, it should not try to configure allowances.

Note: we need to make this more robust for the future, and should add helpers for consumers and authorization checks of the session key, because some session keys might have varying permissions.

cc @rvagg

related to #101 we likely need to fix logic because if allowances are set we shouldn't need to set them again
