### PR TITLE
deps: vitest upgrade and mock fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,10 +121,10 @@
     "@ipld/dag-cbor": "^9.2.5",
     "@types/node": "^24.5.1",
     "@types/semver": "^7.5.8",
-    "@vitest/coverage-v8": "^3.2.4",
+    "@vitest/coverage-v8": "^4.0.12",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2",
-    "vitest": "^3.2.4"
+    "vitest": "^4.0.12"
   },
   "publishConfig": {
     "access": "public"

--- a/src/test/unit/core-data-set.test.ts
+++ b/src/test/unit/core-data-set.test.ts
@@ -97,7 +97,7 @@ vi.mock('@filoz/synapse-sdk/piece', () => ({
 }))
 vi.mock('@filoz/synapse-sdk/sp-registry', () => {
   return {
-    SPRegistryService: vi.fn().mockImplementation(() => {
+    SPRegistryService: vi.fn().mockImplementation(function () {
       return {
         getProviders: mockGetProviders,
       }


### PR DESCRIPTION
replaces #256
replaces #257

Needed to change mock from arrow function to function declaration.
