### PR TITLE
chore: update to synapse-sdk-v0.35.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "homepage": "https://github.com/filecoin-project/filecoin-pin#readme",
   "dependencies": {
     "@clack/prompts": "^0.11.0",
-    "@filoz/synapse-sdk": "^0.35.2",
+    "@filoz/synapse-sdk": "^0.35.3",
     "@helia/unixfs": "^6.0.1",
     "@ipld/car": "^5.4.2",
     "commander": "^14.0.1",


### PR DESCRIPTION
Using the latest Synapse which has telemetry cleanups.