### PR TITLE
fix(dataset-list): honor explicit metadata/provider filter

### DIFF
--- a/src/data-set/display.ts
+++ b/src/data-set/display.ts
@@ -183,9 +183,14 @@ function renderPieces(dataSet: DataSetSummary, indentLevel: number = 0): void {
 /**
  * Print the lightweight dataset list used for the default command output.
  */
-export function displayDataSets(dataSets: DataSetSummary[], network: string, address: string): void {
+export function displayDataSets(
+  dataSets: DataSetSummary[],
+  network: string,
+  address: string,
+  emptyMessage?: string
+): void {
   if (dataSets.length === 0) {
-    log.line(pc.yellow('No data sets managed by filecoin-pin were found for this account.'))
+    log.line(pc.yellow(emptyMessage ?? 'No data sets managed by filecoin-pin were found for this account.'))
     log.flush()
     return
   }

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -89,13 +89,23 @@ export async function runDataSetListCommand(options: DataSetListCommandOptions):
       withProviderDetails: false,
       filter,
     })
-    const dataSets: DataSetSummary[] = options.all
-      ? allDataSets
-      : allDataSets.filter((dataSet) => dataSet.createdWithFilecoinPin)
+    const explicitFilter = filter != null
+    const dataSets: DataSetSummary[] =
+      options.all || explicitFilter ? allDataSets : allDataSets.filter((dataSet) => dataSet.createdWithFilecoinPin)
 
     spinner.stop('━━━ Data Sets ━━━')
 
-    displayDataSets(dataSets, network, address)
+    let emptyMessage: string | undefined
+    if (dataSets.length === 0) {
+      if (explicitFilter) {
+        emptyMessage = 'No data sets matched the requested filter for this account.'
+      } else if (!options.all && allDataSets.length > 0) {
+        emptyMessage =
+          'No data sets managed by filecoin-pin were found for this account. Pass --all to include data sets created by other tools.'
+      }
+    }
+
+    displayDataSets(dataSets, network, address, emptyMessage)
 
     outro('Data set list complete')
   } catch (error) {

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -99,7 +99,9 @@ export async function runDataSetListCommand(options: DataSetListCommandOptions):
     if (dataSets.length === 0) {
       if (explicitFilter) {
         emptyMessage = 'No data sets matched the requested filter for this account.'
-      } else if (!options.all && allDataSets.length > 0) {
+      } else if (options.all) {
+        emptyMessage = 'No data sets were found for this account.'
+      } else if (allDataSets.length > 0) {
         emptyMessage =
           'No data sets managed by filecoin-pin were found for this account. Pass --all to include data sets created by other tools.'
       }

--- a/src/test/unit/data-set.test.ts
+++ b/src/test/unit/data-set.test.ts
@@ -261,6 +261,63 @@ describe('runDataSetCommand', () => {
     expect(dataSets).toHaveLength(0)
   })
 
+  it('includes non-filecoin-pin datasets when explicit metadata filter is passed', async () => {
+    const migrationDataSet = {
+      ...summaryDataSet,
+      pdpVerifierDataSetId: 13260n,
+      metadata: {
+        [METADATA_KEYS.WITH_IPFS_INDEXING]: '',
+        source: 'storacha-migration',
+        'space-did': 'did:key:z6Mk',
+      },
+    }
+    mockFindDataSets.mockResolvedValueOnce([migrationDataSet])
+
+    await runDataSetListCommand({
+      privateKey: 'test-key',
+      rpcUrl: 'wss://sample',
+      dataSetMetadata: { source: 'storacha-migration' },
+    })
+
+    const [dataSets] = displayDataSetListMock.mock.calls[0] as [DataSetSummary[]]
+    expect(dataSets).toHaveLength(1)
+    expect(dataSets[0]?.dataSetId).toBe(13260n)
+    expect(dataSets[0]?.createdWithFilecoinPin).toBe(false)
+  })
+
+  it('passes a filter-aware empty message when explicit filter matches nothing', async () => {
+    await runDataSetListCommand({
+      privateKey: 'test-key',
+      rpcUrl: 'wss://sample',
+      dataSetMetadata: { source: 'nonexistent' },
+    })
+
+    const call = displayDataSetListMock.mock.calls[0] as [DataSetSummary[], string, string, string | undefined]
+    expect(call[0]).toHaveLength(0)
+    expect(call[3]).toMatch(/matched the requested filter/i)
+  })
+
+  it('hints at --all when default filter hides existing non-filecoin-pin datasets', async () => {
+    const migrationDataSet = {
+      ...summaryDataSet,
+      pdpVerifierDataSetId: 13260n,
+      metadata: {
+        [METADATA_KEYS.WITH_IPFS_INDEXING]: '',
+        source: 'storacha-migration',
+      },
+    }
+    mockFindDataSets.mockResolvedValueOnce([migrationDataSet])
+
+    await runDataSetListCommand({
+      privateKey: 'test-key',
+      rpcUrl: 'wss://sample',
+    })
+
+    const call = displayDataSetListMock.mock.calls[0] as [DataSetSummary[], string, string, string | undefined]
+    expect(call[0]).toHaveLength(0)
+    expect(call[3]).toMatch(/--all/)
+  })
+
   it('loads detailed information when a dataset id is provided', async () => {
     state.pieceList = [{ pieceId: 0n, pieceCid: 'bafkpiece0' }]
     const pieceMetadata = {

--- a/src/test/unit/data-set.test.ts
+++ b/src/test/unit/data-set.test.ts
@@ -297,6 +297,20 @@ describe('runDataSetCommand', () => {
     expect(call[3]).toMatch(/matched the requested filter/i)
   })
 
+  it('uses neutral empty message when --all is set and no datasets exist', async () => {
+    mockFindDataSets.mockResolvedValueOnce([])
+
+    await runDataSetListCommand({
+      privateKey: 'test-key',
+      rpcUrl: 'wss://sample',
+      all: true,
+    })
+
+    const call = displayDataSetListMock.mock.calls[0] as [DataSetSummary[], string, string, string | undefined]
+    expect(call[0]).toHaveLength(0)
+    expect(call[3]).toBe('No data sets were found for this account.')
+  })
+
   it('hints at --all when default filter hides existing non-filecoin-pin datasets', async () => {
     const migrationDataSet = {
       ...summaryDataSet,


### PR DESCRIPTION
Closes #431.

### What changed

`dataset list --data-set-metadata <k=v>` returned empty when the requested metadata diverged from `DEFAULT_DATA_SET_METADATA` (`source=filecoin-pin`, `withIPFSIndexing=''`), because `createdWithFilecoinPin` ran as a post-filter even after the explicit metadata filter already narrowed the set. Now the post-filter is skipped when the caller passed `--data-set-metadata` or `--provider-id`. Behavior with no flags is unchanged.

The empty-state message now distinguishes three cases:
- explicit filter matched nothing → "No data sets matched the requested filter for this account."
- default filter hid existing non-filecoin-pin datasets → suggests `--all`
- no datasets at all → existing message

### How to verify

```
pnpm test
```

Manual:
```
filecoin-pin dataset list --private-key "$KEY" --data-set-metadata source=storacha-migration
# previously: "No data sets managed by filecoin-pin..."
# now: lists matching datasets
```