### PR TITLE
fix(upload-action): repair pnpm caching broken by step ordering

### DIFF
--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -159,7 +159,7 @@ runs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Set up pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       with:
         run_install: false
         version: ${{ steps.pnpm-version.outputs.version }}

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -139,6 +139,7 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: '24.x'
+        package-manager-cache: false
 
     - name: Get pnpm version
       id: pnpm-version
@@ -147,7 +148,7 @@ runs:
       run: |
         VERSION=$(node -e "
           const pm = require('./package.json').packageManager;
-          if (typeof pm !== 'string') { console.error('package.json: packageManager field missing'); process.exit(1); }
+          if (typeof pm !== 'string') { console.error('package.json: packageManager field missing or not a string'); process.exit(1); }
           const match = pm.match(/^pnpm@(.+)$/);
           if (!match) { console.error('package.json: packageManager must be pnpm@<version>, got: ' + pm); process.exit(1); }
           process.stdout.write(match[1]);
@@ -163,9 +164,10 @@ runs:
     - name: Get pnpm store path
       id: pnpm-store
       shell: bash
+      working-directory: ${{ steps.repo-root.outputs.path }}
       run: |
         STORE_PATH=$(pnpm store path --silent)
-        echo "path=$STORE_PATH" >> $GITHUB_OUTPUT
+        printf 'path=%s\n' "$STORE_PATH" >> "$GITHUB_OUTPUT"
 
     - name: Compute pnpm-lock.yaml hash
       id: lockfile

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -135,18 +135,23 @@ runs:
         echo "path=$REPO_ROOT" >> $GITHUB_OUTPUT
 
     - name: Set up Node.js
+      id: setup-node
       uses: actions/setup-node@v6
       with:
         node-version: '24.x'
-        cache: pnpm
-        cache-dependency-path: ${{ steps.repo-root.outputs.path }}/pnpm-lock.yaml
 
     - name: Get pnpm version
       id: pnpm-version
       shell: bash
       working-directory: ${{ steps.repo-root.outputs.path }}
       run: |
-        VERSION=$(node -pe "require('./package.json').packageManager.split('@')[1]")
+        VERSION=$(node -e "
+          const pm = require('./package.json').packageManager;
+          if (typeof pm !== 'string') { console.error('package.json: packageManager field missing'); process.exit(1); }
+          const match = pm.match(/^pnpm@(.+)$/);
+          if (!match) { console.error('package.json: packageManager must be pnpm@<version>, got: ' + pm); process.exit(1); }
+          process.stdout.write(match[1]);
+        ")
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Set up pnpm
@@ -154,6 +159,34 @@ runs:
       with:
         run_install: false
         version: ${{ steps.pnpm-version.outputs.version }}
+
+    - name: Get pnpm store path
+      id: pnpm-store
+      shell: bash
+      run: |
+        STORE_PATH=$(pnpm store path --silent)
+        echo "path=$STORE_PATH" >> $GITHUB_OUTPUT
+
+    - name: Compute pnpm-lock.yaml hash
+      id: lockfile
+      shell: bash
+      working-directory: ${{ steps.repo-root.outputs.path }}
+      run: |
+        SHA=$(node -e "
+          const crypto = require('crypto');
+          const fs = require('fs');
+          const buf = fs.readFileSync('pnpm-lock.yaml');
+          process.stdout.write(crypto.createHash('sha256').update(buf).digest('hex'));
+        ")
+        echo "sha256=$SHA" >> $GITHUB_OUTPUT
+
+    - name: Cache pnpm store
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: filecoin-pin-upload-action-pnpm-store-${{ runner.os }}-${{ runner.arch }}-node-${{ steps.setup-node.outputs.node-version }}-pnpm-${{ steps.pnpm-version.outputs.version }}-${{ steps.lockfile.outputs.sha256 }}
+        restore-keys: |
+          filecoin-pin-upload-action-pnpm-store-${{ runner.os }}-${{ runner.arch }}-node-${{ steps.setup-node.outputs.node-version }}-pnpm-${{ steps.pnpm-version.outputs.version }}-
 
     - name: Install workspace dependencies
       shell: bash

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -139,6 +139,9 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: '24.x'
+        # Disable implicit npm cache: setup-node@v6 auto-caches against
+        # the consumer's package.json/package-lock when their packageManager
+        # field is "npm". We manage our own pnpm cache below.
         package-manager-cache: false
 
     - name: Get pnpm version


### PR DESCRIPTION
Fixes #411.

## Problem

`upload-action` is broken on `master` and `v0.20.0`:

1. **`pnpm not found`** — `actions/setup-node@v6` was called with `cache: pnpm` *before* `pnpm/action-setup@v4`. setup-node invokes `pnpm store path --silent` to resolve its cache directory; pnpm wasn't on PATH yet.
2. **`Some specified paths were not resolved`** — `cache-dependency-path` pointed at `${repo-root}/pnpm-lock.yaml`, which lives at the action's checkout (`${{ github.action_path }}/..`) — outside `GITHUB_WORKSPACE`. `hashFiles()` only globs inside the workspace, so the cache key could never be built.

Introduced by #370 (switch to pnpm), partially addressed by #393.

## Fix

- Drop `cache: pnpm` and `cache-dependency-path` from `setup-node`. Those two inputs are the entire source of both failures.
- Replace with an explicit `actions/cache@v4` step run *after* `pnpm/action-setup@v4`, so pnpm is on PATH when we resolve the store path.
- Compute the lockfile hash with `node` (`crypto.createHash('sha256')`) instead of relying on `hashFiles()` or `sha256sum`. `node` reads any absolute path and is portable across linux/macOS/Windows runners.
- Harden the `packageManager` parser to fail loudly if the field is missing or not `pnpm@<version>`.

## Why this approach

- **Caching preserved.** `setup-node`'s built-in `cache: pnpm` is itself a thin wrapper over `actions/cache` that caches only the pnpm store (never `node_modules`). Doing it explicitly gives equivalent behavior — including save-on-job-success semantics — without setup-node's workspace assumptions.
- **Cache key namespaced and scoped tightly.** Key includes runner os + arch + Node version + pnpm version + lockfile sha256, prefixed with `filecoin-pin-upload-action-` to avoid collisions with the consumer repo's own pnpm caches. Node major can affect native deps and optional resolution, so it's part of the key.
- **No mutation of the consumer workspace.** Symlinking the lockfile into `GITHUB_WORKSPACE` to satisfy `hashFiles()` would be a leaky implementation detail for a public composite action; explicit cache avoids that.
- **Cross-platform.** Hashing via `node` works on every runner that already has Node — which we install one step earlier.

## Step order (final)

1. Get action path / repo root.
2. `actions/setup-node@v6` (Node only — no pnpm cache inputs).
3. Read + validate `packageManager` from `package.json`.
4. `pnpm/action-setup@v4`.
5. Get pnpm store path.
6. Compute lockfile sha256 via `node`.
7. `actions/cache@v4` for the pnpm store.
8. `pnpm install --frozen-lockfile`, `pnpm run build`.

## Test plan

- [x] Trigger consumer workflow at filecoin-project/filecoin-pin-website with `@fix/upload-action-pnpm-cache` and verify upload succeeds.
- [x] Verify cache hit on second run (lockfile unchanged).
- [x] Verify cache miss + new save on lockfile change.
- [x] Confirm the action still works when `packageManager` is set to a pnpm version with hash suffix (e.g. `pnpm@9.0.0+sha512.xxx`).

## Follow-up (out of scope, suggested for v0.21+)

Ship a pre-built `dist/` so consumers don't run `pnpm install && pnpm build` at action invocation time. Eliminates the entire class of pnpm-on-PATH issues for consumers and removes the cache concern altogether.