### PR TITLE
feat: support stream uploads to Synapse

### DIFF
--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -10,7 +10,13 @@ import type { CID } from 'multiformats/cid'
 import pc from 'picocolors'
 import type { Logger } from 'pino'
 import { DEFAULT_LOCKUP_DAYS, type PaymentCapacityCheck } from '../core/payments/index.js'
-import { checkUploadReadiness, executeUpload, getNetworkSlug, type SynapseUploadResult } from '../core/upload/index.js'
+import {
+  checkUploadReadiness,
+  executeUpload,
+  getNetworkSlug,
+  type SynapseUploadData,
+  type SynapseUploadResult,
+} from '../core/upload/index.js'
 import { formatUSDFC } from '../core/utils/format.js'
 import { autoFund } from '../payments/fund.js'
 import type { AutoFundOptions } from '../payments/types.js'
@@ -278,14 +284,14 @@ function roleLabel(role: CopyRole): string {
  * Upload CAR data to Synapse with multi-copy progress tracking
  *
  * @param synapse - Initialized Synapse instance
- * @param carData - CAR file data as Uint8Array
+ * @param carData - CAR file data as bytes or a readable stream
  * @param rootCid - Root CID of the content
  * @param options - Upload flow options
  * @returns Upload result with copies and network information
  */
 export async function performUpload(
   synapse: Synapse,
-  carData: Uint8Array,
+  carData: SynapseUploadData,
   rootCid: CID,
   options: UploadFlowOptions
 ): Promise<UploadFlowResult> {

--- a/src/core/payments/README.md
+++ b/src/core/payments/README.md
@@ -69,10 +69,12 @@ const synapseService = await setupSynapse(config, logger, {
 ### Upload CAR File
 
 ```typescript
+import { createReadStream } from 'node:fs'
+import { Readable } from 'node:stream'
 import { uploadToSynapse } from 'filecoin-pin/core/upload'
 import { CID } from 'multiformats/cid'
 
-const carData = await fs.readFile('path/to/file.car')
+const carData = Readable.toWeb(createReadStream('path/to/file.car')) as ReadableStream<Uint8Array>
 const rootCid = CID.parse('bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi')
 
 const result = await uploadToSynapse(
@@ -81,16 +83,15 @@ const result = await uploadToSynapse(
   rootCid,
   logger,
   {
-    callbacks: {
-      onUploadComplete: (pieceCid) => {
-        console.log(`Upload complete: ${pieceCid}`)
+    onProgress: (event) => {
+      if (event.type === 'onStored') {
+        console.log(`Stored on provider ${event.data.providerId}: ${event.data.pieceCid}`)
       }
     }
   }
 )
 
 console.log(`Piece CID: ${result.pieceCid}`)
-console.log(`Download URL: ${result.providerInfo?.downloadURL}`)
 ```
 
 ### Setup Payments

--- a/src/core/payments/README.md
+++ b/src/core/payments/README.md
@@ -92,6 +92,7 @@ const result = await uploadToSynapse(
 )
 
 console.log(`Piece CID: ${result.pieceCid}`)
+console.log(`Retrieval URL: ${result.copies[0]?.retrievalUrl}`)
 ```
 
 ### Setup Payments

--- a/src/core/payments/README.md
+++ b/src/core/payments/README.md
@@ -74,7 +74,7 @@ import { Readable } from 'node:stream'
 import { uploadToSynapse } from 'filecoin-pin/core/upload'
 import { CID } from 'multiformats/cid'
 
-const carData = Readable.toWeb(createReadStream('path/to/file.car')) as ReadableStream<Uint8Array>
+const carData = Readable.toWeb(createReadStream('path/to/file.car'))
 const rootCid = CID.parse('bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi')
 
 const result = await uploadToSynapse(

--- a/src/core/upload/index.ts
+++ b/src/core/upload/index.ts
@@ -20,9 +20,14 @@ import {
   type WaitForIpniProviderResultsOptions,
   waitForIpniProviderResults,
 } from '../utils/validate-ipni-advertisement.js'
-import { type SynapseUploadResult, type UploadProgressEvents, uploadToSynapse } from './synapse.js'
+import {
+  type SynapseUploadData,
+  type SynapseUploadResult,
+  type UploadProgressEvents,
+  uploadToSynapse,
+} from './synapse.js'
 
-export type { SynapseUploadOptions, SynapseUploadResult, UploadProgressEvents } from './synapse.js'
+export type { SynapseUploadData, SynapseUploadOptions, SynapseUploadResult, UploadProgressEvents } from './synapse.js'
 export { getDownloadURL, getServiceURL, uploadToSynapse } from './synapse.js'
 
 /**
@@ -290,7 +295,7 @@ export interface UploadExecutionResult extends SynapseUploadResult {
  */
 export async function executeUpload(
   synapse: Synapse,
-  carData: Uint8Array,
+  carData: SynapseUploadData,
   rootCid: CID,
   options: UploadExecutionOptions
 ): Promise<UploadExecutionResult> {

--- a/src/core/upload/synapse.ts
+++ b/src/core/upload/synapse.ts
@@ -24,6 +24,8 @@ export type UploadProgressEvents =
   | ProgressEvent<'onProviderSelected', { provider: PDPProvider }>
   | ProgressEvent<'onDataSetResolved', { dataSetId: bigint; provider: PDPProvider }>
 
+export type SynapseUploadData = Uint8Array | ReadableStream<Uint8Array>
+
 export interface SynapseUploadOptions {
   /**
    * Optional callbacks for monitoring upload progress
@@ -130,7 +132,7 @@ export function getServiceURL(providerInfo: PDPProvider): string {
  * copies.
  *
  * @param synapse - Initialized Synapse instance
- * @param carData - CAR data as Uint8Array
+ * @param carData - CAR data as bytes or a readable stream
  * @param rootCid - The IPFS root CID to associate with this piece
  * @param logger - Logger instance for tracking
  * @param options - Upload options including context selection and callbacks
@@ -138,7 +140,7 @@ export function getServiceURL(providerInfo: PDPProvider): string {
  */
 export async function uploadToSynapse(
   synapse: Synapse,
-  carData: Uint8Array,
+  carData: SynapseUploadData,
   rootCid: CID,
   logger: Logger,
   options: SynapseUploadOptions = {}

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -6,7 +6,8 @@
  */
 
 import { createReadStream } from 'node:fs'
-import { readFile, stat } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
+import { Readable } from 'node:stream'
 import { CarReader } from '@ipld/car'
 import { CID } from 'multiformats/cid'
 import pc from 'picocolors'
@@ -208,10 +209,10 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
       await validatePaymentSetup(synapse, fileStat.size, spinner)
     }
 
-    // Read CAR file and upload to Synapse
+    // Stream CAR file and upload to Synapse
     spinner.start('Uploading to Filecoin...')
 
-    const carData = await readFile(options.filePath)
+    const carData = Readable.toWeb(createReadStream(options.filePath)) as ReadableStream<Uint8Array>
 
     // Auto-skip IPNI on devnet (no IPNI infrastructure available)
     const skipIpniVerification = options.skipIpniVerification || synapse.chain.id === DEVNET_CHAIN_ID

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -209,7 +209,7 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
       await validatePaymentSetup(synapse, fileStat.size, spinner)
     }
 
-    // Stream CAR file and upload to Synapse
+    // Stream CAR file to Synapse
     spinner.start('Uploading to Filecoin...')
 
     const carData = Readable.toWeb(createReadStream(options.filePath)) as ReadableStream<Uint8Array>

--- a/src/index-types.ts
+++ b/src/index-types.ts
@@ -39,6 +39,7 @@ export type {
 } from './core/synapse/index.js'
 export type { Spinner } from './core/unixfs/car-builder.js'
 export type {
+  SynapseUploadData,
   SynapseUploadOptions,
   SynapseUploadResult,
   UploadExecutionOptions,

--- a/src/test/mocks/synapse-mocks.ts
+++ b/src/test/mocks/synapse-mocks.ts
@@ -47,7 +47,7 @@ export class MockStorageContext extends EventEmitter {
   public readonly provider = mockPDPProvider
   public readonly serviceProvider = mockPDPProvider.serviceProvider
 
-  async upload(_data: ArrayBuffer | Uint8Array, options?: any): Promise<any> {
+  async upload(_data: Uint8Array | ReadableStream<Uint8Array>, options?: any): Promise<any> {
     // Check if already aborted
     options?.signal?.throwIfAborted()
 

--- a/src/test/mocks/synapse-mocks.ts
+++ b/src/test/mocks/synapse-mocks.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events'
 import type { PDPProvider } from '@filoz/synapse-sdk'
+import type { SynapseUploadData } from '../../core/upload/index.js'
 
 /**
  * Test utilities for mocking Synapse SDK components
@@ -47,7 +48,7 @@ export class MockStorageContext extends EventEmitter {
   public readonly provider = mockPDPProvider
   public readonly serviceProvider = mockPDPProvider.serviceProvider
 
-  async upload(_data: Uint8Array | ReadableStream<Uint8Array>, options?: any): Promise<any> {
+  async upload(_data: SynapseUploadData, options?: any): Promise<any> {
     // Check if already aborted
     options?.signal?.throwIfAborted()
 

--- a/src/test/unit/import.test.ts
+++ b/src/test/unit/import.test.ts
@@ -13,6 +13,7 @@ import { createWriteStream } from 'node:fs'
 import { mkdir, rm, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
+import { ReadableStream } from 'node:stream/web'
 import { CarWriter } from '@ipld/car'
 import { CID } from 'multiformats/cid'
 import * as raw from 'multiformats/codecs/raw'
@@ -395,7 +396,7 @@ describe('CAR Import', () => {
       const { performUpload } = await import('../../common/upload-flow.js')
       expect(vi.mocked(performUpload)).toHaveBeenCalledWith(
         expect.any(Object),
-        expect.any(Uint8Array),
+        expect.any(ReadableStream),
         expect.any(Object),
         expect.objectContaining({
           pieceMetadata: { ics: '8004' },

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -216,6 +216,22 @@ describe('synapse-service', () => {
         })
       )
     })
+
+    it('should pass ReadableStream data directly to storage.upload', async () => {
+      const data = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]))
+          controller.close()
+        },
+      })
+      const uploadSpy = vi.spyOn(mockSynapse.storage, 'upload')
+
+      await uploadToSynapse(mockSynapse as any, data, TEST_CID, logger, {
+        contextId: 'pin-stream',
+      })
+
+      expect(uploadSpy).toHaveBeenCalledWith(data, expect.anything())
+    })
   })
 
   describe('Multi-copy Results', () => {

--- a/src/test/unit/upload-validation.test.ts
+++ b/src/test/unit/upload-validation.test.ts
@@ -157,6 +157,23 @@ describe('upload option validation', () => {
       expect(passedOptions?.providerIds).toEqual([1n])
       expect(passedOptions?.copies).toBe(3)
     })
+
+    it('forwards ReadableStream data through executeUpload', async () => {
+      const uploadSpy = vi.spyOn(mockSynapse.storage, 'upload')
+      const data = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1]))
+          controller.close()
+        },
+      })
+
+      await executeUpload(mockSynapse as any, data, TEST_CID, {
+        logger,
+        ipniValidation: { enabled: false },
+      })
+
+      expect(uploadSpy).toHaveBeenCalledWith(data, expect.anything())
+    })
   })
 
   describe('source metadata resolution', () => {


### PR DESCRIPTION
## Summary

  addresses part of #325.

  Adds `ReadableStream<Uint8Array>` support to the shared Synapse upload helpers so callers with pre-generated CAR files can stream upload data without first loading the whole CAR into memory.

  ## Changes

  - Add `SynapseUploadData = Uint8Array | ReadableStream<Uint8Array>`
  - Update `uploadToSynapse()` and `executeUpload()` to accept `SynapseUploadData`
  - Pass upload data directly through to `synapse.storage.upload()` without buffering
  - Export the new upload data type from the public upload/type surface
  - Add unit coverage proving stream objects are forwarded unchanged
  - Update the CAR upload example to show streaming from disk with `Readable.toWeb(createReadStream(...))`

  ## Notes

  This intentionally does not implement true CAR creation streaming from #288, and it does not add byte-level progress callbacks from #326. This PR only covers uploading an already-created CAR as a stream. Will create separet PR for #326

  ## Testing

  ```bash
  pnpm run typecheck
  pnpm exec vitest run --project unit src/test/unit/synapse-service.test.ts src/test/unit/upload-validation.test.ts
  pnpm test

  Full pnpm test passed locally:

  - 37 test files passed
  - 372 tests passed
  - 11 skipped