### PR TITLE
fix: only typecheck upload-action in CI for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,4 @@ jobs:
       - name: Check TypeScript
         run: |
           npm run typecheck
+          npm run typecheck --prefix upload-action

--- a/package.json
+++ b/package.json
@@ -73,9 +73,7 @@
     "test:watch": "vitest",
     "lint": "tsc && biome check --no-errors-on-unmatched --files-ignore-unknown=true .",
     "lint:fix": "biome check --no-errors-on-unmatched --files-ignore-unknown=true --fix .",
-    "typecheck": "npm run typecheck:root && npm run typecheck:upload-action",
-    "typecheck:root": "tsc --noEmit",
-    "typecheck:upload-action": "npm run typecheck --prefix upload-action",
+    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
Fixes an issue brought up in Slack: https://filecoinproject.slack.com/archives/C095WFA0QK1/p1762164463986919?thread_ts=1762147843.661809&cid=C095WFA0QK1

> we either need to decouple upload-action from the root package.json’s scripts (it shouldn’t be testing if its deps aren’t installed with an npm install), or maybe we just need to go monorepo for this now

