### PR TITLE
fix(identify): handle many origins

### DIFF
--- a/src/create-pinning-helia.ts
+++ b/src/create-pinning-helia.ts
@@ -32,7 +32,17 @@ export async function createPinningHeliaNode(options: PinningHeliaOptions): Prom
 }> {
   const { logger, rootCID, outputPath, origins = [] } = options
 
-  const dialAddrs = origins.map(multiaddr)
+  // Parse origins into multiaddrs
+  const dialTargets = origins
+    .map((origin) => {
+      try {
+        return multiaddr(origin)
+      } catch (error) {
+        logger.warn({ origin, error }, 'Failed to parse origin multiaddr')
+        return null
+      }
+    })
+    .filter((addr) => addr != null)
 
   const libp2p = await createLibp2p({
     addresses: {
@@ -74,11 +84,11 @@ export async function createPinningHeliaNode(options: PinningHeliaOptions): Prom
   logger.info(`Writing blocks to CAR file: ${outputPath}`)
 
   // Connect to origin nodes if provided
-  if (dialAddrs.length > 0) {
-    logger.info({ count: dialAddrs.length }, 'Connecting to origin node')
+  if (dialTargets.length > 0) {
+    logger.info({ count: dialTargets.length }, 'Connecting to origin node')
     try {
-      await helia.libp2p.dial(dialAddrs)
-      logger.info({ count: dialAddrs.length }, 'Connected to origin node')
+      await helia.libp2p.dial(dialTargets)
+      logger.info('Connected to origin node')
     } catch (error) {
       logger.warn({ error }, 'Failed to connect to origin node')
     }

--- a/src/create-pinning-helia.ts
+++ b/src/create-pinning-helia.ts
@@ -3,7 +3,7 @@ import { yamux } from '@chainsafe/libp2p-yamux'
 import { bitswap } from '@helia/block-brokers'
 import { identify } from '@libp2p/identify'
 import { tcp } from '@libp2p/tcp'
-import { multiaddr } from '@multiformats/multiaddr'
+import { type Multiaddr, multiaddr } from '@multiformats/multiaddr'
 import { MemoryDatastore } from 'datastore-core'
 import { createHelia, type Helia } from 'helia'
 import { createLibp2p } from 'libp2p'
@@ -11,6 +11,56 @@ import type { CID } from 'multiformats/cid'
 import type { Logger } from 'pino'
 import { CARWritingBlockstore } from './core/car/index.js'
 import type { Config } from './core/synapse/index.js'
+
+/**
+ * Deduplicate origin multiaddrs by target peer ID, picking one address per peer.
+ * Prefers TCP direct connections since that is the only transport Helia has configured.
+ * Addresses without a peer ID component are included as-is.
+ */
+function selectDialTargets(origins: string[], logger: Logger): Multiaddr[] {
+  const parsed: Multiaddr[] = []
+  for (const origin of origins) {
+    try {
+      parsed.push(multiaddr(origin))
+    } catch {
+      logger.warn({ origin }, 'Failed to parse origin multiaddr, skipping')
+    }
+  }
+
+  // Group by the final /p2p/<peerId> component (the target peer, not an intermediate relay)
+  const byPeerId = new Map<string, Multiaddr[]>()
+  const noPeerId: Multiaddr[] = []
+
+  for (const ma of parsed) {
+    const p2pComponents = ma.getComponents().filter((c) => c.name === 'p2p')
+    const targetPeerId = p2pComponents[p2pComponents.length - 1]?.value
+    if (targetPeerId != null) {
+      const group = byPeerId.get(targetPeerId) ?? []
+      group.push(ma)
+      byPeerId.set(targetPeerId, group)
+    } else {
+      noPeerId.push(ma)
+    }
+  }
+
+  // For each peer, pick the best address: TCP direct > any direct > relay
+  const selected: Multiaddr[] = []
+  for (const [, addrs] of byPeerId) {
+    const isTcpDirect = (ma: Multiaddr) => {
+      const components = ma.getComponents()
+      return components.some((c) => c.name === 'tcp') && !components.some((c) => c.name === 'p2p-circuit')
+    }
+    const isDirect = (ma: Multiaddr) => !ma.getComponents().some((c) => c.name === 'p2p-circuit')
+    const best = addrs.find(isTcpDirect) ?? addrs.find(isDirect) ?? addrs[0]
+    if (best != null) {
+      selected.push(best)
+    }
+  }
+
+  return [...selected, ...noPeerId]
+}
+
+const IDENTIFY_MAX_MESSAGE_SIZE = 1024 * 64
 
 export interface PinningHeliaOptions {
   config: Config
@@ -30,17 +80,8 @@ export async function createPinningHeliaNode(options: PinningHeliaOptions): Prom
 }> {
   const { logger, rootCID, outputPath, origins = [] } = options
 
-  // Parse origins into multiaddrs
-  const dialTargets = origins
-    .map((origin) => {
-      try {
-        return multiaddr(origin)
-      } catch (error) {
-        logger.warn({ origin, error }, 'Failed to parse origin multiaddr')
-        return null
-      }
-    })
-    .filter((addr) => addr != null)
+  // Deduplicate origins: one address per target peer, preferring TCP direct connections
+  const dialTargets = selectDialTargets(origins, logger)
 
   const libp2p = await createLibp2p({
     addresses: {
@@ -50,7 +91,7 @@ export async function createPinningHeliaNode(options: PinningHeliaOptions): Prom
     connectionEncrypters: [noise()],
     streamMuxers: [yamux()],
     services: {
-      identify: identify(),
+      identify: identify({ maxMessageSize: IDENTIFY_MAX_MESSAGE_SIZE }),
     },
     // No bootstrap or mdns - we'll connect directly to origins
   })
@@ -83,16 +124,14 @@ export async function createPinningHeliaNode(options: PinningHeliaOptions): Prom
 
   // Connect to origin nodes if provided
   if (dialTargets.length > 0) {
-    logger.info({ origins: dialTargets.length }, 'Connecting to origin nodes')
+    logger.info({ origins: origins.length, dialTargets: dialTargets.length }, 'Connecting to origin nodes')
 
     for (const addr of dialTargets) {
       try {
-        if (addr != null) {
-          await helia.libp2p.dial(addr)
-          logger.info({ addr: addr.toString() }, 'Connected to origin node')
-        }
+        await helia.libp2p.dial(addr)
+        logger.info({ addr: addr.toString() }, 'Connected to origin node')
       } catch (error) {
-        logger.warn({ addr: addr?.toString(), error }, 'Failed to connect to origin node')
+        logger.warn({ addr: addr.toString(), error }, 'Failed to connect to origin node')
       }
     }
   }

--- a/src/create-pinning-helia.ts
+++ b/src/create-pinning-helia.ts
@@ -82,8 +82,10 @@ export async function createPinningHeliaNode(options: PinningHeliaOptions): Prom
 
   logger.info(`Pinning Helia node started with peer ID: ${helia.libp2p.peerId.toString()}`)
   logger.info(`Writing blocks to CAR file: ${outputPath}`)
+
+  // Connect to origin node if provided
   if (dialTargets.length > 0) {
-    logger.info({ options: dialTargets.length }, 'Connecting to origin node')
+    logger.info({ origins: dialTargets.length }, 'Connecting to origin node')
     try {
       await helia.libp2p.dial(dialTargets)
       logger.info('Connected to origin node')

--- a/src/create-pinning-helia.ts
+++ b/src/create-pinning-helia.ts
@@ -82,10 +82,8 @@ export async function createPinningHeliaNode(options: PinningHeliaOptions): Prom
 
   logger.info(`Pinning Helia node started with peer ID: ${helia.libp2p.peerId.toString()}`)
   logger.info(`Writing blocks to CAR file: ${outputPath}`)
-
-  // Connect to origin nodes if provided
   if (dialTargets.length > 0) {
-    logger.info({ count: dialTargets.length }, 'Connecting to origin node')
+    logger.info({ options: dialTargets.length }, 'Connecting to origin node')
     try {
       await helia.libp2p.dial(dialTargets)
       logger.info('Connected to origin node')

--- a/src/create-pinning-helia.ts
+++ b/src/create-pinning-helia.ts
@@ -3,7 +3,7 @@ import { yamux } from '@chainsafe/libp2p-yamux'
 import { bitswap } from '@helia/block-brokers'
 import { identify } from '@libp2p/identify'
 import { tcp } from '@libp2p/tcp'
-import { type Multiaddr, multiaddr } from '@multiformats/multiaddr'
+import { multiaddr } from '@multiformats/multiaddr'
 import { MemoryDatastore } from 'datastore-core'
 import { createHelia, type Helia } from 'helia'
 import { createLibp2p } from 'libp2p'
@@ -11,54 +11,6 @@ import type { CID } from 'multiformats/cid'
 import type { Logger } from 'pino'
 import { CARWritingBlockstore } from './core/car/index.js'
 import type { Config } from './core/synapse/index.js'
-
-/**
- * Deduplicate origin multiaddrs by target peer ID, picking one address per peer.
- * Prefers TCP direct connections since that is the only transport Helia has configured.
- * Addresses without a peer ID component are included as-is.
- */
-function selectDialTargets(origins: string[], logger: Logger): Multiaddr[] {
-  const parsed: Multiaddr[] = []
-  for (const origin of origins) {
-    try {
-      parsed.push(multiaddr(origin))
-    } catch {
-      logger.warn({ origin }, 'Failed to parse origin multiaddr, skipping')
-    }
-  }
-
-  // Group by the final /p2p/<peerId> component (the target peer, not an intermediate relay)
-  const byPeerId = new Map<string, Multiaddr[]>()
-  const noPeerId: Multiaddr[] = []
-
-  for (const ma of parsed) {
-    const p2pComponents = ma.getComponents().filter((c) => c.name === 'p2p')
-    const targetPeerId = p2pComponents[p2pComponents.length - 1]?.value
-    if (targetPeerId != null) {
-      const group = byPeerId.get(targetPeerId) ?? []
-      group.push(ma)
-      byPeerId.set(targetPeerId, group)
-    } else {
-      noPeerId.push(ma)
-    }
-  }
-
-  // For each peer, pick the best address: TCP direct > any direct > relay
-  const selected: Multiaddr[] = []
-  for (const [, addrs] of byPeerId) {
-    const isTcpDirect = (ma: Multiaddr) => {
-      const components = ma.getComponents()
-      return components.some((c) => c.name === 'tcp') && !components.some((c) => c.name === 'p2p-circuit')
-    }
-    const isDirect = (ma: Multiaddr) => !ma.getComponents().some((c) => c.name === 'p2p-circuit')
-    const best = addrs.find(isTcpDirect) ?? addrs.find(isDirect) ?? addrs[0]
-    if (best != null) {
-      selected.push(best)
-    }
-  }
-
-  return [...selected, ...noPeerId]
-}
 
 const IDENTIFY_MAX_MESSAGE_SIZE = 1024 * 64
 
@@ -80,8 +32,7 @@ export async function createPinningHeliaNode(options: PinningHeliaOptions): Prom
 }> {
   const { logger, rootCID, outputPath, origins = [] } = options
 
-  // Deduplicate origins: one address per target peer, preferring TCP direct connections
-  const dialTargets = selectDialTargets(origins, logger)
+  const dialAddrs = origins.map(multiaddr)
 
   const libp2p = await createLibp2p({
     addresses: {
@@ -123,16 +74,13 @@ export async function createPinningHeliaNode(options: PinningHeliaOptions): Prom
   logger.info(`Writing blocks to CAR file: ${outputPath}`)
 
   // Connect to origin nodes if provided
-  if (dialTargets.length > 0) {
-    logger.info({ origins: origins.length, dialTargets: dialTargets.length }, 'Connecting to origin nodes')
-
-    for (const addr of dialTargets) {
-      try {
-        await helia.libp2p.dial(addr)
-        logger.info({ addr: addr.toString() }, 'Connected to origin node')
-      } catch (error) {
-        logger.warn({ addr: addr.toString(), error }, 'Failed to connect to origin node')
-      }
+  if (dialAddrs.length > 0) {
+    logger.info({ count: dialAddrs.length }, 'Connecting to origin node')
+    try {
+      await helia.libp2p.dial(dialAddrs)
+      logger.info({ count: dialAddrs.length }, 'Connected to origin node')
+    } catch (error) {
+      logger.warn({ error }, 'Failed to connect to origin node')
     }
   }
 


### PR DESCRIPTION
Reviewer @SgtPooki
On linux I saw this issue with the server and kubo pinmfs related to there being too many origins.
There were 54 origins.
The repeated dial was causing problems and deduping fixed it.
There was also a problem related to the size of the identify response, which was too large.
#### Changes
* larger identify message size limit
* ~dedupe origins~
* pass all origins to dial