### PR TITLE
fix: re-use upload-action PR comment

### DIFF
--- a/upload-action/src/comments/comment.js
+++ b/upload-action/src/comments/comment.js
@@ -13,7 +13,8 @@ import { getOutputSummary } from '../outputs.js'
  * @returns
  */
 const generateCommentBody = (context, status) => {
-  return `${getOutputSummary(context, status)}
+  return `<!-- filecoin-pin-upload-action -->
+  ${getOutputSummary(context, status)}
   <a href="${getWorkflowRunUrl()}">More details</a>`
 }
 


### PR DESCRIPTION
fixes #99

Testing at https://github.com/filecoin-project/filecoin-pin-github-action-test/pull/12

this is fixed: 

<img width="956" height="761" alt="image" src="https://github.com/user-attachments/assets/07cc3ef5-0bd6-45b0-a366-c904ae4d690d" />

