### PR TITLE
fix: piece metadata is displayed as is

### DIFF
--- a/src/data-set/display.ts
+++ b/src/data-set/display.ts
@@ -171,17 +171,13 @@ function renderMetadata(metadata: Record<string, string>, indentLevel: number = 
  * Render a single piece entry including CommP, root CID, size, and extra metadata.
  */
 function renderPiece(piece: PieceInfo, baseIndentLevel: number = 2): void {
-  const rootDisplay = piece.rootIpfsCid ?? piece.metadata?.[METADATA_KEYS.IPFS_ROOT_CID] ?? pc.gray('unknown')
   const sizeDisplay = piece.size != null ? formatFileSize(piece.size) : pc.gray('unknown')
 
   log.indent(pc.bold(`#${piece.pieceId}`), baseIndentLevel)
   log.indent(`PieceCID: ${piece.pieceCid}`, baseIndentLevel + 1)
-  log.indent(`IPFS Root CID: ${rootDisplay}`, baseIndentLevel + 1)
   log.indent(`Size: ${sizeDisplay}`, baseIndentLevel + 1)
 
-  const extraMetadataEntries = Object.entries(piece.metadata ?? {}).filter(
-    ([key]) => key !== METADATA_KEYS.IPFS_ROOT_CID
-  )
+  const extraMetadataEntries = Object.entries(piece.metadata ?? {})
 
   renderMetadata(Object.fromEntries(extraMetadataEntries), baseIndentLevel + 1)
 }


### PR DESCRIPTION
Fixes #216

See output below:

```shell
┌  Filecoin Onchain Cloud Data Set Details for #48
│
◇  ━━━ Data Set ━━━
│
│  Network: calibration
│  Client address: 0x2B3d0b827BAded638279C637d7ef21a266994c9E
│
│  #48
│    Status: live
│    CDN add-on: disabled
│
│    Provider
│      ID: 2
│      Address: 0xbCdf1bdc1a97D071a5a8EF03F1F05225b6E2a1Ba
│      Name: ezpdpz-calib2
│      Description: PDP Calibration node based in the UK
│      Service URL: https://calib2.ezpdpz.net
│      Active: yes
│      Location: C=GB;ST=Gloucestershire;L=Cheltenham
│
│    Metadata
│      source: "filecoin-pin"
│      withIPFSIndexing: ""
│
│    Payment
│      PDP rail ID: 89
│      Payer: 0x2B3d0b827BAded638279C637d7ef21a266994c9E
│      Payee: 0xbCdf1bdc1a97D071a5a8EF03F1F05225b6E2a1Ba
│
│    Pieces
│      Total pieces: 8
│      Total size: 1.8 KB
│      Unique PieceCIDs: 8
│      Unique IPFS Root CIDs: 8
│
│      #0
│        PieceCID: bafkzcibcdubu26mgqsonwla4uxr5mhf4guvnpsotibmukhiqf77ivnw4nyzsepa
│        Size: 225.0 B
│        Metadata
│          ipfsRootCID: "bafybeihkxtq5henfne4hzxaaep57apwyxmfinszncxry7wktxcawbcqujy"
│
│      #1
│        PieceCID: bafkzcibcdub2fsyawhoxetnwlwxajaqovmapo6b2tgkuw2uwhnjwdqfo2zt6wmq
│        Size: 225.0 B
│        Metadata
│          ipfsRootCID: "bafybeidifi6iaamwjrohdnsnumattjcraz6rm46mbfzpphkbtgnse2wd54"
│
│      #2
│        PieceCID: bafkzcibcdub3mf2pi3y523askafb774xgzz5rwma2qgjpi2tgacxevdozo2huja
│        Size: 225.0 B
│        Metadata
│          ipfsRootCID: "bafybeids6gixmju6uwwji332pa7mg2hej2ecojoqppa5let6whxvuw474u"
│
│      #3
│        PieceCID: bafkzcibcdubu56fv7yais7htphs3j6q6n53sl3osyrwsc45a6zuvv2amdj5qopi
│        Size: 225.0 B
│        Metadata
│          ipfsRootCID: "bafybeieltmtc5xuye5h4jfhjpyujrcloyll5fjdsuop4ulvx6raekxl6zy"
│
│      #4
│        PieceCID: bafkzcibcdubzlvmhmqgjksynuephe32tz7letfuct6o6ielczcsjkifrpfllobq
│        Size: 225.0 B
│        Metadata
│          ipfsRootCID: "bafybeig5utgrmrfqsvvhq42zopcxcf7cytcm4mpck6suaovlhzjt2hyxxu"
│
│      #5
│        PieceCID: bafkzcibcdubxifgdf7nmryydlkqbmo5q7a5r7wirrousepemrrkx55hb644awby
│        Size: 225.0 B
│        Metadata
│          ipfsRootCID: "bafybeidjstuje7huztr4mjwbqslwqkt4q4clypi76ijzzkwxvp5ngxzxra"
│
│      #6
│        PieceCID: bafkzcibcdubuavvokuyremde4qn5lh24rkscmx6onybphbhoeq6ijhwc2fdbcly
│        Size: 225.0 B
│        Metadata
│          ipfsRootCID: "bafybeig577ua2iyo2cyhciu4vcgotxbj3cxsjnmbhbkgzak24ruvtchbxq"
│
│      #7
│        PieceCID: bafkzcibcdubt327wox7wxu267rn4ixkafaqtk6qpvh7pp6ysqrwzpn53ju45igi
│        Size: 225.0 B
│        Metadata
│          ipfsRootCID: "bafybeicbe4tll3s2zt4el5ing2aovhr7ibd6zfgwo23gfmi4labtnqsawe"
│
│
└  Data set inspection complete
```
