### PR TITLE
feat(upload-action): accept pre-built .car path

### DIFF
--- a/upload-action/README.md
+++ b/upload-action/README.md
@@ -19,6 +19,21 @@ See [action.yml](./action.yml) for complete input documentation including:
 
 **Outputs**: `ipfsRootCid`, `dataSetId`, `pieceCid`, `providerId`, `providerName`, `carPath`, `uploadStatus`
 
+### Uploading a pre-built CAR
+
+If `path` points to a regular file whose name ends in `.car`, the action skips its own UnixFS packing and uploads the file as-is, extracting the IPFS root CID from the CAR header. Useful for composing with upstream steps that already produce a CAR (e.g. [`ipfs-deploy-action`](https://github.com/ipfs/ipfs-deploy-action), [`ipfs dag export`](https://docs.ipfs.tech/reference/kubo/cli/#ipfs-dag-export)).
+
+```yaml
+- name: Upload pre-built CAR to Filecoin
+  uses: filecoin-project/filecoin-pin/upload-action@v0
+  with:
+    path: build.car
+    walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
+    network: calibration
+```
+
+The CAR must declare exactly one root; multi-root and rootless CARs are rejected so the upload always has an unambiguous IPFS root CID. Directories (even named `foo.car/`) fall through to the UnixFS packer.
+
 ### Advanced: Provider Overrides
 
 For most users, automatic provider selection is recommended. However, for advanced use cases where you need to target a specific storage provider, set environment variables:

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -7,7 +7,12 @@ branding:
 inputs:
   # Core configuration
   path:
-    description: Path to content to upload (file or directory). Typically your build output directory.
+    description: >-
+      Path to content to upload. Typically your build output directory.
+      If `path` points to a file with the `.car` extension, the action skips its own CAR
+      creation and uploads the file as-is, extracting the IPFS root CID from the CAR header.
+      Otherwise (directory or non-`.car` file) the action packs the content into a CAR first.
+      Pre-built CARs must declare exactly one root; multi-root CARs are not supported.
     required: true
   walletPrivateKey:
     description: Wallet private key used to fund uploads (USDFC on Calibration/Mainnet).

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -12,7 +12,7 @@ inputs:
       If `path` points to a file with the `.car` extension, the action skips its own CAR
       creation and uploads the file as-is, extracting the IPFS root CID from the CAR header.
       Otherwise (directory or non-`.car` file) the action packs the content into a CAR first.
-      Pre-built CARs must declare exactly one root; multi-root CARs are not supported.
+      Pre-built CARs must declare exactly one root; rootless and multi-root CARs are not supported.
     required: true
   walletPrivateKey:
     description: Wallet private key used to fund uploads (USDFC on Calibration/Mainnet).

--- a/upload-action/src/build.js
+++ b/upload-action/src/build.js
@@ -1,6 +1,7 @@
+import { promises as fs } from 'node:fs'
 import pc from 'picocolors'
 import pino from 'pino'
-import { createCarFile } from './filecoin.js'
+import { createCarFile, readCarFile } from './filecoin.js'
 import { readEventPayload, updateCheck } from './github.js'
 import { parseInputs, resolveContentPath } from './inputs.js'
 import { formatSize } from './outputs.js'
@@ -54,7 +55,13 @@ export async function runBuild() {
   const { contentPath } = inputs
   const targetPath = resolveContentPath(contentPath)
 
-  const buildResult = /** @type {BuildResult} */ (await createCarFile(targetPath, contentPath, logger))
+  // If the user passed a path to an existing .car file, skip UnixFS packing
+  // and upload the CAR as-is. Otherwise, pack the directory/file into a CAR.
+  const buildResult = /** @type {BuildResult} */ (
+    (await isPrebuiltCar(targetPath))
+      ? await readCarFile(targetPath, contentPath, logger)
+      : await createCarFile(targetPath, contentPath, logger)
+  )
   const { carPath, ipfsRootCid, carSize } = buildResult
   console.log(`IPFS Root CID: ${pc.bold(ipfsRootCid)}`)
   console.log(`::notice::IPFS Root CID: ${ipfsRootCid}`)
@@ -93,4 +100,22 @@ export async function runBuild() {
   })
 
   return context
+}
+
+/**
+ * A path is treated as a pre-built CAR when it points to a regular file
+ * whose name ends in `.car`. Directories (even named `foo.car/`) fall
+ * through to the UnixFS packer.
+ *
+ * @param {string} targetPath
+ * @returns {Promise<boolean>}
+ */
+async function isPrebuiltCar(targetPath) {
+  if (!targetPath.toLowerCase().endsWith('.car')) return false
+  try {
+    const stats = await fs.stat(targetPath)
+    return stats.isFile()
+  } catch {
+    return false
+  }
 }

--- a/upload-action/src/build.js
+++ b/upload-action/src/build.js
@@ -13,16 +13,17 @@ import { formatSize } from './outputs.js'
  */
 
 /**
- * Run build phase: Create CAR file and return build context details
+ * Run build phase: prepare the CAR file (either pack content into a new CAR
+ * or accept a pre-built `.car` file) and return build context details.
  */
 export async function runBuild() {
   const logger = pino({ level: process.env.LOG_LEVEL || 'info' })
 
-  console.log('━━━ Build Phase: Creating CAR file ━━━')
+  console.log('━━━ Build Phase: Preparing CAR file ━━━')
 
   await updateCheck({
-    title: 'Building CAR file',
-    summary: 'Creating CAR file from content...',
+    title: 'Preparing CAR file',
+    summary: 'Preparing CAR file for upload...',
   })
 
   const event = await readEventPayload()
@@ -46,9 +47,9 @@ export async function runBuild() {
   )
 
   if (isForkPR) {
-    console.log('━━━ Fork PR Detected - Building CAR but Blocking Upload ━━━')
+    console.log('━━━ Fork PR Detected - Preparing CAR but Blocking Upload ━━━')
     console.error('::error::Fork PR support is currently disabled. Only same-repo workflows are supported.')
-    console.log('::notice::Building CAR file but upload will be blocked')
+    console.log('::notice::Preparing CAR file but upload will be blocked')
   }
 
   const inputs = /** @type {ParsedInputs} */ (parseInputs('compute'))
@@ -90,12 +91,12 @@ export async function runBuild() {
     context.pr = pr
   }
 
-  console.log('✓ Build complete. CAR file created.')
-  console.log('::notice::Build phase complete. CAR file created.')
+  console.log('✓ Build complete. CAR file ready.')
+  console.log('::notice::Build phase complete. CAR file ready.')
 
   await updateCheck({
-    title: 'CAR file built',
-    summary: `Built CAR file for IPFS Root CID: \`${ipfsRootCid}\``,
+    title: 'CAR file ready',
+    summary: `CAR file ready for IPFS Root CID: \`${ipfsRootCid}\``,
     text: carSize ? `CAR file size: ${formatSize(carSize)}` : undefined,
   })
 

--- a/upload-action/src/filecoin.js
+++ b/upload-action/src/filecoin.js
@@ -1,4 +1,5 @@
-import { promises as fs } from 'node:fs'
+import { createReadStream, promises as fs } from 'node:fs'
+import { CarReader } from '@ipld/car'
 import {
   calculateFilecoinPayFundingPlan,
   calculateStorageRunway,
@@ -44,6 +45,53 @@ export async function createCarFile(targetPath, contentPath, logger) {
     return { carPath, ipfsRootCid: rootCid, contentPath, carSize: size }
   } catch (error) {
     throw new Error(`Failed to create CAR file: ${getErrorMessage(error)}`)
+  }
+}
+
+/**
+ * Read a pre-built CAR file and extract its single root CID.
+ *
+ * Only the CAR header is parsed, so this is cheap even for large CARs.
+ * The CAR must declare exactly one root; multi-root and rootless CARs
+ * are rejected so the upload flow always has an unambiguous IPFS root CID.
+ *
+ * @param {string} targetPath - Absolute path to the CAR file
+ * @param {string} contentPath - Original input path for logging
+ * @param {Logger} logger - Logger instance
+ * @returns {Promise<BuildResult>} CAR file info
+ */
+export async function readCarFile(targetPath, contentPath, logger) {
+  try {
+    logger.info(`Using pre-built CAR at '${contentPath}' ...`)
+
+    const [{ size }, roots] = await Promise.all([fs.stat(targetPath), readCarRoots(targetPath)])
+
+    const [rootCid, ...extraRoots] = roots
+    if (!rootCid) {
+      throw new Error('CAR file declares no roots; a single-root CAR is required')
+    }
+    if (extraRoots.length > 0) {
+      throw new Error(`CAR file declares ${roots.length} roots; a single-root CAR is required`)
+    }
+
+    return { carPath: targetPath, ipfsRootCid: rootCid.toString(), contentPath, carSize: size }
+  } catch (error) {
+    throw new Error(`Failed to read CAR file: ${getErrorMessage(error)}`)
+  }
+}
+
+/**
+ * Stream-parse a CAR header and return its declared roots.
+ * @param {string} filePath
+ * @returns {Promise<CID[]>}
+ */
+async function readCarRoots(filePath) {
+  const stream = createReadStream(filePath)
+  try {
+    const reader = await CarReader.fromIterable(/** @type {any} */ (stream))
+    return await reader.getRoots()
+  } finally {
+    stream.destroy()
   }
 }
 


### PR DESCRIPTION
This PR enables github action composition with external CAR producers (e.g. [ipfs-deploy-action](https://github.com/ipfs/ipfs-deploy-action)) by treating a `path` that points to a regular `.car` file as a pre-built CAR: skip UnixFS packing, extract the root CID from the CAR header, and upload the file as-is.

Multi-root and rootless CARs are rejected so the upload always has an unambiguous IPFS root CID. Directories (even named `foo.car/`) fall through to the UnixFS packer as before.

Unblocks ipshipyard/ipfs-deploy-action#39.