### PR TITLE
chore: 7day dep update cooldown, use `npm ci` for stable install in action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 2
+      default-days: 7
     ignore:
       - dependency-name: "@biomejs/biome"
         update-types: ["version-update:semver-patch"]

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -164,7 +164,7 @@ runs:
     - name: Install filecoin-pin dependencies
       shell: bash
       working-directory: ${{ github.action_path }}
-      run: npm install --prefix ../
+      run: npm ci --prefix ../
 
     - name: Build filecoin-pin package
       shell: bash


### PR DESCRIPTION
Dialling up the risk aversion slightly here.