### PR TITLE
ci: configure release-please workflow to use trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
       - master
 
 permissions:
+  id-token: write  # Required for OIDC
   contents: write
   pull-requests: write
 
@@ -31,6 +32,11 @@ jobs:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
 
+      # Ensure npm 11.5.1 or later is installed
+      - name: Update npm
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         if: ${{ steps.release.outputs.release_created }}
         run: npm install
@@ -42,5 +48,3 @@ jobs:
       - name: Publish to npm
         if: ${{ steps.release.outputs.release_created }}
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR configures the release-please workflow to use trusted publishing. It is needed because NPM classic tokens (presumably used in this repository currently) are going to be deprecated in November.

Before this PR can be merged, package maintainer should configure trusted publishing on npmjs.org.

After this PR is merged, we can delete the NPM_TOKEN secret from the repository secrets.

#### How to configure trusted publishing on npmjs.org?

1. Go to https://www.npmjs.com/package/filecoin-pin/access
2. Click on the GitHub Actions button in the Trusted Publishing section
3. Fill out the form with the following details:
  - Organization: `filecoin-project`
  - Repository: `filecoin-pin`
  - Workflow: `release-please.yml`