### PR TITLE
fix: remove npm cache from docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Documentation
+name: Build API docs and deploy to GitHub Pages
 
 on:
   push:
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
-          cache: 'npm'
 
       - name: Install Dependencies
         run: npm install --no-progress


### PR DESCRIPTION
npm cache requires lockfile to be present. we do not have one committed (because this is a library, not an application)


Fixes workflow added in https://github.com/filecoin-project/filecoin-pin/pull/260