### PR TITLE
feat(cli): add --min-runway-days and --max-balance to --auto-fund

### DIFF
--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -161,7 +161,10 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
     spinner.stop(`${pc.green('✓')} IPFS content loaded (${formatFileSize(carSize)})`)
 
     if (options.autoFund) {
-      await performAutoFunding(synapse, carSize, spinner)
+      await performAutoFunding(synapse, carSize, spinner, {
+        ...(options.minRunwayDays !== undefined && { minRunwayDays: options.minRunwayDays }),
+        ...(options.maxBalance !== undefined && { maxBalance: options.maxBalance }),
+      })
     } else {
       spinner.start('Checking payment capacity...')
       await validatePaymentSetup(synapse, carSize, spinner)

--- a/src/add/types.ts
+++ b/src/add/types.ts
@@ -4,8 +4,12 @@ import type { CLIAuthOptions } from '../utils/cli-auth.js'
 export interface AddOptions extends CLIAuthOptions {
   filePath: string
   bare?: boolean
-  /** Auto-fund: automatically ensure minimum 30 days of runway */
+  /** Auto-fund: automatically ensure minimum runway (default 30 days) before upload */
   autoFund?: boolean
+  /** Override the minimum runway (in days) targeted by auto-fund */
+  minRunwayDays?: number
+  /** Cap on Filecoin Pay balance after deposit, in USDFC base units */
+  maxBalance?: bigint
   /** Number of storage copies to create */
   copies?: number
   /** Piece metadata attached to each upload */

--- a/src/add/types.ts
+++ b/src/add/types.ts
@@ -1,15 +1,10 @@
 import type { CopyResult, FailedAttempt } from '@filoz/synapse-sdk'
 import type { CLIAuthOptions } from '../utils/cli-auth.js'
+import type { CLIAutoFundOptions } from '../utils/cli-options.js'
 
-export interface AddOptions extends CLIAuthOptions {
+export interface AddOptions extends CLIAuthOptions, CLIAutoFundOptions {
   filePath: string
   bare?: boolean
-  /** Auto-fund: automatically ensure minimum runway (default 30 days) before upload */
-  autoFund?: boolean
-  /** Override the minimum runway (in days) targeted by auto-fund */
-  minRunwayDays?: number
-  /** Cap on Filecoin Pay balance after deposit, in USDFC base units */
-  maxBalance?: bigint
   /** Number of storage copies to create */
   copies?: number
   /** Piece metadata attached to each upload */

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,18 +1,30 @@
 import { Command } from 'commander'
 import { runAdd } from '../add/add.js'
 import type { AddOptions } from '../add/types.js'
-import { MIN_RUNWAY_DAYS } from '../common/constants.js'
-import { addAuthOptions, addContextSelectionOptions, addUploadOptions } from '../utils/cli-options.js'
+import {
+  addAuthOptions,
+  addAutoFundOptions,
+  addContextSelectionOptions,
+  addUploadOptions,
+  validateAndNormalizeAutoFundOptions,
+} from '../utils/cli-options.js'
 import { addMetadataOptions, resolveMetadataOptions } from '../utils/cli-options-metadata.js'
 
 export const addCommand = new Command('add')
   .description('Add a file or directory to Filecoin via Synapse (creates UnixFS CAR)')
   .argument('<path>', 'Path to the file or directory to add')
   .option('--bare', 'Add file without directory wrapper (files only, not supported for directories)')
-  .option('--auto-fund', `Automatically ensure minimum ${MIN_RUNWAY_DAYS} days of runway before upload`)
   .option('--copies <n>', 'Number of storage copies to create (default: 2)', Number.parseInt)
 
 addCommand.action(async (path: string, options: any) => {
+  let autoFundOptions: ReturnType<typeof validateAndNormalizeAutoFundOptions>
+  try {
+    autoFundOptions = validateAndNormalizeAutoFundOptions(options)
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+
   try {
     const {
       metadata: _metadata,
@@ -20,12 +32,16 @@ addCommand.action(async (path: string, options: any) => {
       datasetMetadata: _datasetMetadata,
       '8004Type': _erc8004Type,
       '8004Agent': _erc8004Agent,
+      autoFund: _autoFund,
+      minRunwayDays: _minRunwayDays,
+      maxBalance: _maxBalance,
       ...addOptionsFromCli
     } = options
     const { pieceMetadata, dataSetMetadata } = resolveMetadataOptions(options, { includeErc8004: true })
 
     const addOptions: AddOptions = {
       ...addOptionsFromCli,
+      ...autoFundOptions,
       filePath: path,
       ...(pieceMetadata && { pieceMetadata }),
       ...(dataSetMetadata && { dataSetMetadata }),
@@ -40,4 +56,5 @@ addCommand.action(async (path: string, options: any) => {
 addAuthOptions(addCommand)
 addContextSelectionOptions(addCommand)
 addUploadOptions(addCommand)
+addAutoFundOptions(addCommand)
 addMetadataOptions(addCommand, { includePieceMetadata: true, includeDataSetMetadata: true, includeErc8004: true })

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,16 +1,28 @@
 import { Command } from 'commander'
-import { MIN_RUNWAY_DAYS } from '../common/constants.js'
 import { runCarImport } from '../import/import.js'
 import type { ImportOptions } from '../import/types.js'
-import { addAuthOptions, addContextSelectionOptions, addUploadOptions } from '../utils/cli-options.js'
+import {
+  addAuthOptions,
+  addAutoFundOptions,
+  addContextSelectionOptions,
+  addUploadOptions,
+  validateAndNormalizeAutoFundOptions,
+} from '../utils/cli-options.js'
 import { addMetadataOptions, resolveMetadataOptions } from '../utils/cli-options-metadata.js'
 
 export const importCommand = new Command('import')
   .description('Import an existing CAR file to Filecoin via Synapse')
   .argument('<file>', 'Path to the CAR file to import')
-  .option('--auto-fund', `Automatically ensure minimum ${MIN_RUNWAY_DAYS} days of runway before upload`)
   .option('--copies <n>', 'Number of storage copies to create (default: 2)', Number.parseInt)
   .action(async (file: string, options) => {
+    let autoFundOptions: ReturnType<typeof validateAndNormalizeAutoFundOptions>
+    try {
+      autoFundOptions = validateAndNormalizeAutoFundOptions(options)
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`)
+      process.exit(1)
+    }
+
     try {
       const {
         metadata: _metadata,
@@ -18,12 +30,16 @@ export const importCommand = new Command('import')
         datasetMetadata: _datasetMetadata,
         '8004Type': _erc8004Type,
         '8004Agent': _erc8004Agent,
+        autoFund: _autoFund,
+        minRunwayDays: _minRunwayDays,
+        maxBalance: _maxBalance,
         ...importOptionsFromCli
       } = options
 
       const { pieceMetadata, dataSetMetadata } = resolveMetadataOptions(options, { includeErc8004: true })
       const importOptions: ImportOptions = {
         ...importOptionsFromCli,
+        ...autoFundOptions,
         filePath: file,
         ...(pieceMetadata && { pieceMetadata }),
         ...(dataSetMetadata && { dataSetMetadata }),
@@ -38,4 +54,5 @@ export const importCommand = new Command('import')
 addAuthOptions(importCommand)
 addContextSelectionOptions(importCommand)
 addUploadOptions(importCommand)
+addAutoFundOptions(importCommand)
 addMetadataOptions(importCommand, { includePieceMetadata: true, includeDataSetMetadata: true, includeErc8004: true })

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -116,9 +116,12 @@ export async function performAutoFunding(
       fundOptions.maxBalance = options.maxBalance
     }
     const result = await autoFund(fundOptions)
-    spinner?.stop(`${pc.green('✓')} Funding requirements met`)
+    const hasWarnings = result.warnings != null && result.warnings.length > 0
+    spinner?.stop(
+      hasWarnings ? `${pc.yellow('⚠')} Funding completed with warnings` : `${pc.green('✓')} Funding requirements met`
+    )
 
-    if (result.warnings != null && result.warnings.length > 0) {
+    if (hasWarnings && result.warnings != null) {
       for (const warning of result.warnings) {
         log.line(pc.yellow(`⚠ ${warning}`))
       }

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -83,13 +83,22 @@ export interface UploadFlowResult extends SynapseUploadResult {
 
 /**
  * Perform auto-funding if requested
- * Automatically ensures a minimum of 30 days of runway based on current usage + new file requirements
+ * Automatically ensures the configured minimum runway (default MIN_RUNWAY_DAYS) based on current
+ * usage + new file requirements. Optional `maxBalance` caps the resulting Filecoin Pay balance.
  *
  * @param synapse - Initialized Synapse instance
  * @param fileSize - Size of file being uploaded (in bytes)
  * @param spinner - Optional spinner for progress
+ * @param options - Optional auto-funding modifiers
+ * @param options.minRunwayDays - Minimum runway to maintain, in days (defaults to MIN_RUNWAY_DAYS)
+ * @param options.maxBalance - Maximum Filecoin Pay balance after deposit (USDFC base units)
  */
-export async function performAutoFunding(synapse: Synapse, fileSize: number, spinner?: Spinner): Promise<void> {
+export async function performAutoFunding(
+  synapse: Synapse,
+  fileSize: number,
+  spinner?: Spinner,
+  options: { minRunwayDays?: number; maxBalance?: bigint } = {}
+): Promise<void> {
   spinner?.start('Checking funding requirements for upload...')
 
   try {
@@ -100,11 +109,23 @@ export async function performAutoFunding(synapse: Synapse, fileSize: number, spi
     if (spinner !== undefined) {
       fundOptions.spinner = spinner
     }
+    if (options.minRunwayDays !== undefined) {
+      fundOptions.minRunwayDays = options.minRunwayDays
+    }
+    if (options.maxBalance !== undefined) {
+      fundOptions.maxBalance = options.maxBalance
+    }
     const result = await autoFund(fundOptions)
     spinner?.stop(`${pc.green('✓')} Funding requirements met`)
 
+    if (result.warnings != null && result.warnings.length > 0) {
+      for (const warning of result.warnings) {
+        log.line(pc.yellow(`⚠ ${warning}`))
+      }
+      log.flush()
+    }
+
     if (result.adjusted) {
-      log.line('')
       log.line(pc.bold('Auto-funding completed:'))
       log.indent(`Deposited ${formatUSDFC(result.delta)} USDFC`)
       log.indent(`Total deposited: ${formatUSDFC(result.newDepositedAmount)} USDFC`)
@@ -114,7 +135,6 @@ export async function performAutoFunding(synapse: Synapse, fileSize: number, spi
       if (result.transactionHash) {
         log.indent(pc.gray(`Transaction: ${result.transactionHash}`))
       }
-      log.line('')
       log.flush()
     }
   } catch (error) {

--- a/src/core/payments/top-up.ts
+++ b/src/core/payments/top-up.ts
@@ -5,6 +5,48 @@ import { depositUSDFC, getPaymentStatus } from './index.js'
 import type { TopUpResult } from './types.js'
 
 /**
+ * Result of clamping a requested deposit against a balance limit.
+ *
+ * - `passthrough`: limit is undefined or unreached; deposit equals requested
+ * - `already-at-limit`: current balance already meets/exceeds limit; deposit is 0n
+ * - `clamped`: deposit was reduced to the largest amount that doesn't exceed limit
+ */
+export interface ClampDepositResult {
+  deposit: bigint
+  reason: 'passthrough' | 'already-at-limit' | 'clamped'
+  message?: string
+}
+
+/**
+ * Pure helper: clamp a requested deposit so the resulting balance does not exceed `limit`.
+ *
+ * @param currentBalance - Current Filecoin Pay balance
+ * @param requested - Requested deposit amount (must be > 0n for clamping to apply)
+ * @param limit - Maximum allowed post-deposit balance; undefined means no limit
+ */
+export function clampDepositToLimit(currentBalance: bigint, requested: bigint, limit?: bigint): ClampDepositResult {
+  if (limit == null || limit < 0n || requested <= 0n) {
+    return { deposit: requested, reason: 'passthrough' }
+  }
+  if (currentBalance >= limit) {
+    return {
+      deposit: 0n,
+      reason: 'already-at-limit',
+      message: `Current balance (${formatUSDFC(currentBalance)}) already equals or exceeds the configured balance limit (${formatUSDFC(limit)}). No additional deposits will be made.`,
+    }
+  }
+  if (currentBalance + requested > limit) {
+    const maxAllowed = limit - currentBalance
+    return {
+      deposit: maxAllowed,
+      reason: 'clamped',
+      message: `Required top-up (${formatUSDFC(requested)}) would exceed the configured balance limit (${formatUSDFC(limit)}). Reducing to ${formatUSDFC(maxAllowed)}.`,
+    }
+  }
+  return { deposit: requested, reason: 'passthrough' }
+}
+
+/**
  * Execute a top-up operation with balance limit checking
  *
  * This function handles the complete top-up process including:
@@ -41,40 +83,16 @@ export async function executeTopUp(
   // Get current status for limit checking
   const currentStatus = await getPaymentStatus(synapse)
 
-  // Check if deposit would exceed maximum balance if specified
-  if (balanceLimit != null && balanceLimit >= 0n) {
-    // Check if current balance already equals or exceeds limit
-    if (currentStatus.filecoinPayBalance >= balanceLimit) {
-      const message = `Current balance (${formatUSDFC(currentStatus.filecoinPayBalance)}) already equals or exceeds the configured balance limit (${formatUSDFC(balanceLimit)}). No additional deposits will be made.`
-      logger?.warn(`${message}`)
-      return {
-        success: true,
-        deposited: 0n,
-        message,
-        warnings,
-      }
-    } else {
-      // Check if required top-up would exceed the limit
-      const projectedBalance = currentStatus.filecoinPayBalance + topUpAmount
-      if (projectedBalance > balanceLimit) {
-        // Calculate the maximum allowed top-up that won't exceed the limit
-        const maxAllowedTopUp = balanceLimit - currentStatus.filecoinPayBalance
-        if (maxAllowedTopUp > 0n) {
-          const warning = `Required top-up (${formatUSDFC(topUpAmount)}) would exceed the configured balance limit (${formatUSDFC(balanceLimit)}). Reducing to ${formatUSDFC(maxAllowedTopUp)}.`
-          logger?.warn(`${warning}`)
-          warnings.push(warning)
-          topUpAmount = maxAllowedTopUp
-        } else {
-          return {
-            success: true,
-            deposited: 0n,
-            message: 'Cannot deposit - would exceed balance limit',
-            warnings,
-          }
-        }
-      }
-    }
+  const clamp = clampDepositToLimit(currentStatus.filecoinPayBalance, topUpAmount, balanceLimit)
+  if (clamp.reason === 'already-at-limit') {
+    logger?.warn(clamp.message)
+    return { success: true, deposited: 0n, message: clamp.message ?? '', warnings }
   }
+  if (clamp.reason === 'clamped' && clamp.message != null) {
+    logger?.warn(clamp.message)
+    warnings.push(clamp.message)
+  }
+  topUpAmount = clamp.deposit
 
   // Ensure wallet has sufficient USDFC for the deposit
   if (currentStatus.walletUsdfcBalance < topUpAmount) {

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -202,7 +202,10 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
     spinner.stop(`${pc.green('✓')} Connected to ${pc.bold(network)}`)
 
     if (options.autoFund) {
-      await performAutoFunding(synapse, fileStat.size, spinner)
+      await performAutoFunding(synapse, fileStat.size, spinner, {
+        ...(options.minRunwayDays !== undefined && { minRunwayDays: options.minRunwayDays }),
+        ...(options.maxBalance !== undefined && { maxBalance: options.maxBalance }),
+      })
     } else {
       spinner.start('Checking payment capacity...')
       await validatePaymentSetup(synapse, fileStat.size, spinner)

--- a/src/import/types.ts
+++ b/src/import/types.ts
@@ -3,8 +3,12 @@ import type { CLIAuthOptions } from '../utils/cli-auth.js'
 
 export interface ImportOptions extends CLIAuthOptions {
   filePath: string
-  /** Auto-fund: automatically ensure minimum 30 days of runway */
+  /** Auto-fund: automatically ensure minimum runway (default 30 days) before upload */
   autoFund?: boolean
+  /** Override the minimum runway (in days) targeted by auto-fund */
+  minRunwayDays?: number
+  /** Cap on Filecoin Pay balance after deposit, in USDFC base units */
+  maxBalance?: bigint
   /** Number of storage copies to create */
   copies?: number
   /** Piece metadata attached to the imported CAR */

--- a/src/import/types.ts
+++ b/src/import/types.ts
@@ -1,14 +1,9 @@
 import type { CopyResult, FailedAttempt } from '@filoz/synapse-sdk'
 import type { CLIAuthOptions } from '../utils/cli-auth.js'
+import type { CLIAutoFundOptions } from '../utils/cli-options.js'
 
-export interface ImportOptions extends CLIAuthOptions {
+export interface ImportOptions extends CLIAuthOptions, CLIAutoFundOptions {
   filePath: string
-  /** Auto-fund: automatically ensure minimum runway (default 30 days) before upload */
-  autoFund?: boolean
-  /** Override the minimum runway (in days) targeted by auto-fund */
-  minRunwayDays?: number
-  /** Cap on Filecoin Pay balance after deposit, in USDFC base units */
-  maxBalance?: bigint
   /** Number of storage copies to create */
   copies?: number
   /** Piece metadata attached to the imported CAR */

--- a/src/payments/fund.ts
+++ b/src/payments/fund.ts
@@ -191,7 +191,10 @@ export async function autoFund(options: AutoFundOptions): Promise<FundingAdjustm
     )
   }
 
-  const depositMsg = `Depositing ${formatUSDFC(adjustedPlan.delta)} USDFC to ensure at least ${targetRunwayDays} day(s) runway...`
+  const depositMsg =
+    clamp.reason === 'clamped'
+      ? `Depositing ${formatUSDFC(adjustedPlan.delta)} USDFC toward ${targetRunwayDays} day(s) runway (limited by --max-balance)...`
+      : `Depositing ${formatUSDFC(adjustedPlan.delta)} USDFC to ensure at least ${targetRunwayDays} day(s) runway...`
   spinner?.message(depositMsg)
   const execution = await executeFilecoinPayFunding(synapse, adjustedPlan)
   spinner?.message(`${pc.green('✓')} Deposit complete`)

--- a/src/payments/fund.ts
+++ b/src/payments/fund.ts
@@ -12,6 +12,7 @@ import { MIN_RUNWAY_DAYS } from '../common/constants.js'
 import {
   calculateStorageRunway,
   checkUSDFCBalance,
+  clampDepositToLimit,
   DEFAULT_LOCKUP_DAYS,
   depositUSDFC,
   executeFilecoinPayFunding,
@@ -134,13 +135,14 @@ async function printSummary(synapse: Synapse, title = 'Updated'): Promise<void> 
  * @throws Error if adjustment fails or target is unsafe
  */
 export async function autoFund(options: AutoFundOptions): Promise<FundingAdjustmentResult> {
-  const { synapse, fileSize, spinner } = options
+  const { synapse, fileSize, spinner, maxBalance } = options
+  const targetRunwayDays = options.minRunwayDays ?? MIN_RUNWAY_DAYS
 
   spinner?.message('Checking wallet readiness...')
 
   const planResult = await planFilecoinPayFunding({
     synapse,
-    targetRunwayDays: MIN_RUNWAY_DAYS,
+    targetRunwayDays,
     pieceSizeBytes: fileSize,
     ensureAllowances: true,
     allowWithdraw: false,
@@ -164,24 +166,44 @@ export async function autoFund(options: AutoFundOptions): Promise<FundingAdjustm
     }
   }
 
-  if (plan.walletShortfall != null && plan.walletShortfall > 0n) {
+  // Apply --max-balance ceiling (skip or clamp the planned deposit)
+  const warnings: string[] = []
+  const clamp = clampDepositToLimit(status.filecoinPayBalance, plan.delta, maxBalance)
+  if (clamp.reason === 'already-at-limit') {
+    if (clamp.message) warnings.push(clamp.message)
+    return {
+      adjusted: false,
+      delta: 0n,
+      newDepositedAmount: status.filecoinPayBalance,
+      newRunwayDays: plan.current.runway.days,
+      newRunwayHours: plan.current.runway.hours,
+      warnings,
+    }
+  }
+  if (clamp.reason === 'clamped' && clamp.message != null) {
+    warnings.push(clamp.message)
+  }
+  const adjustedPlan = clamp.deposit !== plan.delta ? { ...plan, delta: clamp.deposit } : plan
+
+  if (status.walletUsdfcBalance < adjustedPlan.delta) {
     throw new Error(
-      `Insufficient USDFC in wallet (need ${formatUSDFC(plan.delta)} USDFC, have ${formatUSDFC(status.walletUsdfcBalance)} USDFC)`
+      `Insufficient USDFC in wallet (need ${formatUSDFC(adjustedPlan.delta)} USDFC, have ${formatUSDFC(status.walletUsdfcBalance)} USDFC)`
     )
   }
 
-  const depositMsg = `Depositing ${formatUSDFC(plan.delta)} USDFC to ensure ${MIN_RUNWAY_DAYS} day(s) runway...`
+  const depositMsg = `Depositing ${formatUSDFC(adjustedPlan.delta)} USDFC to ensure at least ${targetRunwayDays} day(s) runway...`
   spinner?.message(depositMsg)
-  const execution = await executeFilecoinPayFunding(synapse, plan)
+  const execution = await executeFilecoinPayFunding(synapse, adjustedPlan)
   spinner?.message(`${pc.green('✓')} Deposit complete`)
 
   return {
     adjusted: execution.adjusted,
-    delta: plan.delta,
+    delta: adjustedPlan.delta,
     transactionHash: execution.transactionHash,
     newDepositedAmount: execution.newDepositedAmount,
     newRunwayDays: execution.newRunwayDays,
     newRunwayHours: execution.newRunwayHours,
+    warnings,
   }
 }
 

--- a/src/payments/types.ts
+++ b/src/payments/types.ts
@@ -25,6 +25,10 @@ export interface AutoFundOptions {
   fileSize: number
   /** Optional spinner for progress updates */
   spinner?: Spinner
+  /** Minimum runway to maintain, in days. Defaults to MIN_RUNWAY_DAYS. */
+  minRunwayDays?: number
+  /** Maximum Filecoin Pay balance after deposit (USDFC base units). Skips or clamps over-projected deposits. */
+  maxBalance?: bigint
 }
 
 export interface FundingAdjustmentResult {
@@ -40,6 +44,8 @@ export interface FundingAdjustmentResult {
   newRunwayDays: number
   /** New runway hours (fractional part) */
   newRunwayHours: number
+  /** Notices about deviations from the requested plan (e.g. clamped or skipped due to maxBalance) */
+  warnings?: string[]
 }
 
 export interface FundOptions extends CLIAuthOptions {

--- a/src/test/unit/cli-options.test.ts
+++ b/src/test/unit/cli-options.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { validateAndNormalizeAutoFundOptions } from '../../utils/cli-options.js'
+
+describe('validateAndNormalizeAutoFundOptions', () => {
+  it('throws when --min-runway-days is set without --auto-fund', () => {
+    expect(() => validateAndNormalizeAutoFundOptions({ minRunwayDays: 10 })).toThrow(
+      '--min-runway-days requires --auto-fund'
+    )
+  })
+
+  it('throws when --max-balance is set without --auto-fund', () => {
+    expect(() => validateAndNormalizeAutoFundOptions({ maxBalance: '5.0' })).toThrow(
+      '--max-balance requires --auto-fund'
+    )
+  })
+
+  it('throws when --auto-fund is combined with --view-address', () => {
+    expect(() =>
+      validateAndNormalizeAutoFundOptions({
+        autoFund: true,
+        viewAddress: '0x0000000000000000000000000000000000000001',
+      })
+    ).toThrow(/--auto-fund cannot be used with --view-address/)
+  })
+
+  it('parses both modifiers when --auto-fund is set', () => {
+    const result = validateAndNormalizeAutoFundOptions({
+      autoFund: true,
+      minRunwayDays: 365,
+      maxBalance: '5.0',
+    })
+    expect(result.autoFund).toBe(true)
+    expect(result.minRunwayDays).toBe(365)
+    expect(result.maxBalance).toBe(5_000_000_000_000_000_000n) // 5 USDFC at 18 decimals
+  })
+
+  it('rejects non-positive --min-runway-days', () => {
+    expect(() => validateAndNormalizeAutoFundOptions({ autoFund: true, minRunwayDays: 0 })).toThrow(
+      /--min-runway-days must be a positive integer/
+    )
+  })
+})

--- a/src/test/unit/cli-options.test.ts
+++ b/src/test/unit/cli-options.test.ts
@@ -14,15 +14,6 @@ describe('validateAndNormalizeAutoFundOptions', () => {
     )
   })
 
-  it('throws when --auto-fund is combined with --view-address', () => {
-    expect(() =>
-      validateAndNormalizeAutoFundOptions({
-        autoFund: true,
-        viewAddress: '0x0000000000000000000000000000000000000001',
-      })
-    ).toThrow(/--auto-fund cannot be used with --view-address/)
-  })
-
   it('parses both modifiers when --auto-fund is set', () => {
     const result = validateAndNormalizeAutoFundOptions({
       autoFund: true,

--- a/src/test/unit/payments-funding.test.ts
+++ b/src/test/unit/payments-funding.test.ts
@@ -3,11 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as paymentsIndex from '../../core/payments/index.js'
 import {
   executeFilecoinPayFunding,
+  type FilecoinPayFundingPlan,
   getFilecoinPayFundingInsights,
   type PaymentStatus,
   planFilecoinPayFunding,
   type ServiceApprovalStatus,
 } from '../../core/payments/index.js'
+import { autoFund } from '../../payments/fund.js'
 
 function makeStatus(params: {
   filecoinPayBalance: bigint
@@ -253,5 +255,80 @@ describe('getFilecoinPayFundingInsights', () => {
     expect(insights.spendRatePerDay).toBe(perDay)
     expect(insights.runway.days).toBe(3)
     expect(insights.availableDeposited).toBe(available)
+  })
+})
+
+describe('autoFund (modifiers)', () => {
+  const synapseStub = makeSynapseStub()
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function mockPlan(opts: { filecoinPayBalance: bigint; delta: bigint }): { status: PaymentStatus } {
+    const status = makeStatus({
+      filecoinPayBalance: opts.filecoinPayBalance,
+      rateUsed: 1n,
+      wallet: 1_000_000_000_000_000_000_000n,
+    })
+    const insights = getFilecoinPayFundingInsights(status)
+    const plan: FilecoinPayFundingPlan = {
+      targetType: 'runway-days',
+      delta: opts.delta,
+      action: opts.delta > 0n ? 'deposit' : 'none',
+      reasonCode: 'runway-insufficient',
+      mode: 'minimum',
+      projectedDeposit: opts.filecoinPayBalance + opts.delta,
+      projectedRateUsed: 1n,
+      projectedLockupUsed: 0n,
+      current: insights,
+      projected: insights,
+    }
+    vi.spyOn(paymentsIndex, 'planFilecoinPayFunding').mockResolvedValue({
+      plan,
+      status,
+      allowances: { updated: false, currentAllowances: status.currentAllowances },
+    })
+    return { status }
+  }
+
+  it('forwards minRunwayDays as targetRunwayDays to planFilecoinPayFunding', async () => {
+    mockPlan({ filecoinPayBalance: 0n, delta: 0n }) // delta 0n -> no-op return
+    await autoFund({ synapse: synapseStub as any, fileSize: 0, minRunwayDays: 60 })
+    expect(paymentsIndex.planFilecoinPayFunding).toHaveBeenCalledWith(expect.objectContaining({ targetRunwayDays: 60 }))
+  })
+
+  it('clamps the executed deposit to maxBalance when the plan would exceed it', async () => {
+    mockPlan({ filecoinPayBalance: 80n, delta: 50n })
+    vi.spyOn(paymentsIndex, 'executeFilecoinPayFunding').mockResolvedValue({
+      adjusted: true,
+      delta: 20n,
+      newDepositedAmount: 100n,
+      newRunwayDays: 30,
+      newRunwayHours: 0,
+      plan: {} as any,
+      updatedInsights: {} as any,
+    })
+
+    const result = await autoFund({ synapse: synapseStub as any, fileSize: 0, maxBalance: 100n })
+
+    const execCalls = vi.mocked(paymentsIndex.executeFilecoinPayFunding).mock.calls
+    expect(execCalls).toHaveLength(1)
+    const [, executedPlan] = execCalls[0] ?? []
+    expect(executedPlan?.delta).toBe(20n) // 100 (limit) - 80 (current) = 20
+    expect(result.delta).toBe(20n)
+    expect(result.warnings?.[0]).toContain('Reducing')
+  })
+
+  it('returns a warning and skips the deposit when already at maxBalance', async () => {
+    mockPlan({ filecoinPayBalance: 100n, delta: 50n })
+    vi.spyOn(paymentsIndex, 'executeFilecoinPayFunding')
+
+    const result = await autoFund({ synapse: synapseStub as any, fileSize: 0, maxBalance: 100n })
+
+    expect(paymentsIndex.executeFilecoinPayFunding).not.toHaveBeenCalled()
+    expect(result.adjusted).toBe(false)
+    expect(result.delta).toBe(0n)
+    expect(result.warnings?.[0]).toContain('already equals or exceeds')
   })
 })

--- a/src/test/unit/payments-top-up.test.ts
+++ b/src/test/unit/payments-top-up.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { clampDepositToLimit } from '../../core/payments/index.js'
+
+describe('clampDepositToLimit', () => {
+  it('passes the request through when no limit is set', () => {
+    const result = clampDepositToLimit(100n, 50n, undefined)
+    expect(result).toEqual({ deposit: 50n, reason: 'passthrough' })
+  })
+
+  it('returns 0 with already-at-limit when current balance meets the limit', () => {
+    const result = clampDepositToLimit(100n, 25n, 100n)
+    expect(result.deposit).toBe(0n)
+    expect(result.reason).toBe('already-at-limit')
+    expect(result.message).toContain('already equals or exceeds')
+  })
+
+  it('clamps the deposit to the largest amount that does not exceed the limit', () => {
+    const result = clampDepositToLimit(80n, 50n, 100n)
+    expect(result.deposit).toBe(20n)
+    expect(result.reason).toBe('clamped')
+    expect(result.message).toContain('Reducing')
+  })
+})

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -5,6 +5,8 @@
  * to ensure consistency across all CLI commands.
  */
 import { type Command, Option } from 'commander'
+import { parseUnits } from 'viem'
+import { MIN_RUNWAY_DAYS } from '../common/constants.js'
 
 /**
  * Decorator to add common authentication options to a Commander command
@@ -107,4 +109,82 @@ export function addUploadOptions(command: Command): Command {
       'Skip IPNI advertisement verification after upload (automatic for devnet)'
     ).env('SKIP_IPNI_VERIFICATION')
   )
+}
+
+/**
+ * Add auto-fund options to a command.
+ * Used by `add` and `import` commands. Modifiers require `--auto-fund`; validate
+ * post-parse with {@link validateAndNormalizeAutoFundOptions}.
+ */
+export function addAutoFundOptions(command: Command): Command {
+  return command
+    .option(
+      '--auto-fund',
+      `Automatically deposit USDFC before upload to maintain runway (default: ${MIN_RUNWAY_DAYS} days)`
+    )
+    .option(
+      '--min-runway-days <n>',
+      'Minimum days of runway to maintain when auto-funding (requires --auto-fund)',
+      Number.parseInt
+    )
+    .option('--max-balance <usdfc>', 'Maximum Filecoin Pay balance after deposit, e.g. 5.00 (requires --auto-fund)')
+}
+
+export interface NormalizedAutoFundOptions {
+  autoFund: boolean
+  minRunwayDays?: number
+  maxBalance?: bigint
+}
+
+/**
+ * Validate and normalize auto-fund options parsed by Commander.
+ *
+ * Strict mode: `--min-runway-days` and `--max-balance` require `--auto-fund` (no implicit
+ * activation). `--view-address` (read-only auth) is incompatible with `--auto-fund` since
+ * deposits require a signing wallet.
+ *
+ * @throws Error with a flag-specific message on validation failure
+ */
+export function validateAndNormalizeAutoFundOptions(raw: {
+  autoFund?: boolean
+  minRunwayDays?: number
+  maxBalance?: string
+  viewAddress?: string
+}): NormalizedAutoFundOptions {
+  const autoFund = raw.autoFund === true
+
+  if (raw.minRunwayDays !== undefined && !autoFund) {
+    throw new Error('--min-runway-days requires --auto-fund')
+  }
+  if (raw.maxBalance !== undefined && !autoFund) {
+    throw new Error('--max-balance requires --auto-fund')
+  }
+  if (autoFund && raw.viewAddress !== undefined) {
+    throw new Error('--auto-fund cannot be used with --view-address (read-only mode cannot sign deposits)')
+  }
+
+  let minRunwayDays: number | undefined
+  if (raw.minRunwayDays !== undefined) {
+    if (!Number.isFinite(raw.minRunwayDays) || !Number.isInteger(raw.minRunwayDays) || raw.minRunwayDays <= 0) {
+      throw new Error(`--min-runway-days must be a positive integer, got: ${raw.minRunwayDays}`)
+    }
+    minRunwayDays = raw.minRunwayDays
+  }
+
+  let maxBalance: bigint | undefined
+  if (raw.maxBalance !== undefined) {
+    try {
+      maxBalance = parseUnits(raw.maxBalance, 18)
+    } catch {
+      throw new Error(`--max-balance must be a USDFC decimal value (e.g. 5.00), got: ${raw.maxBalance}`)
+    }
+    if (maxBalance < 0n) {
+      throw new Error(`--max-balance must be non-negative, got: ${raw.maxBalance}`)
+    }
+  }
+
+  const result: NormalizedAutoFundOptions = { autoFund }
+  if (minRunwayDays !== undefined) result.minRunwayDays = minRunwayDays
+  if (maxBalance !== undefined) result.maxBalance = maxBalance
+  return result
 }

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -4,9 +4,10 @@
  * This module provides reusable option definitions for Commander.js commands
  * to ensure consistency across all CLI commands.
  */
-import { type Command, Option } from 'commander'
+import { type Command, InvalidArgumentError, Option } from 'commander'
 import { parseUnits } from 'viem'
 import { MIN_RUNWAY_DAYS } from '../common/constants.js'
+import { USDFC_DECIMALS } from '../core/payments/constants.js'
 
 /**
  * Decorator to add common authentication options to a Commander command
@@ -125,7 +126,12 @@ export function addAutoFundOptions(command: Command): Command {
     .option(
       '--min-runway-days <n>',
       'Minimum days of runway to maintain when auto-funding (requires --auto-fund)',
-      Number.parseInt
+      (v) => {
+        if (!/^\d+$/.test(v)) {
+          throw new InvalidArgumentError('Must be a positive integer.')
+        }
+        return Number(v)
+      }
     )
     .option('--max-balance <usdfc>', 'Maximum Filecoin Pay balance after deposit, e.g. 5.00 (requires --auto-fund)')
 }
@@ -174,7 +180,7 @@ export function validateAndNormalizeAutoFundOptions(raw: {
   let maxBalance: bigint | undefined
   if (raw.maxBalance !== undefined) {
     try {
-      maxBalance = parseUnits(raw.maxBalance, 18)
+      maxBalance = parseUnits(raw.maxBalance, USDFC_DECIMALS)
     } catch {
       throw new Error(`--max-balance must be a USDFC decimal value (e.g. 5.00), got: ${raw.maxBalance}`)
     }

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -113,15 +113,27 @@ export function addUploadOptions(command: Command): Command {
 }
 
 /**
+ * Auto-fund option fields shared by `add` and `import` runner option types.
+ * Extend this on command-specific option interfaces so additions ripple through.
+ */
+export interface CLIAutoFundOptions {
+  autoFund?: boolean
+  minRunwayDays?: number
+  maxBalance?: bigint
+}
+
+/**
  * Add auto-fund options to a command.
  * Used by `add` and `import` commands. Modifiers require `--auto-fund`; validate
  * post-parse with {@link validateAndNormalizeAutoFundOptions}.
  */
 export function addAutoFundOptions(command: Command): Command {
   return command
-    .option(
-      '--auto-fund',
-      `Automatically deposit USDFC before upload to maintain runway (default: ${MIN_RUNWAY_DAYS} days)`
+    .addOption(
+      new Option(
+        '--auto-fund',
+        `Automatically deposit USDFC before upload to maintain runway (default: ${MIN_RUNWAY_DAYS} days)`
+      ).conflicts('viewAddress')
     )
     .option(
       '--min-runway-days <n>',
@@ -136,18 +148,12 @@ export function addAutoFundOptions(command: Command): Command {
     .option('--max-balance <usdfc>', 'Maximum Filecoin Pay balance after deposit, e.g. 5.00 (requires --auto-fund)')
 }
 
-export interface NormalizedAutoFundOptions {
-  autoFund: boolean
-  minRunwayDays?: number
-  maxBalance?: bigint
-}
-
 /**
  * Validate and normalize auto-fund options parsed by Commander.
  *
  * Strict mode: `--min-runway-days` and `--max-balance` require `--auto-fund` (no implicit
- * activation). `--view-address` (read-only auth) is incompatible with `--auto-fund` since
- * deposits require a signing wallet.
+ * activation). The `--auto-fund` / `--view-address` conflict is enforced by Commander's
+ * `.conflicts()` on the option declaration itself.
  *
  * @throws Error with a flag-specific message on validation failure
  */
@@ -155,8 +161,7 @@ export function validateAndNormalizeAutoFundOptions(raw: {
   autoFund?: boolean
   minRunwayDays?: number
   maxBalance?: string
-  viewAddress?: string
-}): NormalizedAutoFundOptions {
+}): CLIAutoFundOptions {
   const autoFund = raw.autoFund === true
 
   if (raw.minRunwayDays !== undefined && !autoFund) {
@@ -164,9 +169,6 @@ export function validateAndNormalizeAutoFundOptions(raw: {
   }
   if (raw.maxBalance !== undefined && !autoFund) {
     throw new Error('--max-balance requires --auto-fund')
-  }
-  if (autoFund && raw.viewAddress !== undefined) {
-    throw new Error('--auto-fund cannot be used with --view-address (read-only mode cannot sign deposits)')
   }
 
   let minRunwayDays: number | undefined
@@ -189,7 +191,7 @@ export function validateAndNormalizeAutoFundOptions(raw: {
     }
   }
 
-  const result: NormalizedAutoFundOptions = { autoFund }
+  const result: CLIAutoFundOptions = { autoFund }
   if (minRunwayDays !== undefined) result.minRunwayDays = minRunwayDays
   if (maxBalance !== undefined) result.maxBalance = maxBalance
   return result

--- a/upload-action/README.md
+++ b/upload-action/README.md
@@ -12,6 +12,8 @@ See the two-workflow approach in the [examples directory](./examples/) for compl
 
 ## Inputs & Outputs
 
+> **Using the CLI directly?** `filecoin-pin add` and `filecoin-pin import` accept `--auto-fund`, `--min-runway-days`, and `--max-balance` flags that mirror `minStorageDays` and `filecoinPayBalanceLimit` here. See `filecoin-pin add --help`.
+
 See [action.yml](./action.yml) for complete input documentation including:
 - **Core**: `path`, `walletPrivateKey`, `network`
 - **Financial**: `minStorageDays`, `filecoinPayBalanceLimit`


### PR DESCRIPTION
Brings add/import auto-fund to parity with upload-action's minStorageDays and filecoinPayBalanceLimit. Both modifiers strictly require --auto-fund.
Closes: #427

I've tried this out with the various possible permutations on a calibnet wallet and it seems to work really well.

Unblocks https://github.com/ipshipyard/ipfs-deploy-action/pull/49