### PR TITLE
refactor: replace WarmStorageService instantiation with synapse-core getAllPieceMetadata

### DIFF
--- a/src/core/data-set/get-data-set-pieces.ts
+++ b/src/core/data-set/get-data-set-pieces.ts
@@ -8,19 +8,12 @@
 
 import { getSizeFromPieceCID } from '@filoz/synapse-core/piece'
 import { getDataSet as getProviderDataSet } from '@filoz/synapse-core/sp'
+import { getAllPieceMetadata } from '@filoz/synapse-core/warm-storage'
 import { type DataSetPieceData, METADATA_KEYS, type Synapse } from '@filoz/synapse-sdk'
 import type { StorageContext } from '@filoz/synapse-sdk/storage'
-import { WarmStorageService } from '@filoz/synapse-sdk/warm-storage'
 import { reconcilePieceStatus } from '../piece/piece-status.js'
 import type { Warning } from '../utils/types.js'
-import { isStorageContextWithDataSetId } from './type-guards.js'
-import {
-  type DataSetPiecesResult,
-  type GetDataSetPiecesOptions,
-  type PieceInfo,
-  PieceStatus,
-  type StorageContextWithDataSetId,
-} from './types.js'
+import { type DataSetPiecesResult, type GetDataSetPiecesOptions, type PieceInfo, PieceStatus } from './types.js'
 
 /**
  * Get all pieces for a dataset from a StorageContext
@@ -41,9 +34,10 @@ export async function getDataSetPieces(
   const logger = options?.logger
   const includeMetadata = options?.includeMetadata ?? false
 
-  if (!isStorageContextWithDataSetId(storageContext)) {
+  if (storageContext.dataSetId == null) {
     throw new Error('Storage context does not have a dataset ID')
   }
+  const dataSetId = storageContext.dataSetId
 
   const pieces: PieceInfo[] = []
   const warnings: Warning[] = []
@@ -56,7 +50,7 @@ export async function getDataSetPieces(
     storageContext.getScheduledRemovals(),
     getProviderDataSet({
       serviceURL: storageContext.provider.pdp?.serviceURL ?? '',
-      dataSetId: storageContext.dataSetId,
+      dataSetId,
     }),
   ])
 
@@ -67,7 +61,7 @@ export async function getDataSetPieces(
     warnings.push({
       code: 'SCHEDULED_REMOVALS_UNAVAILABLE',
       message: 'Failed to get scheduled removals',
-      context: { dataSetId: storageContext.dataSetId.toString(), error: String(scheduledRemovalsResult.reason) },
+      context: { dataSetId: dataSetId.toString(), error: String(scheduledRemovalsResult.reason) },
     })
   }
 
@@ -78,7 +72,7 @@ export async function getDataSetPieces(
     warnings.push({
       code: 'PROVIDER_PIECES_UNAVAILABLE',
       message: 'Failed to fetch provider-side pieces',
-      context: { dataSetId: storageContext.dataSetId.toString(), error: String(providerPiecesResult.reason) },
+      context: { dataSetId: dataSetId.toString(), error: String(providerPiecesResult.reason) },
     })
   }
 
@@ -143,13 +137,13 @@ export async function getDataSetPieces(
     if (error instanceof Error && error.name === 'AbortError') {
       throw error
     }
-    logger?.error({ dataSetId: storageContext.dataSetId.toString(), error }, 'Failed to retrieve pieces from dataset')
-    throw new Error(`Failed to retrieve pieces for dataset ${storageContext.dataSetId}: ${String(error)}`)
+    logger?.error({ dataSetId: dataSetId.toString(), error }, 'Failed to retrieve pieces from dataset')
+    throw new Error(`Failed to retrieve pieces for dataset ${dataSetId}: ${String(error)}`)
   }
 
   // Optionally enrich with metadata
   if (includeMetadata && pieces.length > 0) {
-    await enrichPiecesWithMetadata(synapse, storageContext, pieces, warnings, logger)
+    await enrichPiecesWithMetadata(synapse, dataSetId, pieces, warnings, logger)
   }
 
   // Calculate total size from pieces that have sizes
@@ -157,7 +151,7 @@ export async function getDataSetPieces(
 
   const result: DataSetPiecesResult = {
     pieces,
-    dataSetId: storageContext.dataSetId,
+    dataSetId: dataSetId,
     warnings,
   }
 
@@ -169,33 +163,18 @@ export async function getDataSetPieces(
 }
 
 /**
- * Internal helper: Enrich pieces with metadata from WarmStorage
+ * Internal helper: Enrich pieces with metadata from WarmStorage via synapse-core
  */
 async function enrichPiecesWithMetadata(
   synapse: Synapse,
-  storageContext: StorageContextWithDataSetId,
+  dataSetId: bigint,
   pieces: PieceInfo[],
   warnings: Warning[],
   logger?: GetDataSetPiecesOptions['logger']
 ): Promise<void> {
-  const dataSetId = storageContext.dataSetId
-
-  let warmStorage: WarmStorageService
-  try {
-    warmStorage = new WarmStorageService({ client: synapse.client })
-  } catch (error) {
-    logger?.warn({ error }, 'Failed to create WarmStorageService for metadata enrichment')
-    warnings.push({
-      code: 'WARM_STORAGE_INIT_FAILED',
-      message: 'Failed to initialize WarmStorageService for metadata enrichment',
-      context: { error: String(error) },
-    })
-    return
-  }
-
   for (const piece of pieces) {
     try {
-      const metadata = await warmStorage.getPieceMetadata({ dataSetId, pieceId: piece.pieceId })
+      const metadata = await getAllPieceMetadata(synapse.client, { dataSetId, pieceId: piece.pieceId })
 
       const rootIpfsCid = metadata[METADATA_KEYS.IPFS_ROOT_CID]
       if (rootIpfsCid) {

--- a/src/core/data-set/type-guards.ts
+++ b/src/core/data-set/type-guards.ts
@@ -1,6 +1,0 @@
-import type { StorageContext } from '@filoz/synapse-sdk/storage'
-import type { StorageContextWithDataSetId } from './types.js'
-
-export function isStorageContextWithDataSetId(value: StorageContext): value is StorageContextWithDataSetId {
-  return typeof value === 'object' && value !== null && 'dataSetId' in value && typeof value.dataSetId === 'bigint'
-}

--- a/src/core/data-set/types.ts
+++ b/src/core/data-set/types.ts
@@ -9,7 +9,6 @@
  */
 
 import type { EnhancedDataSetInfo, PDPProvider } from '@filoz/synapse-sdk'
-import type { StorageContext } from '@filoz/synapse-sdk/storage'
 import type { Logger } from 'pino'
 import type { Hex } from 'viem'
 import type { Warning } from '../utils/types.js'
@@ -128,5 +127,3 @@ export interface GetDataSetPiecesOptions {
   /** Logger instance for debugging (optional) */
   logger?: Logger | undefined
 }
-
-export type StorageContextWithDataSetId = StorageContext & { dataSetId: bigint }

--- a/src/test/unit/core-data-set.test.ts
+++ b/src/test/unit/core-data-set.test.ts
@@ -11,8 +11,7 @@ import { getDataSetPieces, listDataSets } from '../../core/data-set/index.js'
 const {
   mockSynapse,
   mockStorageContext,
-  mockWarmStorageInstance,
-  mockWarmStorageConstructor,
+  mockGetAllPieceMetadata,
   mockFindDataSets,
   mockGetProviders,
   mockGetPieces,
@@ -55,13 +54,9 @@ const {
     return { id: 123n, nextChallengeEpoch: 100, pieces }
   })
 
-  const mockWarmStorageInstance = {
-    getPieceMetadata: vi.fn(async ({ pieceId }: any) => {
-      return state.pieceMetadata[Number(pieceId)] ?? {}
-    }),
-  }
-
-  const mockWarmStorageConstructor = vi.fn((_options: any) => mockWarmStorageInstance)
+  const mockGetAllPieceMetadata = vi.fn(async (_client: any, { pieceId }: any) => {
+    return state.pieceMetadata[Number(pieceId)] ?? {}
+  })
 
   const mockStorageContext = {
     dataSetId: 123n,
@@ -83,8 +78,7 @@ const {
   return {
     mockSynapse,
     mockStorageContext,
-    mockWarmStorageInstance,
-    mockWarmStorageConstructor,
+    mockGetAllPieceMetadata,
     mockFindDataSets,
     mockGetProviders,
     mockGetPieces,
@@ -101,13 +95,8 @@ vi.mock('@filoz/synapse-sdk', async () => {
   }
 })
 
-vi.mock('@filoz/synapse-sdk/warm-storage', () => ({
-  WarmStorageService: class {
-    constructor(options: any) {
-      mockWarmStorageConstructor(options)
-      Object.assign(this, mockWarmStorageInstance)
-    }
-  },
+vi.mock('@filoz/synapse-core/warm-storage', () => ({
+  getAllPieceMetadata: mockGetAllPieceMetadata,
 }))
 
 vi.mock('@filoz/synapse-core/sp', () => ({
@@ -395,7 +384,7 @@ describe('getDataSetPieces', () => {
         label: 'test-file-0.txt',
       },
     })
-    expect(mockWarmStorageConstructor).toHaveBeenCalledWith({ client: mockSynapse.client })
+    expect(mockGetAllPieceMetadata).toHaveBeenCalledWith(mockSynapse.client, { dataSetId: 123n, pieceId: 0n })
   })
 
   it('handles metadata fetch failures gracefully with warnings', async () => {
@@ -409,7 +398,7 @@ describe('getDataSetPieces', () => {
       },
     }
     // Simulate failure for piece 1
-    mockWarmStorageInstance.getPieceMetadata.mockImplementation(async ({ pieceId }: any) => {
+    mockGetAllPieceMetadata.mockImplementation(async (_client: any, { pieceId }: any) => {
       const metadata = state.pieceMetadata[Number(pieceId)]
       if (metadata == null) {
         throw new Error('Metadata not found')
@@ -433,26 +422,6 @@ describe('getDataSetPieces', () => {
         dataSetId: '123',
         error: expect.any(String),
       },
-    })
-  })
-
-  it('adds warning when WarmStorage initialization fails', async () => {
-    state.pieces = [{ pieceId: 0n, pieceCid: { toString: () => 'bafkpiece0' } }]
-    mockWarmStorageConstructor.mockImplementationOnce(() => {
-      throw new Error('WarmStorage unavailable')
-    })
-
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any, {
-      includeMetadata: true,
-    })
-
-    expect(result.pieces).toHaveLength(1)
-    expect(result.pieces[0]?.metadata).toBeUndefined()
-    expect(result.warnings).toHaveLength(1)
-    expect(result.warnings).toContainEqual({
-      code: 'WARM_STORAGE_INIT_FAILED',
-      message: 'Failed to initialize WarmStorageService for metadata enrichment',
-      context: { error: 'Error: WarmStorage unavailable' },
     })
   })
 

--- a/src/test/unit/data-set.test.ts
+++ b/src/test/unit/data-set.test.ts
@@ -9,8 +9,7 @@ const {
   cancelMock,
   mockFindDataSets,
   mockGetProvider,
-  mockWarmStorageConstructor,
-  mockWarmStorageInstance,
+  mockGetAllPieceMetadata,
   mockTerminateDataSet,
   mockWaitForTransactionReceipt,
   mockSynapseCreate,
@@ -26,16 +25,12 @@ const {
   }
   const mockFindDataSets = vi.fn()
   const mockGetProvider = vi.fn()
-  const mockWarmStorageConstructor = vi.fn()
+  const mockGetAllPieceMetadata = vi.fn(async () => ({ ...state.pieceMetadata }))
   const mockTerminateDataSet = vi.fn()
   const mockWaitForTransactionReceipt = vi.fn()
   const state = {
     pieceMetadata: {} as Record<string, string>,
     pieceList: [] as Array<{ pieceId: bigint; pieceCid: string }>,
-  }
-
-  const mockWarmStorageInstance = {
-    getPieceMetadata: vi.fn(async () => ({ ...state.pieceMetadata })),
   }
 
   const mockCreateContext = vi.fn(async () => ({
@@ -101,8 +96,7 @@ const {
     spinnerMock,
     mockFindDataSets,
     mockGetProvider,
-    mockWarmStorageConstructor,
-    mockWarmStorageInstance,
+    mockGetAllPieceMetadata,
     mockTerminateDataSet,
     mockWaitForTransactionReceipt,
     mockSynapseCreate,
@@ -150,13 +144,8 @@ vi.mock('@filoz/synapse-sdk', async () => {
   }
 })
 
-vi.mock('@filoz/synapse-sdk/warm-storage', () => ({
-  WarmStorageService: class {
-    constructor(options: any) {
-      mockWarmStorageConstructor(options)
-      Object.assign(this, mockWarmStorageInstance)
-    }
-  },
+vi.mock('@filoz/synapse-core/warm-storage', () => ({
+  getAllPieceMetadata: mockGetAllPieceMetadata,
 }))
 
 vi.mock('@filoz/synapse-core/sp', () => ({
@@ -224,7 +213,7 @@ describe('runDataSetCommand', () => {
     state.pieceList = []
     mockFindDataSets.mockResolvedValue([summaryDataSet])
     mockGetProvider.mockResolvedValue(provider)
-    mockWarmStorageInstance.getPieceMetadata.mockResolvedValue({})
+    mockGetAllPieceMetadata.mockResolvedValue({})
   })
 
   afterEach(() => {
@@ -279,7 +268,7 @@ describe('runDataSetCommand', () => {
       custom: 'value',
     }
     state.pieceMetadata = pieceMetadata
-    mockWarmStorageInstance.getPieceMetadata.mockResolvedValue(pieceMetadata)
+    mockGetAllPieceMetadata.mockResolvedValue(pieceMetadata)
 
     await runDataSetDetailsCommand(158, {
       privateKey: 'test-key',
@@ -361,7 +350,7 @@ describe('runTerminateDataSetCommand', () => {
     state.pieceList = []
     mockFindDataSets.mockResolvedValue([terminatableDataSet])
     mockGetProvider.mockResolvedValue(provider)
-    mockWarmStorageInstance.getPieceMetadata.mockResolvedValue({})
+    mockGetAllPieceMetadata.mockResolvedValue({})
     mockTerminateDataSet.mockResolvedValue('0xtxhash123')
     mockWaitForTransactionReceipt.mockResolvedValue({ status: 'success' })
   })


### PR DESCRIPTION
Eliminates the last direct SDK class instantiation in filecoin-pin, using the lower-level synapse-core function instead. Removes the StorageContextWithDataSetId type and type-guards.ts as they existed solely for this call path.
  
Closes: https://github.com/filecoin-project/filecoin-pin/issues/278

---

Couldn't help doing this, I noticed it in the issues list and it related to the new 0.38 support. I hope removing the type guard is OK, it feels like significant overkill just for this.