### PR TITLE
fix: correct Filfox explorer URL format for mainnet and use dynamic n…

### DIFF
--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -298,16 +298,17 @@ export async function performUpload(
           if (event.data.txHash) {
             transactionHash = event.data.txHash
           }
+          const network = synapseService.synapse.getNetwork()
+          const explorerUrls = [pc.gray(`Piece: https://pdp.vxb.ai/${network}/piece/${pieceCid}`)]
+          if (transactionHash) {
+            const filfoxBase = network === 'mainnet' ? 'https://filfox.info' : `https://${network}.filfox.info`
+            explorerUrls.push(pc.gray(`Transaction: ${filfoxBase}/en/message/${transactionHash}`))
+          }
           flow.completeOperation('add-to-dataset', 'Piece added to DataSet (unconfirmed on-chain)', {
             type: 'success',
             details: {
               title: 'Explorer URLs',
-              content: [
-                pc.gray(`Piece: https://pdp.vxb.ai/calibration/piece/${pieceCid}`),
-                pc.gray(
-                  `Transaction: https://${synapseService.synapse.getNetwork()}.filfox.info/en/message/${transactionHash}`
-                ),
-              ],
+              content: explorerUrls,
             },
           })
           // Start chain confirmation operation


### PR DESCRIPTION
Closes: #235

Fixes incorrect Filfox explorer URL format on mainnet by removing the `mainnet.` subdomain (mainnet uses https://filfox.info, not https://mainnet.filfox.info). Also fixes PDP piece URLs to use the dynamic network value instead of hardcoded "calibration", ensuring correct URLs are displayed for both mainnet and calibration testnet.