### PR TITLE
fix: include sybil fees in shared upload funding

### DIFF
--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -160,8 +160,21 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
     const carSize = carData.length
     spinner.stop(`${pc.green('✓')} IPFS content loaded (${formatFileSize(carSize)})`)
 
+    const autoFundOptions: Parameters<typeof performAutoFunding>[3] = {
+      ...(dataSetMetadata && { metadata: dataSetMetadata }),
+      ...(options.copies != null && { copies: options.copies }),
+    }
+    if (contextSelection.providerIds) {
+      autoFundOptions.providerIds = contextSelection.providerIds
+      autoFundOptions.copies = contextSelection.providerIds.length
+    }
+    if (contextSelection.dataSetIds) {
+      autoFundOptions.dataSetIds = contextSelection.dataSetIds
+      autoFundOptions.copies = contextSelection.dataSetIds.length
+    }
+
     if (options.autoFund) {
-      await performAutoFunding(synapse, carSize, spinner)
+      await performAutoFunding(synapse, carSize, spinner, autoFundOptions)
     } else {
       spinner.start('Checking payment capacity...')
       await validatePaymentSetup(synapse, carSize, spinner)

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -88,14 +88,24 @@ export interface UploadFlowResult extends SynapseUploadResult {
  * @param synapse - Initialized Synapse instance
  * @param fileSize - Size of file being uploaded (in bytes)
  * @param spinner - Optional spinner for progress
+ * @param options - Optional upload targeting inputs used to estimate new data set fees
  */
-export async function performAutoFunding(synapse: Synapse, fileSize: number, spinner?: Spinner): Promise<void> {
+export async function performAutoFunding(
+  synapse: Synapse,
+  fileSize: number,
+  spinner?: Spinner,
+  options?: Pick<AutoFundOptions, 'copies' | 'providerIds' | 'dataSetIds' | 'metadata'>
+): Promise<void> {
   spinner?.start('Checking funding requirements for upload...')
 
   try {
     const fundOptions: AutoFundOptions = {
       synapse,
       fileSize,
+      ...(options?.copies != null ? { copies: options.copies } : {}),
+      ...(options?.providerIds != null ? { providerIds: options.providerIds } : {}),
+      ...(options?.dataSetIds != null ? { dataSetIds: options.dataSetIds } : {}),
+      ...(options?.metadata != null ? { metadata: options.metadata } : {}),
     }
     if (spinner !== undefined) {
       fundOptions.spinner = spinner

--- a/src/core/payments/constants.ts
+++ b/src/core/payments/constants.ts
@@ -29,6 +29,11 @@ export const DEFAULT_LOCKUP_DAYS = 30
 export const FLOOR_PRICE_PER_30_DAYS = parseUnits('0.06', USDFC_DECIMALS)
 
 /**
+ * One-time sybil fee charged when creating a new WarmStorage data set
+ */
+export const USDFC_SYBIL_FEE = parseUnits('0.1', USDFC_DECIMALS)
+
+/**
  * Number of days the floor price covers
  */
 export const FLOOR_PRICE_DAYS = 30

--- a/src/core/payments/funding.ts
+++ b/src/core/payments/funding.ts
@@ -8,6 +8,7 @@ import {
   computeAdjustmentForExactDeposit,
   depositUSDFC,
   getPaymentStatus,
+  USDFC_SYBIL_FEE,
   validatePaymentRequirements,
   withdrawUSDFC,
 } from './index.js'
@@ -139,6 +140,7 @@ export function calculateFilecoinPayFundingPlan(options: FilecoinPayFundingPlanO
     targetDeposit,
     pieceSizeBytes,
     pricePerTiBPerEpoch,
+    newDataSetCount = 0,
     mode = 'exact',
     allowWithdraw = true,
   } = options
@@ -153,6 +155,10 @@ export function calculateFilecoinPayFundingPlan(options: FilecoinPayFundingPlanO
 
   if (pieceSizeBytes != null && pricePerTiBPerEpoch == null) {
     throw new Error('pricePerTiBPerEpoch is required when pieceSizeBytes is provided')
+  }
+
+  if (!Number.isInteger(newDataSetCount) || newDataSetCount < 0) {
+    throw new Error('newDataSetCount must be a non-negative integer')
   }
 
   let delta: bigint
@@ -175,8 +181,9 @@ export function calculateFilecoinPayFundingPlan(options: FilecoinPayFundingPlanO
         pieceSizeBytes,
         pricePerTiBPerEpoch
       )
-      delta = adjustment.delta
-      resolvedTargetDeposit = adjustment.targetDeposit
+      const dataSetCreationFees = BigInt(newDataSetCount) * USDFC_SYBIL_FEE
+      delta = adjustment.delta + dataSetCreationFees
+      resolvedTargetDeposit = adjustment.targetDeposit + dataSetCreationFees
       projectedRateUsed = adjustment.newRateUsed
       projectedLockupUsed = adjustment.newLockupUsed
 
@@ -260,6 +267,7 @@ export function calculateFilecoinPayFundingPlan(options: FilecoinPayFundingPlanO
     ...(resolvedTargetDeposit != null ? { targetDeposit: resolvedTargetDeposit } : {}),
     ...(pieceSizeBytes != null ? { pieceSizeBytes } : {}),
     ...(pricePerTiBPerEpoch != null ? { pricePerTiBPerEpoch } : {}),
+    ...(newDataSetCount > 0 ? { newDataSetCount } : {}),
     ...(walletShortfall != null ? { walletShortfall } : {}),
   }
 
@@ -280,6 +288,7 @@ export interface PlanFilecoinPayFundingOptions {
   targetDeposit?: bigint | undefined
   pieceSizeBytes?: number | undefined
   pricePerTiBPerEpoch?: bigint | undefined
+  newDataSetCount?: number | undefined
   mode?: FundingMode | undefined
   allowWithdraw?: boolean | undefined
   ensureAllowances?: boolean | undefined
@@ -313,6 +322,7 @@ export async function planFilecoinPayFunding(options: PlanFilecoinPayFundingOpti
     targetDeposit,
     pieceSizeBytes,
     pricePerTiBPerEpoch,
+    newDataSetCount = 0,
     mode = 'exact',
     allowWithdraw = true,
     ensureAllowances = false,
@@ -364,6 +374,7 @@ export async function planFilecoinPayFunding(options: PlanFilecoinPayFundingOpti
     targetDeposit,
     pieceSizeBytes,
     pricePerTiBPerEpoch: pricing,
+    newDataSetCount,
     mode,
     allowWithdraw,
   })

--- a/src/core/payments/types.ts
+++ b/src/core/payments/types.ts
@@ -106,6 +106,7 @@ export interface FilecoinPayFundingPlanOptions {
   targetDeposit?: bigint | undefined
   pieceSizeBytes?: number | undefined
   pricePerTiBPerEpoch?: bigint | undefined
+  newDataSetCount?: number | undefined
   mode?: FundingMode | undefined
   allowWithdraw?: boolean | undefined
 }
@@ -131,6 +132,7 @@ export interface FilecoinPayFundingPlan {
   mode: FundingMode
   pieceSizeBytes?: number
   pricePerTiBPerEpoch?: bigint
+  newDataSetCount?: number
   projectedDeposit: bigint
   projectedRateUsed: bigint
   projectedLockupUsed: bigint

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -202,7 +202,20 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
     spinner.stop(`${pc.green('✓')} Connected to ${pc.bold(network)}`)
 
     if (options.autoFund) {
-      await performAutoFunding(synapse, fileStat.size, spinner)
+      const autoFundOptions: Parameters<typeof performAutoFunding>[3] = {
+        ...(dataSetMetadata && { metadata: dataSetMetadata }),
+        ...(options.copies != null && { copies: options.copies }),
+      }
+      if (contextSelection.providerIds) {
+        autoFundOptions.providerIds = contextSelection.providerIds
+        autoFundOptions.copies = contextSelection.providerIds.length
+      }
+      if (contextSelection.dataSetIds) {
+        autoFundOptions.dataSetIds = contextSelection.dataSetIds
+        autoFundOptions.copies = contextSelection.dataSetIds.length
+      }
+
+      await performAutoFunding(synapse, fileStat.size, spinner, autoFundOptions)
     } else {
       spinner.start('Checking payment capacity...')
       await validatePaymentSetup(synapse, fileStat.size, spinner)

--- a/src/payments/fund.ts
+++ b/src/payments/fund.ts
@@ -134,14 +134,23 @@ async function printSummary(synapse: Synapse, title = 'Updated'): Promise<void> 
  * @throws Error if adjustment fails or target is unsafe
  */
 export async function autoFund(options: AutoFundOptions): Promise<FundingAdjustmentResult> {
-  const { synapse, fileSize, spinner } = options
+  const { synapse, fileSize, copies, providerIds, dataSetIds, metadata, spinner } = options
 
   spinner?.message('Checking wallet readiness...')
+
+  const contexts = await synapse.storage.createContexts({
+    ...(copies != null ? { copies } : {}),
+    ...(providerIds != null ? { providerIds } : {}),
+    ...(dataSetIds != null ? { dataSetIds } : {}),
+    ...(metadata != null ? { metadata } : {}),
+  })
+  const newDataSetCount = contexts.filter((context) => context.dataSetId == null).length
 
   const planResult = await planFilecoinPayFunding({
     synapse,
     targetRunwayDays: MIN_RUNWAY_DAYS,
     pieceSizeBytes: fileSize,
+    newDataSetCount,
     ensureAllowances: true,
     allowWithdraw: false,
   })

--- a/src/payments/types.ts
+++ b/src/payments/types.ts
@@ -23,6 +23,14 @@ export interface AutoFundOptions {
   synapse: Synapse
   /** Size of file being uploaded (in bytes) - used to calculate additional funding needed */
   fileSize: number
+  /** Number of storage copies to create */
+  copies?: number
+  /** Specific provider IDs to upload to */
+  providerIds?: bigint[]
+  /** Specific existing data set IDs to target */
+  dataSetIds?: bigint[]
+  /** Data set metadata applied when creating or matching contexts */
+  metadata?: Record<string, string>
   /** Optional spinner for progress updates */
   spinner?: Spinner
 }

--- a/src/test/unit/add.test.ts
+++ b/src/test/unit/add.test.ts
@@ -17,6 +17,7 @@ import { runAdd } from '../../add/add.js'
 // Mock the external dependencies at module level
 vi.mock('../../common/upload-flow.js', () => ({
   validatePaymentSetup: vi.fn(),
+  performAutoFunding: vi.fn(),
   performUpload: vi.fn().mockResolvedValue({
     pieceCid: 'bafkzcibtest1234567890',
     size: 1024,
@@ -238,6 +239,30 @@ describe('Add Command', () => {
         expect.objectContaining({
           dataSetIds: [123n],
           copies: 1,
+        })
+      )
+    })
+
+    it('passes upload targeting options through to auto-funding', async () => {
+      await runAdd({
+        filePath: testFile,
+        privateKey: 'test-private-key',
+        rpcUrl: 'wss://test.rpc.url',
+        autoFund: true,
+        providerIds: '7,8',
+        dataSetMetadata: { purpose: 'erc8004' },
+      })
+
+      const { performAutoFunding } = await import('../../common/upload-flow.js')
+
+      expect(vi.mocked(performAutoFunding)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Number),
+        expect.anything(),
+        expect.objectContaining({
+          providerIds: [7n, 8n],
+          copies: 2,
+          metadata: { purpose: 'erc8004' },
         })
       )
     })

--- a/src/test/unit/import.test.ts
+++ b/src/test/unit/import.test.ts
@@ -402,6 +402,33 @@ describe('CAR Import', () => {
         })
       )
     })
+
+    it('passes upload targeting options through to auto-funding', async () => {
+      const carPath = join(testDir, 'auto-fund.car')
+      await createTestCarFile(carPath, [], [{ content: 'test content' }])
+
+      const options: ImportOptions = {
+        filePath: carPath,
+        privateKey: testPrivateKey,
+        autoFund: true,
+        dataSetIds: '123',
+        dataSetMetadata: { erc8004Files: '' },
+      }
+
+      await runCarImport(options)
+
+      const { performAutoFunding } = await import('../../common/upload-flow.js')
+      expect(vi.mocked(performAutoFunding)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Number),
+        expect.anything(),
+        expect.objectContaining({
+          dataSetIds: [123n],
+          copies: 1,
+          metadata: { erc8004Files: '' },
+        })
+      )
+    })
   })
 
   describe('Upload Result', () => {

--- a/src/test/unit/payments-funding.test.ts
+++ b/src/test/unit/payments-funding.test.ts
@@ -2,6 +2,7 @@ import { TIME_CONSTANTS } from '@filoz/synapse-sdk'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as paymentsIndex from '../../core/payments/index.js'
 import {
+  calculateFilecoinPayFundingPlan,
   executeFilecoinPayFunding,
   getFilecoinPayFundingInsights,
   type PaymentStatus,
@@ -194,6 +195,33 @@ describe('planFilecoinPayFunding', () => {
     expect(plan.pricePerTiBPerEpoch).toBe(1n)
     expect(plan.delta).toBeGreaterThan(0n)
     expect(plan.reasonCode).toBe('runway-with-piece')
+  })
+
+  it('adds sybil fees for new data sets in the shared funding plan', () => {
+    const status = makeStatus({ filecoinPayBalance: 0n, wallet: 1_000_000_000_000_000_000n })
+
+    const basePlan = calculateFilecoinPayFundingPlan({
+      status,
+      targetRunwayDays: 30,
+      pieceSizeBytes: 1024,
+      pricePerTiBPerEpoch: 1n,
+      newDataSetCount: 0,
+      mode: 'minimum',
+      allowWithdraw: false,
+    })
+
+    const withFeesPlan = calculateFilecoinPayFundingPlan({
+      status,
+      targetRunwayDays: 30,
+      pieceSizeBytes: 1024,
+      pricePerTiBPerEpoch: 1n,
+      newDataSetCount: 2,
+      mode: 'minimum',
+      allowWithdraw: false,
+    })
+
+    expect(withFeesPlan.delta - basePlan.delta).toBe(200_000_000_000_000_000n)
+    expect(withFeesPlan.targetDeposit).toBe((basePlan.targetDeposit ?? 0n) + 200_000_000_000_000_000n)
   })
 })
 

--- a/upload-action/src/filecoin.js
+++ b/upload-action/src/filecoin.js
@@ -12,13 +12,15 @@ import { formatRunwaySummary, formatUSDFC } from 'filecoin-pin/core/utils'
 import { CID } from 'multiformats/cid'
 import { getErrorMessage } from './errors.js'
 
+const USDFC_SYBIL_FEE = 100_000_000_000_000_000n
+
 /**
  * @typedef {import('./types.js').ParsedInputs} ParsedInputs
  * @typedef {import('./types.js').BuildResult} BuildResult
  * @typedef {import('./types.js').UploadResult} UploadResult
  * @typedef {import('./types.js').PaymentStatus} PaymentStatus
  * @typedef {import('./types.js').SimplifiedPaymentStatus} SimplifiedPaymentStatus
- * @typedef {import('./types.js').PaymentConfig} PaymentConfig
+ * @typedef {import('./types.js').PaymentFundingConfig} PaymentFundingConfig
  * @typedef {import('./types.js').UploadConfig} UploadConfig
  * @typedef {import('./types.js').FilecoinPinPaymentStatus} FilecoinPinPaymentStatus
  * @typedef {import('./types.js').Synapse} Synapse
@@ -50,15 +52,22 @@ export async function createCarFile(targetPath, contentPath, logger) {
 /**
  * Handle payment setup and top-ups using core payment functions
  * @param {Synapse} synapse - Synapse service
- * @param {PaymentConfig} options - Payment options
+ * @param {PaymentFundingConfig} options - Payment options
  * @param {Logger | undefined} logger - Logger instance
  * @returns {Promise<SimplifiedPaymentStatus>} Updated payment status
  */
 export async function handlePayments(synapse, options, logger) {
-  const { minStorageDays, filecoinPayBalanceLimit, pieceSizeBytes } = options
+  const { minStorageDays, filecoinPayBalanceLimit, pieceSizeBytes, withCDN, providerIds } = options
 
   console.log('Checking current Filecoin Pay account balance...')
-  const [rawStatus, storageInfo] = await Promise.all([getPaymentStatus(synapse), synapse.storage.getStorageInfo()])
+  const [rawStatus, storageInfo, contexts] = await Promise.all([
+    getPaymentStatus(synapse),
+    synapse.storage.getStorageInfo(),
+    synapse.storage.createContexts({
+      ...(providerIds != null && providerIds.length > 0 ? { providerIds } : {}),
+      ...(withCDN ? { withCDN } : {}),
+    }),
+  ])
 
   const initialFilecoinPayBalance = formatUSDFC(rawStatus.filecoinPayBalance)
   const initialWalletBalance = formatUSDFC(rawStatus.walletUsdfcBalance)
@@ -81,8 +90,20 @@ export async function handlePayments(synapse, options, logger) {
     console.log(`\n${reasonMessage}: ${formatUSDFC(fundingPlan.delta)} USDFC`)
   }
 
+  const newDataSetCount = contexts.filter((context) => context.dataSetId == null).length
+  const sybilFeeTopUp = BigInt(newDataSetCount) * USDFC_SYBIL_FEE
+
+  if (sybilFeeTopUp > 0n) {
+    console.log(
+      `Additional funding for ${newDataSetCount} new data set${newDataSetCount === 1 ? '' : 's'} ` +
+        `(sybil fee): ${formatUSDFC(sybilFeeTopUp)} USDFC`
+    )
+  }
+
+  const totalTopUp = fundingPlan.delta + sybilFeeTopUp
+
   // Execute top-up with balance limit checking
-  const topUpResult = await executeTopUp(synapse, fundingPlan.delta, {
+  const topUpResult = await executeTopUp(synapse, totalTopUp, {
     balanceLimit: filecoinPayBalanceLimit,
     logger,
   })

--- a/upload-action/src/filecoin.js
+++ b/upload-action/src/filecoin.js
@@ -12,8 +12,6 @@ import { formatRunwaySummary, formatUSDFC } from 'filecoin-pin/core/utils'
 import { CID } from 'multiformats/cid'
 import { getErrorMessage } from './errors.js'
 
-const USDFC_SYBIL_FEE = 100_000_000_000_000_000n
-
 /**
  * @typedef {import('./types.js').ParsedInputs} ParsedInputs
  * @typedef {import('./types.js').BuildResult} BuildResult
@@ -75,6 +73,8 @@ export async function handlePayments(synapse, options, logger) {
   console.log(`Current Filecoin Pay balance: ${initialFilecoinPayBalance} USDFC`)
   console.log(`Wallet USDFC balance: ${initialWalletBalance} USDFC`)
 
+  const newDataSetCount = contexts.filter((context) => context.dataSetId == null).length
+
   // Calculate required funding using the comprehensive funding planner
   const fundingPlan = calculateFilecoinPayFundingPlan({
     status: rawStatus,
@@ -83,6 +83,7 @@ export async function handlePayments(synapse, options, logger) {
     targetRunwayDays: minStorageDays,
     pieceSizeBytes,
     pricePerTiBPerEpoch: storageInfo.pricing.noCDN.perTiBPerEpoch,
+    newDataSetCount,
   })
 
   if (fundingPlan.delta > 0n) {
@@ -90,20 +91,15 @@ export async function handlePayments(synapse, options, logger) {
     console.log(`\n${reasonMessage}: ${formatUSDFC(fundingPlan.delta)} USDFC`)
   }
 
-  const newDataSetCount = contexts.filter((context) => context.dataSetId == null).length
-  const sybilFeeTopUp = BigInt(newDataSetCount) * USDFC_SYBIL_FEE
-
-  if (sybilFeeTopUp > 0n) {
+  if (newDataSetCount > 0) {
     console.log(
       `Additional funding for ${newDataSetCount} new data set${newDataSetCount === 1 ? '' : 's'} ` +
-        `(sybil fee): ${formatUSDFC(sybilFeeTopUp)} USDFC`
+        '(sybil fee) is included in the planned top-up'
     )
   }
 
-  const totalTopUp = fundingPlan.delta + sybilFeeTopUp
-
   // Execute top-up with balance limit checking
-  const topUpResult = await executeTopUp(synapse, totalTopUp, {
+  const topUpResult = await executeTopUp(synapse, fundingPlan.delta, {
     balanceLimit: filecoinPayBalanceLimit,
     logger,
   })

--- a/upload-action/src/types.ts
+++ b/upload-action/src/types.ts
@@ -88,6 +88,11 @@ export interface PaymentConfig {
   pieceSizeBytes?: number | undefined
 }
 
+export interface PaymentFundingConfig extends PaymentConfig {
+  withCDN: boolean
+  providerIds?: bigint[] | undefined
+}
+
 export interface UploadConfig {
   withCDN: boolean
   providerIds?: bigint[] | undefined

--- a/upload-action/src/upload.js
+++ b/upload-action/src/upload.js
@@ -165,6 +165,8 @@ export async function runUpload(buildContext = {}) {
         minStorageDays,
         filecoinPayBalanceLimit,
         pieceSizeBytes: context.carSize,
+        withCDN,
+        providerIds,
       },
       logger
     )


### PR DESCRIPTION
## Summary
This PR is the short-term mitigation for the recent `InsufficientLockupFunds` failures.

It keeps filecoin-pin's existing funding planner, but patches the shared upload funding path so both the GitHub Action and CLI auto-fund logic include the new-data-set 0.1 USDFC sybil fee.

## What changed
- add the WarmStorage new-data-set sybil fee constant to filecoin-pin payment constants
- extend the shared funding planner to accept `newDataSetCount` and include those fees in the planned deposit
- thread that input through `planFilecoinPayFunding()`
- update CLI auto-fund to resolve upload contexts and count how many new data sets will be created
- update the upload action to do the same and feed the result into the shared planner
- add targeted unit coverage for the planner and the add/import auto-fund call sites

## Why
The failure we hit was caused by funding only the lockup requirement for an upload while omitting the 0.1 USDFC fee charged when a new WarmStorage data set is created.

Because upload-time funding exists in both the upload action and CLI auto-fund flow, the short-term patch should live in the shared planner path rather than only in the action wrapper.

## Scope and tradeoff
This is intentionally the tactical fix.

It does **not** replace filecoin-pin's custom cost planner with Synapse's full upload-cost calculation. Instead, it patches the known missing fee in the existing planner so the immediate failure is addressed with a smaller change set.

The longer-term cleanup direction is in #401.

## Validation
- `pnpm run build`
- `pnpm --filter filecoin-pin-upload-action-helper typecheck`
- `pnpm exec vitest run --project unit src/test/unit/payments-funding.test.ts src/test/unit/add.test.ts src/test/unit/import.test.ts`
- `pnpm exec biome check src/core/payments/constants.ts src/core/payments/types.ts src/core/payments/funding.ts src/payments/types.ts src/payments/fund.ts src/common/upload-flow.ts src/add/add.ts src/import/import.ts src/test/unit/payments-funding.test.ts src/test/unit/add.test.ts src/test/unit/import.test.ts upload-action/src/filecoin.js`