### PR TITLE
fix: pad rawSize for payment calculations

### DIFF
--- a/src/core/payments/constants.ts
+++ b/src/core/payments/constants.ts
@@ -57,13 +57,3 @@ export const STORAGE_SCALE_MAX_BI = BigInt(STORAGE_SCALE_MAX)
  * @see - https://github.com/FilOzone/synapse-sdk/issues/339#issue-3539254596
  */
 export const PDP_LEAF_SIZE = 32
-
-/**
- * Pad raw size to the next multiple of 32 bytes
- *
- * @param rawSizeBytes - The actual size in bytes
- * @returns Padded size (next multiple of 32)
- */
-export function padSizeToPDPLeaves(rawSizeBytes: number): number {
-  return Math.ceil(rawSizeBytes / PDP_LEAF_SIZE) * PDP_LEAF_SIZE
-}

--- a/src/core/payments/index.ts
+++ b/src/core/payments/index.ts
@@ -26,13 +26,13 @@ import {
   MAX_LOCKUP_ALLOWANCE,
   MAX_RATE_ALLOWANCE,
   MIN_FIL_FOR_GAS,
-  padSizeToPDPLeaves,
   STORAGE_SCALE_MAX,
   STORAGE_SCALE_MAX_BI,
   USDFC_DECIMALS,
 } from './constants.js'
 import { applyFloorPricing } from './floor-pricing.js'
 import type { PaymentStatus, ServiceApprovalStatus, StorageAllowances, StorageRunwaySummary } from './types.js'
+import { padSizeToPDPLeaves } from './utils.js'
 
 // Re-export all constants
 export * from './constants.js'

--- a/src/core/payments/utils.ts
+++ b/src/core/payments/utils.ts
@@ -1,0 +1,11 @@
+import { PDP_LEAF_SIZE } from './constants.js'
+
+/**
+ * Pad raw size to the next multiple of 32 bytes
+ *
+ * @param rawSizeBytes - The actual size in bytes
+ * @returns Padded size (next multiple of 32)
+ */
+export function padSizeToPDPLeaves(rawSizeBytes: number): number {
+  return Math.ceil(rawSizeBytes / PDP_LEAF_SIZE) * PDP_LEAF_SIZE
+}


### PR DESCRIPTION
`calculateRequiredAllowances()`, supposedly, is the entry point for all the calculate* functions in /core/payments.

calling `padSizeToPDPLeaves` once in it, shares that converted value with the rest.

closes #213 