### PR TITLE
ci(release-please): use org PAT so release PRs trigger downstream workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   id-token: write  # Required for OIDC
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -17,7 +18,10 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # PAT so release PRs trigger other workflows (auto-label, add-issues-and-prs-to-fs-project-board).
+          # This PAT has the permissions outlined in https://github.com/googleapis/release-please-action?tab=readme-ov-file#workflow-permissions.
+          # Using GITHUB_TOKEN suppresses follow-on workflow runs, which would mean release please PRs wouldn't get properly labeled and added to the project board.
+          token: ${{ secrets.FILOZZY_RELEASE_PLEASE_PAT }}
           config-file: release-please-config.json
 
       # The following steps only run if a release is created


### PR DESCRIPTION
## Problem

Release Please opens PRs using `GITHUB_TOKEN`. GitHub does not start new workflow runs for events caused by `GITHUB_TOKEN`, so those PRs were not treated like PRs opened by regular users: downstream CI did not run as expected. In our repo that meant release PRs skipped auto-labeling and were not added to the FS project board (which is driven by `labeled` events after `team/fs-wg` is applied).

## Solution

Configure `googleapis/release-please-action` to authenticate with the organization secret `FILOZZY_RELEASE_PLEASE_PAT` so release PRs are created/updated by a PAT-backed identity and other workflows (tests, [`auto-label.yml`](.github/workflows/auto-label.yml), [`add-issues-and-prs-to-fs-project-board.yml`](.github/workflows/add-issues-and-prs-to-fs-project-board.yml)) run normally.

Also grant `issues: write` on the job per [release-please-action workflow permissions](https://github.com/googleapis/release-please-action#workflow-permissions).

Refs: [Triggering a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)

Made with [Cursor](https://cursor.com)