### PR TITLE
refactor: clean separation pattern for import cli command

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -29,8 +29,7 @@ export const importCommand = new Command('import')
       }
 
       await runCarImport(importOptions)
-    } catch (error) {
-      console.error('Import failed:', error instanceof Error ? error.message : error)
+    } catch {
       process.exit(1)
     }
   })

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -145,7 +145,6 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
     const proceed = await warnAboutCDNPricingLimitations()
     if (!proceed) {
       cancel('Import cancelled')
-      process.exitCode = 1
       throw new Error('CDN pricing limitations warning cancelled')
     }
   }
@@ -158,7 +157,7 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
     if (!fileValidation.exists || !fileValidation.stats) {
       spinner.stop(`${pc.red('✗')} ${fileValidation.error}`)
       cancel('Import cancelled')
-      process.exit(1)
+      throw new Error(fileValidation.error)
     }
     const fileStat = fileValidation.stats
 
@@ -169,7 +168,7 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
     } catch (error) {
       spinner.stop(`${pc.red('✗')} Invalid CAR file: ${error instanceof Error ? error.message : 'Unknown error'}`)
       cancel('Import cancelled')
-      process.exit(1)
+      throw new Error('Invalid CAR file')
     }
 
     // Step 3: Handle root CID cases
@@ -290,6 +289,6 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
     await cleanupSynapseService()
 
     cancel('Import failed')
-    process.exit(1)
+    throw error
   }
 }

--- a/src/test/unit/import.test.ts
+++ b/src/test/unit/import.test.ts
@@ -338,8 +338,7 @@ describe('CAR Import', () => {
         privateKey: testPrivateKey,
       }
 
-      await expect(runCarImport(options)).rejects.toThrow('process.exit called')
-      expect(consoleMocks.error).toHaveBeenCalledWith('Import cancelled')
+      await expect(runCarImport(options)).rejects.toThrow()
     })
 
     it('should reject non-existent file', async () => {
@@ -348,8 +347,7 @@ describe('CAR Import', () => {
         privateKey: testPrivateKey,
       }
 
-      await expect(runCarImport(options)).rejects.toThrow('process.exit called')
-      expect(consoleMocks.error).toHaveBeenCalledWith('Import cancelled')
+      await expect(runCarImport(options)).rejects.toThrow()
     })
   })
 
@@ -394,7 +392,7 @@ describe('CAR Import', () => {
         // No private key provided
       }
 
-      await expect(runCarImport(options)).rejects.toThrow('process.exit called')
+      await expect(runCarImport(options)).rejects.toThrow()
       // The error is caught and logged generically as "Import failed"
       expect(consoleMocks.error).toHaveBeenCalled()
     })
@@ -493,7 +491,7 @@ describe('CAR Import', () => {
         privateKey: testPrivateKey,
       }
 
-      await expect(runCarImport(options)).rejects.toThrow('process.exit called')
+      await expect(runCarImport(options)).rejects.toThrow()
       expect(cleanupSpy).toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
Second part of #254 fixes.

- ensure all UI & error handling stays in the business layer
- ensure command layer handles exit codes only
- fix tests

NB: follows existing rm  and add command pattern in https://github.com/filecoin-project/filecoin-pin/pull/253 and https://github.com/filecoin-project/filecoin-pin/pull/273 rsptv. 