### PR TITLE
feat!: align with synapse-sdk 0.40 UploadResult ergonomics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ src/
 
 ## Key Patterns
 
-**Synapse SDK**: Initialize via `initializeSynapse()` in `src/core/synapse/index.ts`. Upload via `executeUpload()` in `src/core/upload/index.ts` with progress events (`onStored`, `onPullProgress`, `onCopyComplete`, `onPiecesAdded`, `onPiecesConfirmed`). Returns `{pieceCid, size, copies, failures}`.
+**Synapse SDK**: Initialize via `initializeSynapse()` in `src/core/synapse/index.ts`. Upload via `executeUpload()` in `src/core/upload/index.ts` with progress events (`onStored`, `onPullProgress`, `onCopyComplete`, `onPiecesAdded`, `onPiecesConfirmed`). Returns `{pieceCid, size, copies, failedAttempts}`. Check `complete` on the SDK's `UploadResult` to determine overall success.
 
 **CAR files**: CARv1 streaming, handle 3 root cases (single/multiple/none), use zero CID for no roots. See `src/core/car/car-blockstore.ts`.
 

--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -178,19 +178,19 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
       skipIpniVerification,
       ...(pieceMetadata && { pieceMetadata }),
       ...(dataSetMetadata && { metadata: dataSetMetadata }),
-      ...(options.count != null && { count: options.count }),
+      ...(options.copies != null && { copies: options.copies }),
     }
     if (contextSelection.providerIds) {
       uploadOptions.providerIds = contextSelection.providerIds
-      uploadOptions.count = contextSelection.providerIds.length
+      uploadOptions.copies = contextSelection.providerIds.length
     }
     if (contextSelection.dataSetIds) {
       uploadOptions.dataSetIds = contextSelection.dataSetIds
-      uploadOptions.count = contextSelection.dataSetIds.length
+      uploadOptions.copies = contextSelection.dataSetIds.length
     }
 
     // Upload to Synapse (SDK handles provider selection and multi-copy)
-    const requestedCopies = uploadOptions.count ?? 2
+    const requestedCopies = uploadOptions.copies ?? 2
     const uploadResult = await performUpload(synapse, carData, rootCid, uploadOptions)
 
     // Display results
@@ -204,7 +204,7 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
       pieceCid: uploadResult.pieceCid,
       size: uploadResult.size,
       copies: uploadResult.copies,
-      failures: uploadResult.failures,
+      failedAttempts: uploadResult.failedAttempts,
     }
 
     displayUploadResults(result, 'Add', network, networkSlug)
@@ -213,16 +213,16 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
       log.line('')
       log.line(
         pc.yellow(
-          `${uploadResult.failures.length} copy failure(s). ` +
+          `${uploadResult.failedAttempts.length} copy failure(s). ` +
             `Got ${uploadResult.copies.length}/${requestedCopies} copies. Data is stored but with reduced redundancy.`
         )
       )
       log.flush()
       outro('Add completed with errors')
       process.exitCode = 1
-    } else if (uploadResult.failures.length > 0) {
+    } else if (uploadResult.failedAttempts.length > 0) {
       log.line('')
-      log.line(pc.gray(`${uploadResult.failures.length} non-critical copy failure(s) during upload.`))
+      log.line(pc.gray(`${uploadResult.failedAttempts.length} non-critical copy failure(s) during upload.`))
       log.flush()
       outro('Add completed successfully')
     } else {

--- a/src/add/types.ts
+++ b/src/add/types.ts
@@ -1,4 +1,4 @@
-import type { CopyResult, FailedCopy } from '@filoz/synapse-sdk'
+import type { CopyResult, FailedAttempt } from '@filoz/synapse-sdk'
 import type { CLIAuthOptions } from '../utils/cli-auth.js'
 
 export interface AddOptions extends CLIAuthOptions {
@@ -7,7 +7,7 @@ export interface AddOptions extends CLIAuthOptions {
   /** Auto-fund: automatically ensure minimum 30 days of runway */
   autoFund?: boolean
   /** Number of storage copies to create */
-  count?: number
+  copies?: number
   /** Piece metadata attached to each upload */
   pieceMetadata?: Record<string, string>
   /** Data set metadata applied when creating or updating the storage context */
@@ -24,5 +24,5 @@ export interface AddResult {
   pieceCid: string
   size: number
   copies: CopyResult[]
-  failures: FailedCopy[]
+  failedAttempts: FailedAttempt[]
 }

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -10,7 +10,7 @@ export const addCommand = new Command('add')
   .argument('<path>', 'Path to the file or directory to add')
   .option('--bare', 'Add file without directory wrapper (files only, not supported for directories)')
   .option('--auto-fund', `Automatically ensure minimum ${MIN_RUNWAY_DAYS} days of runway before upload`)
-  .option('--count <n>', 'Number of storage copies to create (default: 2)', Number.parseInt)
+  .option('--copies <n>', 'Number of storage copies to create (default: 2)', Number.parseInt)
 
 addCommand.action(async (path: string, options: any) => {
   try {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -9,7 +9,7 @@ export const importCommand = new Command('import')
   .description('Import an existing CAR file to Filecoin via Synapse')
   .argument('<file>', 'Path to the CAR file to import')
   .option('--auto-fund', `Automatically ensure minimum ${MIN_RUNWAY_DAYS} days of runway before upload`)
-  .option('--count <n>', 'Number of storage copies to create (default: 2)', Number.parseInt)
+  .option('--copies <n>', 'Number of storage copies to create (default: 2)', Number.parseInt)
   .action(async (file: string, options) => {
     try {
       const {

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -5,7 +5,7 @@
  * including payment validation, storage context creation, and result display.
  */
 
-import type { CopyResult, FailedCopy, Synapse } from '@filoz/synapse-sdk'
+import type { CopyResult, CopyRole, FailedAttempt, Synapse } from '@filoz/synapse-sdk'
 import type { CID } from 'multiformats/cid'
 import pc from 'picocolors'
 import type { Logger } from 'pino'
@@ -46,7 +46,7 @@ export interface UploadFlowOptions {
   pieceMetadata?: Record<string, string>
 
   /** Number of storage copies to create. */
-  count?: number
+  copies?: number
 
   /** Specific provider IDs to use. */
   providerIds?: bigint[]
@@ -255,8 +255,6 @@ function displayPaymentIssues(capacityCheck: PaymentCapacityCheck, fileSize: num
 /**
  * Format a role label for spinner output (e.g., "[Primary]" or "[Secondary]")
  */
-type CopyRole = 'primary' | 'secondary'
-
 function roleLabel(role: CopyRole): string {
   return role === 'primary' ? pc.cyan('[Primary]') : pc.magenta('[Secondary]')
 }
@@ -268,7 +266,7 @@ function roleLabel(role: CopyRole): string {
  * @param carData - CAR file data as Uint8Array
  * @param rootCid - Root CID of the content
  * @param options - Upload flow options
- * @returns Upload result with copies and failures
+ * @returns Upload result with copies and completion status
  */
 export async function performUpload(
   synapse: Synapse,
@@ -313,7 +311,7 @@ export async function performUpload(
     logger,
     contextId: `${contextType}-${Date.now()}`,
     ...(pieceMetadata && { pieceMetadata }),
-    ...(options.count != null && { count: options.count }),
+    ...(options.copies != null && { copies: options.copies }),
     ...(options.providerIds != null && { providerIds: options.providerIds }),
     ...(options.dataSetIds != null && { dataSetIds: options.dataSetIds }),
     ...(options.excludeProviderIds != null && { excludeProviderIds: options.excludeProviderIds }),
@@ -452,7 +450,7 @@ export function displayUploadResults(
     pieceCid: string
     size?: number
     copies: CopyResult[]
-    failures: FailedCopy[]
+    failedAttempts: FailedAttempt[]
   },
   operation: string,
   networkDisplay: string,
@@ -493,12 +491,12 @@ export function displayUploadResults(
     }
   }
 
-  if (result.failures.length > 0) {
+  if (result.failedAttempts.length > 0) {
     log.line('')
     log.line(pc.bold(pc.yellow('Warnings')))
-    for (const failure of result.failures) {
-      const label = failure.role === 'primary' ? pc.cyan('[Primary]') : pc.magenta('[Secondary]')
-      log.indent(`${pc.yellow('⚠')} ${label} Provider ${failure.providerId} failed: ${failure.error}`)
+    for (const attempt of result.failedAttempts) {
+      const label = attempt.role === 'primary' ? pc.cyan('[Primary]') : pc.magenta('[Secondary]')
+      log.indent(`${pc.yellow('⚠')} ${label} Provider ${attempt.providerId} failed: ${attempt.error}`)
     }
   }
 

--- a/src/core/upload/index.ts
+++ b/src/core/upload/index.ts
@@ -222,7 +222,7 @@ export interface UploadExecutionOptions {
   } & Omit<WaitForIpniProviderResultsOptions, 'onProgress'>
 
   /** Number of storage copies to create (default determined by SDK). */
-  count?: number
+  copies?: number
 
   /** Specific provider IDs to use. */
   providerIds?: bigint[]
@@ -327,8 +327,8 @@ export async function executeUpload(
   if (options.signal != null) {
     uploadOptions.signal = options.signal
   }
-  if (options.count != null) {
-    uploadOptions.count = options.count
+  if (options.copies != null) {
+    uploadOptions.copies = options.copies
   }
   if (options.providerIds != null) {
     uploadOptions.providerIds = options.providerIds

--- a/src/core/upload/synapse.ts
+++ b/src/core/upload/synapse.ts
@@ -5,7 +5,7 @@
  * used by both CLI commands and the pinning server. Uses the StorageManager for
  * provider selection and multi-copy orchestration.
  */
-import type { CopyResult, FailedCopy, PieceCID, PullStatus, Synapse, UploadResult } from '@filoz/synapse-sdk'
+import type { CopyResult, FailedAttempt, PieceCID, PullStatus, Synapse, UploadResult } from '@filoz/synapse-sdk'
 import { METADATA_KEYS, type PDPProvider } from '@filoz/synapse-sdk'
 import type { StorageManagerUploadOptions } from '@filoz/synapse-sdk/storage'
 import type { CID } from 'multiformats/cid'
@@ -47,7 +47,7 @@ export interface SynapseUploadOptions {
   /**
    * Number of storage copies to create (default determined by SDK).
    */
-  count?: number
+  copies?: number
 
   /**
    * Specific provider IDs to use (mutually exclusive with dataSetIds).
@@ -74,7 +74,7 @@ export interface SynapseUploadResult {
   pieceCid: string
   size: number
   copies: CopyResult[]
-  failures: FailedCopy[]
+  failedAttempts: FailedAttempt[]
 }
 
 /**
@@ -104,7 +104,7 @@ export function getServiceURL(providerInfo: PDPProvider): string {
  * @param rootCid - The IPFS root CID to associate with this piece
  * @param logger - Logger instance for tracking
  * @param options - Upload options including context selection and callbacks
- * @returns Upload result with copies and failures
+ * @returns Upload result with copies and completion status
  */
 export async function uploadToSynapse(
   synapse: Synapse,
@@ -243,8 +243,8 @@ export async function uploadToSynapse(
   }
 
   // Pass through context selection options
-  if (options.count != null) {
-    uploadOptions.count = options.count
+  if (options.copies != null) {
+    uploadOptions.copies = options.copies
   }
   if (options.providerIds != null) {
     uploadOptions.providerIds = options.providerIds
@@ -268,7 +268,7 @@ export async function uploadToSynapse(
       pieceCid: synapseResult.pieceCid.toString(),
       size: synapseResult.size,
       copies: synapseResult.copies.length,
-      failures: synapseResult.failures.length,
+      failedAttempts: synapseResult.failedAttempts.length,
     },
     'Successfully uploaded to Filecoin with Synapse'
   )
@@ -277,6 +277,6 @@ export async function uploadToSynapse(
     pieceCid: synapseResult.pieceCid.toString(),
     size: synapseResult.size,
     copies: synapseResult.copies,
-    failures: synapseResult.failures,
+    failedAttempts: synapseResult.failedAttempts,
   }
 }

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -224,18 +224,18 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
       skipIpniVerification,
       ...(pieceMetadata && { pieceMetadata }),
       ...(dataSetMetadata && { metadata: dataSetMetadata }),
-      ...(options.count != null && { count: options.count }),
+      ...(options.copies != null && { copies: options.copies }),
     }
     if (contextSelection.providerIds) {
       uploadOptions.providerIds = contextSelection.providerIds
-      uploadOptions.count = contextSelection.providerIds.length
+      uploadOptions.copies = contextSelection.providerIds.length
     }
     if (contextSelection.dataSetIds) {
       uploadOptions.dataSetIds = contextSelection.dataSetIds
-      uploadOptions.count = contextSelection.dataSetIds.length
+      uploadOptions.copies = contextSelection.dataSetIds.length
     }
 
-    const requestedCopies = uploadOptions.count ?? 2
+    const requestedCopies = uploadOptions.copies ?? 2
     const uploadResult = await performUpload(synapse, carData, rootCid, uploadOptions)
 
     // Display results
@@ -248,7 +248,7 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
       pieceCid: uploadResult.pieceCid,
       size: uploadResult.size,
       copies: uploadResult.copies,
-      failures: uploadResult.failures,
+      failedAttempts: uploadResult.failedAttempts,
     }
 
     displayUploadResults(result, 'Import', network, networkSlug)
@@ -257,16 +257,16 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
       log.line('')
       log.line(
         pc.yellow(
-          `${uploadResult.failures.length} copy failure(s). ` +
+          `${uploadResult.failedAttempts.length} copy failure(s). ` +
             `Got ${uploadResult.copies.length}/${requestedCopies} copies. Data is stored but with reduced redundancy.`
         )
       )
       log.flush()
       outro('Import completed with errors')
       process.exitCode = 1
-    } else if (uploadResult.failures.length > 0) {
+    } else if (uploadResult.failedAttempts.length > 0) {
       log.line('')
-      log.line(pc.gray(`${uploadResult.failures.length} non-critical copy failure(s) during upload.`))
+      log.line(pc.gray(`${uploadResult.failedAttempts.length} non-critical copy failure(s) during upload.`))
       log.flush()
       outro('Import completed successfully')
     } else {

--- a/src/import/types.ts
+++ b/src/import/types.ts
@@ -1,4 +1,4 @@
-import type { CopyResult, FailedCopy } from '@filoz/synapse-sdk'
+import type { CopyResult, FailedAttempt } from '@filoz/synapse-sdk'
 import type { CLIAuthOptions } from '../utils/cli-auth.js'
 
 export interface ImportOptions extends CLIAuthOptions {
@@ -6,7 +6,7 @@ export interface ImportOptions extends CLIAuthOptions {
   /** Auto-fund: automatically ensure minimum 30 days of runway */
   autoFund?: boolean
   /** Number of storage copies to create */
-  count?: number
+  copies?: number
   /** Piece metadata attached to the imported CAR */
   pieceMetadata?: Record<string, string>
   /** Data set metadata applied when creating or updating the storage context */
@@ -22,5 +22,5 @@ export interface ImportResult {
   pieceCid: string
   size: number
   copies: CopyResult[]
-  failures: FailedCopy[]
+  failedAttempts: FailedAttempt[]
 }

--- a/src/index-types.ts
+++ b/src/index-types.ts
@@ -20,7 +20,7 @@ export interface FilecoinPinAPI {
   executeUpload: typeof executeUpload
 }
 
-export type { CopyResult, FailedCopy, PDPProvider } from '@filoz/synapse-sdk'
+export type { CopyResult, CopyRole, FailedAttempt, PDPProvider } from '@filoz/synapse-sdk'
 export type {
   DataSetPiecesResult,
   DataSetSummary,

--- a/src/test/mocks/synapse-mocks.ts
+++ b/src/test/mocks/synapse-mocks.ts
@@ -88,7 +88,7 @@ export class MockStorageContext extends EventEmitter {
           isNewDataSet: false,
         },
       ],
-      failures: [],
+      failedAttempts: [],
     }
   }
 }

--- a/src/test/unit/add.test.ts
+++ b/src/test/unit/add.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../common/upload-flow.js', () => ({
         isNewDataSet: false,
       },
     ],
-    failures: [],
+    failedAttempts: [],
     network: 'calibration',
   }),
   displayUploadResults: vi.fn(),
@@ -147,7 +147,7 @@ describe('Add Command', () => {
       })
       expect(result.copies).toHaveLength(1)
       expect(result.copies[0]?.role).toBe('primary')
-      expect(result.failures).toHaveLength(0)
+      expect(result.failedAttempts).toHaveLength(0)
 
       // Verify createCarFromPath was called without bare flag
       const { createCarFromPath } = await import('../../core/unixfs/index.js')
@@ -177,7 +177,7 @@ describe('Add Command', () => {
         size: 1024,
       })
       expect(result.copies).toHaveLength(1)
-      expect(result.failures).toHaveLength(0)
+      expect(result.failedAttempts).toHaveLength(0)
 
       // Verify createCarFromPath was called with bare flag
       const { createCarFromPath } = await import('../../core/unixfs/index.js')
@@ -237,7 +237,7 @@ describe('Add Command', () => {
         expect.anything(),
         expect.objectContaining({
           dataSetIds: [123n],
-          count: 1,
+          copies: 1,
         })
       )
     })

--- a/src/test/unit/import.test.ts
+++ b/src/test/unit/import.test.ts
@@ -41,7 +41,7 @@ vi.mock('../../common/upload-flow.js', () => ({
         isNewDataSet: false,
       },
     ],
-    failures: [],
+    failedAttempts: [],
     network: 'calibration',
   }),
   displayUploadResults: vi.fn(),
@@ -433,7 +433,7 @@ describe('CAR Import', () => {
       expect(result.copies).toHaveLength(1)
       expect(result.copies[0]?.role).toBe('primary')
       expect(result.copies[0]?.providerId).toBe(1n)
-      expect(result.failures).toHaveLength(0)
+      expect(result.failedAttempts).toHaveLength(0)
     })
   })
 })

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -90,10 +90,10 @@ describe('synapse-service', () => {
 
       expect(result).toHaveProperty('pieceCid')
       expect(result).toHaveProperty('copies')
-      expect(result).toHaveProperty('failures')
+      expect(result).toHaveProperty('failedAttempts')
       expect(result.pieceCid).toMatch(/^bafkzcib/)
       expect(result.copies).toHaveLength(1)
-      expect(result.failures).toHaveLength(0)
+      expect(result.failedAttempts).toHaveLength(0)
     })
 
     it('should log upload events', async () => {
@@ -197,7 +197,7 @@ describe('synapse-service', () => {
       expect(primaryCopy?.retrievalUrl).toContain('/pdp/piece/')
     })
 
-    it('should return empty failures array on success', async () => {
+    it('should return empty failedAttempts array on success', async () => {
       const mockSynapse = new MockSynapse()
       await mockSynapse.createStorageContext()
 
@@ -206,8 +206,8 @@ describe('synapse-service', () => {
         contextId: 'test-upload',
       })
 
-      expect(result.failures).toBeDefined()
-      expect(result.failures).toHaveLength(0)
+      expect(result.failedAttempts).toBeDefined()
+      expect(result.failedAttempts).toHaveLength(0)
     })
   })
 })

--- a/upload-action/src/filecoin.js
+++ b/upload-action/src/filecoin.js
@@ -198,7 +198,7 @@ export async function uploadCarToFilecoin(synapse, carPath, ipfsRootCid, options
   const primaryCopy = uploadResult.copies.find((c) => c.role === 'primary')
 
   if (primaryCopy == null) {
-    const failureCount = uploadResult.failures.length
+    const failureCount = uploadResult.failedAttempts.length
     throw new Error(
       failureCount > 0
         ? `Upload failed: all ${failureCount} copy attempt(s) failed`
@@ -218,6 +218,6 @@ export async function uploadCarToFilecoin(synapse, carPath, ipfsRootCid, options
     network: uploadResult.network,
     ipniValidated: uploadResult.ipniValidated,
     copies: uploadResult.copies,
-    failures: uploadResult.failures,
+    failedAttempts: uploadResult.failedAttempts,
   }
 }

--- a/upload-action/src/types.ts
+++ b/upload-action/src/types.ts
@@ -2,7 +2,7 @@
  * TypeScript type definitions for the Filecoin Upload Action
  */
 
-import type { CopyResult, FailedCopy } from '@filoz/synapse-sdk'
+import type { CopyResult, FailedAttempt } from '@filoz/synapse-sdk'
 import type { PaymentStatus as FilecoinPinPaymentStatus } from 'filecoin-pin/core/payments'
 import type { initializeSynapse } from 'filecoin-pin/core/synapse'
 import type { Logger as PinoLogger } from 'pino'
@@ -26,7 +26,7 @@ export interface UploadResult {
   network: string
   ipniValidated: boolean
   copies: CopyResult[]
-  failures: FailedCopy[]
+  failedAttempts: FailedAttempt[]
 }
 
 export interface BuildResult {


### PR DESCRIPTION
Rename FailedCopy to FailedAttempt, failures to failedAttempts, count to copies. Import CopyRole from synapse-sdk instead of local definition.

Depends on https://github.com/FilOzone/synapse-sdk/pull/664