### PR TITLE
fix `upload-action`: pnpm needs `version`

### DIFF
--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -129,6 +129,13 @@ runs:
         REPO_ROOT=$(cd "$REPO_ROOT" && pwd)
         echo "path=$REPO_ROOT" >> $GITHUB_OUTPUT
 
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24.x'
+        cache: pnpm
+        cache-dependency-path: ${{ steps.repo-root.outputs.path }}/pnpm-lock.yaml
+
     - name: Get pnpm version
       id: pnpm-version
       shell: bash
@@ -142,13 +149,6 @@ runs:
       with:
         run_install: false
         version: ${{ steps.pnpm-version.outputs.version }}
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: '24.x'
-        cache: pnpm
-        cache-dependency-path: ${{ steps.repo-root.outputs.path }}/pnpm-lock.yaml
 
     - name: Install workspace dependencies
       shell: bash


### PR DESCRIPTION
https://github.com/pnpm/action-setup/tree/v4

Discovered in https://github.com/filecoin-project/filecoin-pin-website/actions/runs/23843458554/job/69505217523, working on https://github.com/filecoin-project/filecoin-pin-website/pull/169