### PR TITLE
fix: mainnet flag consideration in payments setup

### DIFF
--- a/src/commands/payments.ts
+++ b/src/commands/payments.ts
@@ -26,7 +26,7 @@ const setupCommand = new Command('setup')
         auto: options.auto || false,
         deposit: options.deposit || '1',
         rateAllowance: options.rateAllowance || '1TiB/month',
-        network: options.mainnet ? 'mainnet' : 'calibration'
+        network: options.mainnet ? 'mainnet' : options.network,
       }
 
       if (setupOptions.auto) {

--- a/src/payments/interactive.ts
+++ b/src/payments/interactive.ts
@@ -87,7 +87,8 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
     const s = createSpinner()
     s.start('Initializing connection...')
 
-    const rpcUrl = options.network == 'mainnet' ? RPC_URLS.mainnet.websocket : options.rpcUrl || RPC_URLS.calibration.websocket
+    const defaultRpcUrl = options.network === 'mainnet' ? RPC_URLS.mainnet.websocket : RPC_URLS.calibration.websocket
+    const rpcUrl = options.rpcUrl || defaultRpcUrl
 
     const synapse = await Synapse.create({
       privateKey,


### PR DESCRIPTION
Issue: #309 

--mainnet flag was not being considered while setting up payments. 

## Testing 

```bash
# Points to Mainnet
node ./dist/cli.js payments setup --private-key $PRIVATE_KEY --mainnet
```

```bash
# Points to Mainnet
node ./dist/cli.js payments setup --private-key $PRIVATE_KEY --network mainnet
```

```bash
# Points to Calibration
node ./dist/cli.js payments setup --private-key $PRIVATE_KEY --network calibration
```
And if the rpc-url is specified, then it takes precedence. 
