### PR TITLE
fix: log level defaults to error for CLI

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,7 +1,7 @@
 import { type Logger, pino } from 'pino'
 
-export function createLogger(config: { logLevel?: string }): Logger {
+export function createLogger(config: { logLevel?: string | undefined }): Logger {
   return pino({
-    level: config.logLevel ?? 'info',
+    level: config.logLevel ?? 'error',
   })
 }

--- a/src/utils/cli-auth.ts
+++ b/src/utils/cli-auth.ts
@@ -105,5 +105,5 @@ export function parseProviderOptions(options?: CLIAuthOptions): ProviderSelectio
  * @returns Logger configured for CLI use
  */
 export function getCLILogger() {
-  return createLogger({ logLevel: process.env.LOG_LEVEL || 'info' })
+  return createLogger({ logLevel: process.env.LOG_LEVEL })
 }


### PR DESCRIPTION
Fix CLI commands outputting pino log entries unexpectedly.

cc @rvagg
