### PR TITLE
feat(ipni): surface per-CID outcomes for diagnostic visibility

### DIFF
--- a/src/core/utils/validate-ipni-advertisement.ts
+++ b/src/core/utils/validate-ipni-advertisement.ts
@@ -45,8 +45,14 @@ interface ProviderResult {
  * for a given CID. Earlier intermediate failures (e.g. transient fetch errors)
  * may have been retried away and are not reported here.
  */
+/**
+ * Per-CID terminal failure classification.
+ *
+ * Whichever observation was current on the *last* attempt becomes the
+ * terminal reason — there is no separate "timeout" type, since attempts
+ * exhaustion always carries one of the per-attempt observations.
+ */
 export type IpniFailureReason =
-  | { type: 'timeout'; attempts: number; lastObservation?: string }
   | {
       type: 'missingProviders'
       attempts: number
@@ -488,9 +494,14 @@ async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<C
       continue
     }
 
+    // Every loop iteration that does not return success sets `lastReason`,
+    // so this fallback should be unreachable. Surface a structured fallback
+    // rather than throwing to keep the function total.
     const finalReason: IpniFailureReason = lastReason ?? {
-      type: 'timeout',
+      type: 'missingProviders',
       attempts: retryCount,
+      missingServiceUrls: [],
+      actualMultiaddrs: [],
     }
     return { verified: false, reason: finalReason, attempts: retryCount }
   }
@@ -543,10 +554,7 @@ function buildOutcomeError(
   }
 
   if (firstFailure.reason.type === 'aborted') {
-    const error = new Error('Check IPNI announce aborted', {
-      cause: { signal: options?.signal, outcome },
-    })
-    return error
+    return new Error('Check IPNI announce aborted', { cause: outcome })
   }
 
   const expectedProviders = options?.expectedProviders?.filter((p) => p != null) ?? []
@@ -587,8 +595,6 @@ function formatLastObservation(reason: IpniFailureReason): string | undefined {
       return `Failed to parse IPNI response body: ${reason.message}`
     case 'http':
       return `IPNI indexer request failed with status ${reason.status}`
-    case 'timeout':
-      return reason.lastObservation
     case 'aborted':
     case 'notAttempted':
       return undefined

--- a/src/core/utils/validate-ipni-advertisement.ts
+++ b/src/core/utils/validate-ipni-advertisement.ts
@@ -38,6 +38,51 @@ interface ProviderResult {
   }
 }
 
+/**
+ * Per-CID failure classification produced by {@link waitForIpniProviderResults}.
+ *
+ * The `type` discriminator tells consumers what happened on the *last* attempt
+ * for a given CID. Earlier intermediate failures (e.g. transient fetch errors)
+ * may have been retried away and are not reported here.
+ */
+export type IpniFailureReason =
+  | { type: 'timeout'; attempts: number; lastObservation?: string }
+  | {
+      type: 'missingProviders'
+      attempts: number
+      missingServiceUrls: string[]
+      actualMultiaddrs: string[]
+    }
+  | { type: 'fetch'; attempts: number; message: string }
+  | { type: 'parse'; attempts: number; message: string }
+  | { type: 'http'; attempts: number; status: number; statusText?: string }
+  | { type: 'aborted'; attempts: number }
+  | { type: 'notAttempted' }
+
+export interface IpniVerifiedEntry {
+  cid: CID
+  attempts: number
+}
+
+export interface IpniFailedEntry {
+  cid: CID
+  reason: IpniFailureReason
+}
+
+/**
+ * Per-CID outcome of an IPNI validation walk.
+ *
+ * `success === true` iff every CID checked produced a `verified` entry.
+ * Walk stops at the first per-CID failure; CIDs after that point appear in
+ * `failed` with reason `{ type: 'notAttempted' }`.
+ */
+export interface IpniValidationOutcome {
+  success: boolean
+  ipniIndexerUrl: string
+  verified: IpniVerifiedEntry[]
+  failed: IpniFailedEntry[]
+}
+
 export type ValidateIPNIProgressEvents =
   | ProgressEvent<
       'ipniProviderResults.retryUpdate',
@@ -52,6 +97,7 @@ export type ValidateIPNIProgressEvents =
         cidMaxAttempts: number
       }
     >
+  | ProgressEvent<'ipniProviderResults.outcome', { outcome: IpniValidationOutcome }>
   | ProgressEvent<'ipniProviderResults.complete', { result: true; retryCount: number }>
   | ProgressEvent<'ipniProviderResults.failed', { error: Error }>
 
@@ -115,25 +161,69 @@ export interface WaitForIpniProviderResultsOptions {
 }
 
 /**
- * Check if the IPNI Indexer has the provided ProviderResults for the provided ipfsRootCid.
- * This effectively verifies the entire SP<->IPNI flow, including:
- * - The SP announced the advertisement chain to the IPNI indexer(s)
- * - The IPNI indexer(s) pulled the advertisement chain from the SP
- * - The IPNI indexer(s) updated their index
- * This doesn't check individual steps, but rather the end ProviderResults reponse from the IPNI indexer.
- * If the IPNI indexer ProviderResults have the expected providers, then the steps abomove must have completed.
- * This doesn't actually do any IPFS Mainnet retrieval checks of the ipfsRootCid.
+ * Check if the IPNI Indexer has the expected ProviderResults for the provided CIDs.
  *
- * This should not be called until you receive confirmation from the SP that the piece has been parked, i.e. `onPieceAdded` in the `synapse.storage.upload` callbacks.
+ * Verifies the entire SP<->IPNI flow end-to-end:
+ * - SPs announced the advertisement chain to the IPNI indexer
+ * - The IPNI indexer pulled and indexed the chain
  *
- * @param ipfsRootCid - The IPFS root CID to check
- * @param options - Options for the check
- * @returns True if the IPNI announce succeeded, false otherwise
+ * Walks `[ipfsRootCid, ...childBlocks]` in order. Stops at the first CID that
+ * fails to verify within `maxAttempts`. Throws `Error(msg, { cause: outcome })`
+ * on any failure; the `cause` is an {@link IpniValidationOutcome} with per-CID
+ * `verified` and `failed` lists. CIDs not yet walked at failure time appear in
+ * `failed` with `reason.type === 'notAttempted'`.
+ *
+ * Should not be called until you receive confirmation from the SP that the
+ * piece has been parked (e.g. `onPieceAdded` in `synapse.storage.upload`).
+ *
+ * @returns `true` when every CID verified.
+ * @throws Error with `cause: IpniValidationOutcome` on any failure.
  */
 export async function waitForIpniProviderResults(
   ipfsRootCid: CID,
   options?: WaitForIpniProviderResultsOptions
 ): Promise<boolean> {
+  const outcome = await waitForIpniProviderResultsDetailed(ipfsRootCid, options)
+
+  try {
+    options?.onProgress?.({ type: 'ipniProviderResults.outcome', data: { outcome } })
+  } catch (error) {
+    options?.logger?.warn({ error }, 'Error in consumer onProgress callback for outcome event')
+  }
+
+  if (outcome.success) {
+    try {
+      // Legacy retryCount semantics: number of retryUpdate emissions across all CIDs minus 1.
+      const totalAttempts = outcome.verified.reduce((sum, v) => sum + v.attempts, 0)
+      const retryCount = totalAttempts > 0 ? totalAttempts - 1 : 0
+      options?.onProgress?.({ type: 'ipniProviderResults.complete', data: { result: true, retryCount } })
+    } catch (error) {
+      options?.logger?.warn({ error }, 'Error in consumer onProgress callback for complete event')
+    }
+    return true
+  }
+
+  const error = buildOutcomeError(outcome, options)
+  try {
+    options?.onProgress?.({ type: 'ipniProviderResults.failed', data: { error } })
+  } catch (callbackError) {
+    options?.logger?.warn({ error: callbackError }, 'Error in consumer onProgress callback for failed event')
+  }
+  throw error
+}
+
+/**
+ * Detailed variant: never throws on per-CID failures, always returns an
+ * {@link IpniValidationOutcome} with full per-CID verified/failed lists.
+ *
+ * Use this when you need diagnostic visibility into which specific CIDs
+ * verified vs. timed out vs. were aborted mid-walk. The boolean-returning
+ * {@link waitForIpniProviderResults} is a thin wrapper around this function.
+ */
+export async function waitForIpniProviderResultsDetailed(
+  ipfsRootCid: CID,
+  options?: WaitForIpniProviderResultsOptions
+): Promise<IpniValidationOutcome> {
   const delayMs = options?.delayMs ?? 5000
   const maxAttempts = options?.maxAttempts ?? 20
   const ipniIndexerUrl = options?.ipniIndexerUrl ?? 'https://filecoinpin.contact'
@@ -144,8 +234,6 @@ export async function waitForIpniProviderResults(
 
   const hasProviderExpectations = expectedUris.size > 0
 
-  // Log a warning if we expected providers but couldn't derive their URIs
-  // In this case, we fall back to generic validation (just checking if there are any provider records for the CID)
   if (!hasProviderExpectations && expectedProviders.length > 0 && skippedProviderCount > 0) {
     options?.logger?.info(
       { skippedProviderExpectationCount: skippedProviderCount, expectedProviders: expectedProviders.length },
@@ -166,61 +254,70 @@ export async function waitForIpniProviderResults(
   const totalAttempts = cidsToValidate.length * maxAttempts
   let totalChecks = 0
 
-  try {
-    for (const [index, cid] of cidsToValidate.entries()) {
-      await waitForIpniProviderResultsForCid(cid, {
-        delayMs,
-        maxAttempts,
-        ipniIndexerUrl,
-        expectedUris,
-        uriToServiceUrl,
-        hasProviderExpectations,
-        cidIndex: index + 1,
-        cidCount: cidsToValidate.length,
-        totalAttempts,
-        onRetryUpdate: () => {
-          totalChecks++
-          return { retryCount: totalChecks - 1, attempt: totalChecks }
-        },
-        options,
-      })
+  const verified: IpniVerifiedEntry[] = []
+  const failed: IpniFailedEntry[] = []
+
+  for (const [index, cid] of cidsToValidate.entries()) {
+    const result = await validateOneCid(cid, {
+      delayMs,
+      maxAttempts,
+      ipniIndexerUrl,
+      expectedUris,
+      uriToServiceUrl,
+      hasProviderExpectations,
+      cidIndex: index + 1,
+      cidCount: cidsToValidate.length,
+      totalAttempts,
+      onRetryUpdate: () => {
+        totalChecks++
+        return { retryCount: totalChecks - 1, attempt: totalChecks }
+      },
+      options,
+    })
+
+    if (result.verified) {
+      verified.push({ cid, attempts: result.attempts })
+      continue
     }
 
-    try {
-      // totalChecks is incremented before each emitted retryUpdate, so last retryCount is totalChecks - 1
-      const retryCount = totalChecks > 0 ? totalChecks - 1 : 0
-      options?.onProgress?.({ type: 'ipniProviderResults.complete', data: { result: true, retryCount } })
-    } catch (error) {
-      options?.logger?.warn({ error }, 'Error in consumer onProgress callback for complete event')
+    failed.push({ cid, reason: result.reason })
+    // Stop walking. Mark remaining CIDs as not attempted.
+    for (let i = index + 1; i < cidsToValidate.length; i++) {
+      const skipped = cidsToValidate[i]
+      if (skipped != null) {
+        failed.push({ cid: skipped, reason: { type: 'notAttempted' } })
+      }
     }
+    break
+  }
 
-    return true
-  } catch (error) {
-    try {
-      options?.onProgress?.({ type: 'ipniProviderResults.failed', data: { error: error as Error } })
-    } catch (callbackError) {
-      options?.logger?.warn({ error: callbackError }, 'Error in consumer onProgress callback for failed event')
-    }
-    throw error
+  return {
+    success: failed.length === 0,
+    ipniIndexerUrl,
+    verified,
+    failed,
   }
 }
 
-async function waitForIpniProviderResultsForCid(
-  cid: CID,
-  config: {
-    delayMs: number
-    maxAttempts: number
-    ipniIndexerUrl: string
-    expectedUris: Set<string>
-    uriToServiceUrl: Map<string, string>
-    hasProviderExpectations: boolean
-    cidIndex: number
-    cidCount: number
-    totalAttempts: number
-    onRetryUpdate: (() => { retryCount: number; attempt: number }) | undefined
-    options: WaitForIpniProviderResultsOptions | undefined
-  }
-): Promise<boolean> {
+type CidValidationResult =
+  | { verified: true; attempts: number }
+  | { verified: false; reason: IpniFailureReason; attempts: number }
+
+interface ValidateOneCidConfig {
+  delayMs: number
+  maxAttempts: number
+  ipniIndexerUrl: string
+  expectedUris: Set<string>
+  uriToServiceUrl: Map<string, string>
+  hasProviderExpectations: boolean
+  cidIndex: number
+  cidCount: number
+  totalAttempts: number
+  onRetryUpdate: (() => { retryCount: number; attempt: number }) | undefined
+  options: WaitForIpniProviderResultsOptions | undefined
+}
+
+async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<CidValidationResult> {
   const {
     delayMs,
     maxAttempts,
@@ -231,179 +328,271 @@ async function waitForIpniProviderResultsForCid(
     cidIndex,
     cidCount,
     totalAttempts,
+    onRetryUpdate,
+    options,
   } = config
-  const { onRetryUpdate } = config
-  const { options } = config
 
-  return new Promise<boolean>((resolve, reject) => {
-    let retryCount = 0
-    // Tracks the most recent validation failure reason for error reporting
-    let lastFailureReason: string | undefined
-    // Tracks the normalized URIs (for comparison) and raw multiaddrs (for display) from the last IPNI response
-    let lastActualUris: Set<string> = new Set()
-    let lastActualMultiaddrs: Set<string> = new Set()
+  let retryCount = 0
+  let lastReason: IpniFailureReason | null = null
+  let lastActualMultiaddrs: Set<string> = new Set()
+  let lastActualUris: Set<string> = new Set()
 
-    const check = async (): Promise<void> => {
-      if (options?.signal?.aborted) {
-        throw new Error('Check IPNI announce aborted', { cause: options?.signal })
-      }
-
-      options?.logger?.info(
-        {
-          event: 'check-ipni-announce',
-          ipfsRootCid: cid.toString(),
-        },
-        'Checking IPNI for announcement of IPFS CID "%s"',
-        cid.toString()
-      )
-
-      // Emit progress event for this attempt
-      const emittedRetryMetadata = onRetryUpdate?.()
-      try {
-        options?.onProgress?.({
-          type: 'ipniProviderResults.retryUpdate',
-          data: {
-            retryCount: emittedRetryMetadata?.retryCount ?? retryCount,
-            attempt: emittedRetryMetadata?.attempt ?? retryCount + 1,
-            totalAttempts,
-            cid,
-            cidIndex,
-            cidCount,
-            cidAttempt: retryCount + 1,
-            cidMaxAttempts: maxAttempts,
-          },
-        })
-      } catch (error) {
-        options?.logger?.warn({ error }, 'Error in consumer onProgress callback for retryUpdate event')
-      }
-
-      // Fetch IPNI provider records
-      const fetchOptions: RequestInit = {
-        headers: { Accept: 'application/json' },
-      }
-      if (options?.signal) {
-        fetchOptions.signal = options?.signal
-      }
-
-      let response: Response | undefined
-      try {
-        response = await fetch(`${ipniIndexerUrl}/cid/${cid}`, fetchOptions)
-      } catch (fetchError) {
-        lastActualMultiaddrs = new Set()
-        lastActualUris = new Set()
-        lastFailureReason = `Failed to query IPNI indexer: ${getErrorMessage(fetchError)}`
-        options?.logger?.warn({ error: fetchError }, `${lastFailureReason}. Retrying...`)
-      }
-
-      // Parse and validate response
-      if (response?.ok) {
-        let providerResults: ProviderResult[] = []
-        try {
-          const body = (await response.json()) as IpniIndexerResponse
-          // Extract provider results
-          providerResults = (body.MultihashResults ?? []).flatMap((r) => r.ProviderResults ?? [])
-          // Extract raw multiaddrs for display and normalized URIs for comparison.
-          // URI comparison is format-agnostic: both `/dns/host/tcp/443/https`
-          // and `/dns/host/https` normalize to `https://host`.
-          const rawAddrs = providerResults.flatMap((pr) => pr.Provider?.Addrs ?? [])
-          lastActualMultiaddrs = new Set(rawAddrs)
-          lastActualUris = new Set(rawAddrs.map(multiaddrToNormalizedUri))
-          lastFailureReason = undefined
-        } catch (parseError) {
-          // Clear actual multiaddrs on parse error
-          lastActualMultiaddrs = new Set()
-          lastActualUris = new Set()
-          lastFailureReason = `Failed to parse IPNI response body: ${getErrorMessage(parseError)}`
-          options?.logger?.warn({ error: parseError }, `${lastFailureReason}. Retrying...`)
-        }
-
-        // Check if we have provider results to validate
-        if (providerResults.length > 0) {
-          let isValid = false
-
-          if (hasProviderExpectations) {
-            // Find matching URIs and compute which are missing
-            const matchedUris = lastActualUris.intersection(expectedUris)
-            isValid = matchedUris.size === expectedUris.size
-
-            if (!isValid) {
-              // Compute only the missing serviceURLs for precise diagnostics
-              const missingUris = expectedUris.difference(matchedUris)
-              const missingServiceUrls = Array.from(missingUris).map((uri) => uriToServiceUrl.get(uri) ?? uri)
-              lastFailureReason = `Missing expected provider(s): ${missingServiceUrls.join(', ')}`
-              options?.logger?.info(
-                {
-                  missingServiceUrls,
-                  actualMultiaddrs: Array.from(lastActualMultiaddrs),
-                },
-                `${lastFailureReason}. Retrying...`
-              )
-            }
-          } else {
-            // Generic validation: just need any provider with addresses
-            isValid = lastActualUris.size > 0
-            if (!isValid) {
-              lastFailureReason = 'Expected at least one provider record'
-              options?.logger?.info(`${lastFailureReason}. Retrying...`)
-            }
-          }
-
-          if (isValid) {
-            // Validation succeeded!
-            resolve(true)
-            return
-          }
-        } else if (lastFailureReason == null) {
-          // Only set generic message if we don't already have a more specific reason (e.g., parse error)
-          lastFailureReason = 'IPNI response did not include any provider results'
-          // Track that we got an empty response
-          lastActualMultiaddrs = new Set()
-          lastActualUris = new Set()
-          options?.logger?.info(
-            { providerResultsCount: providerResults?.length ?? 0 },
-            `${lastFailureReason}. Retrying...`
-          )
-        }
-      } else if (response != null) {
-        lastActualMultiaddrs = new Set()
-        lastActualUris = new Set()
-        lastFailureReason = `IPNI indexer request failed with status ${response.status}`
-        options?.logger?.info(
-          { status: response.status, statusText: response.statusText },
-          `${lastFailureReason}. Retrying...`
-        )
-      }
-
-      // Retry or fail
-      if (++retryCount < maxAttempts) {
-        options?.logger?.info(
-          { retryCount, maxAttempts },
-          'IPFS CID "%s" not announced to IPNI yet (%d/%d). Retrying in %dms...',
-          cid.toString(),
-          retryCount,
-          maxAttempts,
-          delayMs
-        )
-        await new Promise((resolve) => setTimeout(resolve, delayMs))
-        await check()
-      } else {
-        // Max attempts reached - validation failed
-        const msgBase = `IPFS CID "${cid.toString()}" does not have expected IPNI ProviderResults after ${maxAttempts} attempt${maxAttempts === 1 ? '' : 's'}`
-        let msg = msgBase
-        if (lastFailureReason != null) {
-          msg = `${msgBase}. Last observation: ${lastFailureReason}`
-        }
-        if (hasProviderExpectations) {
-          msg = `${msg}. Expected serviceURLs: [${Array.from(uriToServiceUrl.values()).join(', ')}]. Actual multiaddrs in response: [${Array.from(lastActualMultiaddrs).join(', ')}]`
-        }
-        const error = new Error(msg)
-        options?.logger?.warn({ error }, msg)
-        throw error
-      }
+  while (true) {
+    if (options?.signal?.aborted) {
+      return { verified: false, reason: { type: 'aborted', attempts: retryCount }, attempts: retryCount }
     }
 
-    check().catch(reject)
+    options?.logger?.info(
+      { event: 'check-ipni-announce', ipfsRootCid: cid.toString() },
+      'Checking IPNI for announcement of IPFS CID "%s"',
+      cid.toString()
+    )
+
+    const emittedRetryMetadata = onRetryUpdate?.()
+    try {
+      options?.onProgress?.({
+        type: 'ipniProviderResults.retryUpdate',
+        data: {
+          retryCount: emittedRetryMetadata?.retryCount ?? retryCount,
+          attempt: emittedRetryMetadata?.attempt ?? retryCount + 1,
+          totalAttempts,
+          cid,
+          cidIndex,
+          cidCount,
+          cidAttempt: retryCount + 1,
+          cidMaxAttempts: maxAttempts,
+        },
+      })
+    } catch (error) {
+      options?.logger?.warn({ error }, 'Error in consumer onProgress callback for retryUpdate event')
+    }
+
+    const fetchOptions: RequestInit = {
+      headers: { Accept: 'application/json' },
+    }
+    if (options?.signal) {
+      fetchOptions.signal = options?.signal
+    }
+
+    let response: Response | undefined
+    try {
+      response = await fetch(`${ipniIndexerUrl}/cid/${cid}`, fetchOptions)
+    } catch (fetchError) {
+      if (options?.signal?.aborted) {
+        return { verified: false, reason: { type: 'aborted', attempts: retryCount + 1 }, attempts: retryCount + 1 }
+      }
+      lastActualMultiaddrs = new Set()
+      lastActualUris = new Set()
+      const message = getErrorMessage(fetchError)
+      lastReason = { type: 'fetch', attempts: retryCount + 1, message }
+      options?.logger?.warn({ error: fetchError }, `Failed to query IPNI indexer: ${message}. Retrying...`)
+    }
+
+    if (response?.ok) {
+      let providerResults: ProviderResult[] = []
+      try {
+        const body = (await response.json()) as IpniIndexerResponse
+        providerResults = (body.MultihashResults ?? []).flatMap((r) => r.ProviderResults ?? [])
+        const rawAddrs = providerResults.flatMap((pr) => pr.Provider?.Addrs ?? [])
+        lastActualMultiaddrs = new Set(rawAddrs)
+        lastActualUris = new Set(rawAddrs.map(multiaddrToNormalizedUri))
+        lastReason = null
+      } catch (parseError) {
+        lastActualMultiaddrs = new Set()
+        lastActualUris = new Set()
+        const message = getErrorMessage(parseError)
+        lastReason = { type: 'parse', attempts: retryCount + 1, message }
+        options?.logger?.warn({ error: parseError }, `Failed to parse IPNI response body: ${message}. Retrying...`)
+      }
+
+      if (providerResults.length > 0 && lastReason == null) {
+        let isValid = false
+
+        if (hasProviderExpectations) {
+          const matchedUris = lastActualUris.intersection(expectedUris)
+          isValid = matchedUris.size === expectedUris.size
+
+          if (!isValid) {
+            const missingUris = expectedUris.difference(matchedUris)
+            const missingServiceUrls = Array.from(missingUris).map((uri) => uriToServiceUrl.get(uri) ?? uri)
+            lastReason = {
+              type: 'missingProviders',
+              attempts: retryCount + 1,
+              missingServiceUrls,
+              actualMultiaddrs: Array.from(lastActualMultiaddrs),
+            }
+            options?.logger?.info(
+              { missingServiceUrls, actualMultiaddrs: Array.from(lastActualMultiaddrs) },
+              `Missing expected provider(s): ${missingServiceUrls.join(', ')}. Retrying...`
+            )
+          }
+        } else {
+          isValid = lastActualUris.size > 0
+          if (!isValid) {
+            lastReason = {
+              type: 'missingProviders',
+              attempts: retryCount + 1,
+              missingServiceUrls: [],
+              actualMultiaddrs: [],
+            }
+            options?.logger?.info('Expected at least one provider record. Retrying...')
+          }
+        }
+
+        if (isValid) {
+          return { verified: true, attempts: retryCount + 1 }
+        }
+      } else if (lastReason == null) {
+        lastReason = {
+          type: 'missingProviders',
+          attempts: retryCount + 1,
+          missingServiceUrls: hasProviderExpectations ? Array.from(uriToServiceUrl.values()) : [],
+          actualMultiaddrs: [],
+        }
+        lastActualMultiaddrs = new Set()
+        lastActualUris = new Set()
+        options?.logger?.info(
+          { providerResultsCount: providerResults?.length ?? 0 },
+          'IPNI response did not include any provider results. Retrying...'
+        )
+      }
+    } else if (response != null) {
+      lastActualMultiaddrs = new Set()
+      lastActualUris = new Set()
+      lastReason = {
+        type: 'http',
+        attempts: retryCount + 1,
+        status: response.status,
+        statusText: response.statusText,
+      }
+      options?.logger?.info(
+        { status: response.status, statusText: response.statusText },
+        `IPNI indexer request failed with status ${response.status}. Retrying...`
+      )
+    }
+
+    if (++retryCount < maxAttempts) {
+      options?.logger?.info(
+        { retryCount, maxAttempts },
+        'IPFS CID "%s" not announced to IPNI yet (%d/%d). Retrying in %dms...',
+        cid.toString(),
+        retryCount,
+        maxAttempts,
+        delayMs
+      )
+      try {
+        await abortableDelay(delayMs, options?.signal)
+      } catch {
+        return { verified: false, reason: { type: 'aborted', attempts: retryCount }, attempts: retryCount }
+      }
+      continue
+    }
+
+    const finalReason: IpniFailureReason = lastReason ?? {
+      type: 'timeout',
+      attempts: retryCount,
+    }
+    return { verified: false, reason: finalReason, attempts: retryCount }
+  }
+}
+
+/**
+ * Promise-based delay that rejects when `signal` aborts mid-sleep.
+ *
+ * Replaces `setTimeout` + `await` so an outer `AbortSignal.timeout(...)` does
+ * not have to wait for the next fetch boundary to take effect.
+ */
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('aborted'))
+      return
+    }
+    const timer = setTimeout(() => {
+      if (signal != null) {
+        signal.removeEventListener('abort', onAbort)
+      }
+      resolve()
+    }, ms)
+    const onAbort = (): void => {
+      clearTimeout(timer)
+      reject(new Error('aborted'))
+    }
+    if (signal != null) {
+      signal.addEventListener('abort', onAbort, { once: true })
+    }
   })
+}
+
+/**
+ * Build the legacy single-Error message + attach the structured outcome as
+ * `cause` so consumers that want per-CID detail can read `error.cause`.
+ *
+ * Message format is preserved verbatim from prior versions for callers that
+ * pattern-match on it (e.g. tests).
+ */
+function buildOutcomeError(
+  outcome: IpniValidationOutcome,
+  options: WaitForIpniProviderResultsOptions | undefined
+): Error {
+  const firstFailure = outcome.failed.find((f) => f.reason.type !== 'notAttempted') ?? outcome.failed[0]
+
+  if (firstFailure == null) {
+    const error = new Error('IPNI validation failed', { cause: outcome })
+    return error
+  }
+
+  if (firstFailure.reason.type === 'aborted') {
+    const error = new Error('Check IPNI announce aborted', {
+      cause: { signal: options?.signal, outcome },
+    })
+    return error
+  }
+
+  const expectedProviders = options?.expectedProviders?.filter((p) => p != null) ?? []
+  const { uriToServiceUrl } = deriveExpectedUris(expectedProviders, undefined)
+  const hasProviderExpectations = uriToServiceUrl.size > 0
+  const maxAttempts = options?.maxAttempts ?? 20
+
+  const cid = firstFailure.cid
+  const reason = firstFailure.reason
+  const attempts = 'attempts' in reason ? reason.attempts : maxAttempts
+
+  const msgBase = `IPFS CID "${cid.toString()}" does not have expected IPNI ProviderResults after ${attempts} attempt${attempts === 1 ? '' : 's'}`
+  let msg = msgBase
+  const lastObservation = formatLastObservation(reason)
+  if (lastObservation != null) {
+    msg = `${msgBase}. Last observation: ${lastObservation}`
+  }
+  if (hasProviderExpectations) {
+    const actualMultiaddrs = reason.type === 'missingProviders' ? reason.actualMultiaddrs : []
+    msg = `${msg}. Expected serviceURLs: [${Array.from(uriToServiceUrl.values()).join(', ')}]. Actual multiaddrs in response: [${actualMultiaddrs.join(', ')}]`
+  }
+
+  const error = new Error(msg, { cause: outcome })
+  options?.logger?.warn({ error }, msg)
+  return error
+}
+
+function formatLastObservation(reason: IpniFailureReason): string | undefined {
+  switch (reason.type) {
+    case 'missingProviders':
+      if (reason.missingServiceUrls.length > 0) {
+        return `Missing expected provider(s): ${reason.missingServiceUrls.join(', ')}`
+      }
+      return 'IPNI response did not include any provider results'
+    case 'fetch':
+      return `Failed to query IPNI indexer: ${reason.message}`
+    case 'parse':
+      return `Failed to parse IPNI response body: ${reason.message}`
+    case 'http':
+      return `IPNI indexer request failed with status ${reason.status}`
+    case 'timeout':
+      return reason.lastObservation
+    case 'aborted':
+    case 'notAttempted':
+      return undefined
+  }
 }
 
 /**
@@ -458,9 +647,6 @@ function deriveExpectedUris(
     }
 
     try {
-      // Normalize the service URL to match multiaddrToUri output format.
-      // multiaddrToUri never produces trailing slashes, so we strip them
-      // from the URL to ensure consistent comparison.
       const url = new URL(serviceURL)
       const normalized = url.href.replace(/\/+$/, '')
       uriToServiceUrl.set(normalized, serviceURL)

--- a/src/core/utils/validate-ipni-advertisement.ts
+++ b/src/core/utils/validate-ipni-advertisement.ts
@@ -39,14 +39,19 @@ interface ProviderResult {
 }
 
 /**
- * Per-CID failure classification produced by {@link waitForIpniProviderResults}.
+ * Per-CID terminal failure classification produced by {@link waitForIpniProviderResults}.
  *
  * The `type` discriminator tells consumers what happened on the *last* attempt
  * for a given CID. Earlier intermediate failures (e.g. transient fetch errors)
- * may have been retried away and are not reported here.
+ * may have been retried away and are not reported here. There is no separate
+ * "timeout" type, since attempts exhaustion always carries one of the
+ * per-attempt observations.
+ *
+ * `attempts` counts attempts started when the failure was observed: an abort
+ * mid-fetch counts the in-flight attempt, while an abort between attempts
+ * (before the loop or during the retry sleep) does not add one.
  */
 export type IpniFailureReason =
-  | { type: 'timeout'; attempts: number; lastObservation?: string }
   | {
       type: 'missingProviders'
       attempts: number
@@ -488,9 +493,14 @@ async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<C
       continue
     }
 
+    // Every loop iteration that does not return success sets `lastReason`,
+    // so this fallback should be unreachable. Surface a structured fallback
+    // rather than throwing to keep the function total.
     const finalReason: IpniFailureReason = lastReason ?? {
-      type: 'timeout',
+      type: 'missingProviders',
       attempts: retryCount,
+      missingServiceUrls: [],
+      actualMultiaddrs: [],
     }
     return { verified: false, reason: finalReason, attempts: retryCount }
   }
@@ -543,10 +553,7 @@ function buildOutcomeError(
   }
 
   if (firstFailure.reason.type === 'aborted') {
-    const error = new Error('Check IPNI announce aborted', {
-      cause: { signal: options?.signal, outcome },
-    })
-    return error
+    return new Error('Check IPNI announce aborted', { cause: outcome })
   }
 
   const expectedProviders = options?.expectedProviders?.filter((p) => p != null) ?? []
@@ -587,8 +594,6 @@ function formatLastObservation(reason: IpniFailureReason): string | undefined {
       return `Failed to parse IPNI response body: ${reason.message}`
     case 'http':
       return `IPNI indexer request failed with status ${reason.status}`
-    case 'timeout':
-      return reason.lastObservation
     case 'aborted':
     case 'notAttempted':
       return undefined

--- a/src/core/utils/validate-ipni-advertisement.ts
+++ b/src/core/utils/validate-ipni-advertisement.ts
@@ -198,7 +198,7 @@ export async function waitForIpniProviderResults(
 
   if (outcome.success) {
     try {
-      // Legacy retryCount semantics: number of retryUpdate emissions across all CIDs minus 1.
+      // retryCount mirrors the ':retryUpdate' counter: total emissions across all CIDs minus 1.
       const totalAttempts = outcome.verified.reduce((sum, v) => sum + v.attempts, 0)
       const retryCount = totalAttempts > 0 ? totalAttempts - 1 : 0
       options?.onProgress?.({ type: 'ipniProviderResults:complete', data: { result: true, retryCount } })
@@ -222,7 +222,7 @@ export async function waitForIpniProviderResults(
  * {@link IpniValidationOutcome} with full per-CID verified/failed lists.
  *
  * Use this when you need diagnostic visibility into which specific CIDs
- * verified vs. timed out vs. were aborted mid-walk. The boolean-returning
+ * verified, failed, or were aborted mid-walk. The boolean-returning
  * {@link waitForIpniProviderResults} is a thin wrapper around this function.
  */
 export async function waitForIpniProviderResultsDetailed(
@@ -509,8 +509,8 @@ async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<C
 /**
  * Promise-based delay that rejects when `signal` aborts mid-sleep.
  *
- * Replaces `setTimeout` + `await` so an outer `AbortSignal.timeout(...)` does
- * not have to wait for the next fetch boundary to take effect.
+ * An outer `AbortSignal.timeout(...)` takes effect during the sleep rather
+ * than at the next fetch boundary.
  */
 function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -535,11 +535,12 @@ function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
 }
 
 /**
- * Build the legacy single-Error message + attach the structured outcome as
- * `cause` so consumers that want per-CID detail can read `error.cause`.
+ * Build the single Error thrown by {@link waitForIpniProviderResults}, with
+ * the structured outcome attached as `cause` so consumers that want per-CID
+ * detail can read `error.cause`.
  *
- * Message format is preserved verbatim from prior versions for callers that
- * pattern-match on it (e.g. tests).
+ * The message format is part of the function's contract: callers and tests
+ * pattern-match on it, so change it deliberately or not at all.
  */
 function buildOutcomeError(
   outcome: IpniValidationOutcome,

--- a/src/core/utils/validate-ipni-advertisement.ts
+++ b/src/core/utils/validate-ipni-advertisement.ts
@@ -38,6 +38,51 @@ interface ProviderResult {
   }
 }
 
+/**
+ * Per-CID failure classification produced by {@link waitForIpniProviderResults}.
+ *
+ * The `type` discriminator tells consumers what happened on the *last* attempt
+ * for a given CID. Earlier intermediate failures (e.g. transient fetch errors)
+ * may have been retried away and are not reported here.
+ */
+export type IpniFailureReason =
+  | { type: 'timeout'; attempts: number; lastObservation?: string }
+  | {
+      type: 'missingProviders'
+      attempts: number
+      missingServiceUrls: string[]
+      actualMultiaddrs: string[]
+    }
+  | { type: 'fetch'; attempts: number; message: string }
+  | { type: 'parse'; attempts: number; message: string }
+  | { type: 'http'; attempts: number; status: number; statusText?: string }
+  | { type: 'aborted'; attempts: number }
+  | { type: 'notAttempted' }
+
+export interface IpniVerifiedEntry {
+  cid: CID
+  attempts: number
+}
+
+export interface IpniFailedEntry {
+  cid: CID
+  reason: IpniFailureReason
+}
+
+/**
+ * Per-CID outcome of an IPNI validation walk.
+ *
+ * `success === true` iff every CID checked produced a `verified` entry.
+ * Walk stops at the first per-CID failure; CIDs after that point appear in
+ * `failed` with reason `{ type: 'notAttempted' }`.
+ */
+export interface IpniValidationOutcome {
+  success: boolean
+  ipniIndexerUrl: string
+  verified: IpniVerifiedEntry[]
+  failed: IpniFailedEntry[]
+}
+
 export type ValidateIPNIProgressEvents =
   | ProgressEvent<
       'ipniProviderResults:retryUpdate',
@@ -52,6 +97,7 @@ export type ValidateIPNIProgressEvents =
         cidMaxAttempts: number
       }
     >
+  | ProgressEvent<'ipniProviderResults:outcome', { outcome: IpniValidationOutcome }>
   | ProgressEvent<'ipniProviderResults:complete', { result: true; retryCount: number }>
   | ProgressEvent<'ipniProviderResults:failed', { error: Error }>
 
@@ -115,25 +161,69 @@ export interface WaitForIpniProviderResultsOptions {
 }
 
 /**
- * Check if the IPNI Indexer has the provided ProviderResults for the provided ipfsRootCid.
- * This effectively verifies the entire SP<->IPNI flow, including:
- * - The SP announced the advertisement chain to the IPNI indexer(s)
- * - The IPNI indexer(s) pulled the advertisement chain from the SP
- * - The IPNI indexer(s) updated their index
- * This doesn't check individual steps, but rather the end ProviderResults reponse from the IPNI indexer.
- * If the IPNI indexer ProviderResults have the expected providers, then the steps abomove must have completed.
- * This doesn't actually do any IPFS Mainnet retrieval checks of the ipfsRootCid.
+ * Check if the IPNI Indexer has the expected ProviderResults for the provided CIDs.
  *
- * This should not be called until you receive confirmation from the SP that the piece has been parked, i.e. `onPieceAdded` in the `synapse.storage.upload` callbacks.
+ * Verifies the entire SP<->IPNI flow end-to-end:
+ * - SPs announced the advertisement chain to the IPNI indexer
+ * - The IPNI indexer pulled and indexed the chain
  *
- * @param ipfsRootCid - The IPFS root CID to check
- * @param options - Options for the check
- * @returns True if the IPNI announce succeeded, false otherwise
+ * Walks `[ipfsRootCid, ...childBlocks]` in order. Stops at the first CID that
+ * fails to verify within `maxAttempts`. Throws `Error(msg, { cause: outcome })`
+ * on any failure; the `cause` is an {@link IpniValidationOutcome} with per-CID
+ * `verified` and `failed` lists. CIDs not yet walked at failure time appear in
+ * `failed` with `reason.type === 'notAttempted'`.
+ *
+ * Should not be called until you receive confirmation from the SP that the
+ * piece has been parked (e.g. `onPieceAdded` in `synapse.storage.upload`).
+ *
+ * @returns `true` when every CID verified.
+ * @throws Error with `cause: IpniValidationOutcome` on any failure.
  */
 export async function waitForIpniProviderResults(
   ipfsRootCid: CID,
   options?: WaitForIpniProviderResultsOptions
 ): Promise<boolean> {
+  const outcome = await waitForIpniProviderResultsDetailed(ipfsRootCid, options)
+
+  try {
+    options?.onProgress?.({ type: 'ipniProviderResults:outcome', data: { outcome } })
+  } catch (error) {
+    options?.logger?.warn({ error }, 'Error in consumer onProgress callback for outcome event')
+  }
+
+  if (outcome.success) {
+    try {
+      // Legacy retryCount semantics: number of retryUpdate emissions across all CIDs minus 1.
+      const totalAttempts = outcome.verified.reduce((sum, v) => sum + v.attempts, 0)
+      const retryCount = totalAttempts > 0 ? totalAttempts - 1 : 0
+      options?.onProgress?.({ type: 'ipniProviderResults:complete', data: { result: true, retryCount } })
+    } catch (error) {
+      options?.logger?.warn({ error }, 'Error in consumer onProgress callback for complete event')
+    }
+    return true
+  }
+
+  const error = buildOutcomeError(outcome, options)
+  try {
+    options?.onProgress?.({ type: 'ipniProviderResults:failed', data: { error } })
+  } catch (callbackError) {
+    options?.logger?.warn({ error: callbackError }, 'Error in consumer onProgress callback for failed event')
+  }
+  throw error
+}
+
+/**
+ * Detailed variant: never throws on per-CID failures, always returns an
+ * {@link IpniValidationOutcome} with full per-CID verified/failed lists.
+ *
+ * Use this when you need diagnostic visibility into which specific CIDs
+ * verified vs. timed out vs. were aborted mid-walk. The boolean-returning
+ * {@link waitForIpniProviderResults} is a thin wrapper around this function.
+ */
+export async function waitForIpniProviderResultsDetailed(
+  ipfsRootCid: CID,
+  options?: WaitForIpniProviderResultsOptions
+): Promise<IpniValidationOutcome> {
   const delayMs = options?.delayMs ?? 5000
   const maxAttempts = options?.maxAttempts ?? 20
   const ipniIndexerUrl = options?.ipniIndexerUrl ?? 'https://filecoinpin.contact'
@@ -144,8 +234,6 @@ export async function waitForIpniProviderResults(
 
   const hasProviderExpectations = expectedUris.size > 0
 
-  // Log a warning if we expected providers but couldn't derive their URIs
-  // In this case, we fall back to generic validation (just checking if there are any provider records for the CID)
   if (!hasProviderExpectations && expectedProviders.length > 0 && skippedProviderCount > 0) {
     options?.logger?.info(
       { skippedProviderExpectationCount: skippedProviderCount, expectedProviders: expectedProviders.length },
@@ -166,61 +254,70 @@ export async function waitForIpniProviderResults(
   const totalAttempts = cidsToValidate.length * maxAttempts
   let totalChecks = 0
 
-  try {
-    for (const [index, cid] of cidsToValidate.entries()) {
-      await waitForIpniProviderResultsForCid(cid, {
-        delayMs,
-        maxAttempts,
-        ipniIndexerUrl,
-        expectedUris,
-        uriToServiceUrl,
-        hasProviderExpectations,
-        cidIndex: index + 1,
-        cidCount: cidsToValidate.length,
-        totalAttempts,
-        onRetryUpdate: () => {
-          totalChecks++
-          return { retryCount: totalChecks - 1, attempt: totalChecks }
-        },
-        options,
-      })
+  const verified: IpniVerifiedEntry[] = []
+  const failed: IpniFailedEntry[] = []
+
+  for (const [index, cid] of cidsToValidate.entries()) {
+    const result = await validateOneCid(cid, {
+      delayMs,
+      maxAttempts,
+      ipniIndexerUrl,
+      expectedUris,
+      uriToServiceUrl,
+      hasProviderExpectations,
+      cidIndex: index + 1,
+      cidCount: cidsToValidate.length,
+      totalAttempts,
+      onRetryUpdate: () => {
+        totalChecks++
+        return { retryCount: totalChecks - 1, attempt: totalChecks }
+      },
+      options,
+    })
+
+    if (result.verified) {
+      verified.push({ cid, attempts: result.attempts })
+      continue
     }
 
-    try {
-      // totalChecks is incremented before each emitted retryUpdate, so last retryCount is totalChecks - 1
-      const retryCount = totalChecks > 0 ? totalChecks - 1 : 0
-      options?.onProgress?.({ type: 'ipniProviderResults:complete', data: { result: true, retryCount } })
-    } catch (error) {
-      options?.logger?.warn({ error }, 'Error in consumer onProgress callback for complete event')
+    failed.push({ cid, reason: result.reason })
+    // Stop walking. Mark remaining CIDs as not attempted.
+    for (let i = index + 1; i < cidsToValidate.length; i++) {
+      const skipped = cidsToValidate[i]
+      if (skipped != null) {
+        failed.push({ cid: skipped, reason: { type: 'notAttempted' } })
+      }
     }
+    break
+  }
 
-    return true
-  } catch (error) {
-    try {
-      options?.onProgress?.({ type: 'ipniProviderResults:failed', data: { error: error as Error } })
-    } catch (callbackError) {
-      options?.logger?.warn({ error: callbackError }, 'Error in consumer onProgress callback for failed event')
-    }
-    throw error
+  return {
+    success: failed.length === 0,
+    ipniIndexerUrl,
+    verified,
+    failed,
   }
 }
 
-async function waitForIpniProviderResultsForCid(
-  cid: CID,
-  config: {
-    delayMs: number
-    maxAttempts: number
-    ipniIndexerUrl: string
-    expectedUris: Set<string>
-    uriToServiceUrl: Map<string, string>
-    hasProviderExpectations: boolean
-    cidIndex: number
-    cidCount: number
-    totalAttempts: number
-    onRetryUpdate: (() => { retryCount: number; attempt: number }) | undefined
-    options: WaitForIpniProviderResultsOptions | undefined
-  }
-): Promise<boolean> {
+type CidValidationResult =
+  | { verified: true; attempts: number }
+  | { verified: false; reason: IpniFailureReason; attempts: number }
+
+interface ValidateOneCidConfig {
+  delayMs: number
+  maxAttempts: number
+  ipniIndexerUrl: string
+  expectedUris: Set<string>
+  uriToServiceUrl: Map<string, string>
+  hasProviderExpectations: boolean
+  cidIndex: number
+  cidCount: number
+  totalAttempts: number
+  onRetryUpdate: (() => { retryCount: number; attempt: number }) | undefined
+  options: WaitForIpniProviderResultsOptions | undefined
+}
+
+async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<CidValidationResult> {
   const {
     delayMs,
     maxAttempts,
@@ -231,179 +328,271 @@ async function waitForIpniProviderResultsForCid(
     cidIndex,
     cidCount,
     totalAttempts,
+    onRetryUpdate,
+    options,
   } = config
-  const { onRetryUpdate } = config
-  const { options } = config
 
-  return new Promise<boolean>((resolve, reject) => {
-    let retryCount = 0
-    // Tracks the most recent validation failure reason for error reporting
-    let lastFailureReason: string | undefined
-    // Tracks the normalized URIs (for comparison) and raw multiaddrs (for display) from the last IPNI response
-    let lastActualUris: Set<string> = new Set()
-    let lastActualMultiaddrs: Set<string> = new Set()
+  let retryCount = 0
+  let lastReason: IpniFailureReason | null = null
+  let lastActualMultiaddrs: Set<string> = new Set()
+  let lastActualUris: Set<string> = new Set()
 
-    const check = async (): Promise<void> => {
-      if (options?.signal?.aborted) {
-        throw new Error('Check IPNI announce aborted', { cause: options?.signal })
-      }
-
-      options?.logger?.info(
-        {
-          event: 'check-ipni-announce',
-          ipfsRootCid: cid.toString(),
-        },
-        'Checking IPNI for announcement of IPFS CID "%s"',
-        cid.toString()
-      )
-
-      // Emit progress event for this attempt
-      const emittedRetryMetadata = onRetryUpdate?.()
-      try {
-        options?.onProgress?.({
-          type: 'ipniProviderResults:retryUpdate',
-          data: {
-            retryCount: emittedRetryMetadata?.retryCount ?? retryCount,
-            attempt: emittedRetryMetadata?.attempt ?? retryCount + 1,
-            totalAttempts,
-            cid,
-            cidIndex,
-            cidCount,
-            cidAttempt: retryCount + 1,
-            cidMaxAttempts: maxAttempts,
-          },
-        })
-      } catch (error) {
-        options?.logger?.warn({ error }, 'Error in consumer onProgress callback for retryUpdate event')
-      }
-
-      // Fetch IPNI provider records
-      const fetchOptions: RequestInit = {
-        headers: { Accept: 'application/json' },
-      }
-      if (options?.signal) {
-        fetchOptions.signal = options?.signal
-      }
-
-      let response: Response | undefined
-      try {
-        response = await fetch(`${ipniIndexerUrl}/cid/${cid}`, fetchOptions)
-      } catch (fetchError) {
-        lastActualMultiaddrs = new Set()
-        lastActualUris = new Set()
-        lastFailureReason = `Failed to query IPNI indexer: ${getErrorMessage(fetchError)}`
-        options?.logger?.warn({ error: fetchError }, `${lastFailureReason}. Retrying...`)
-      }
-
-      // Parse and validate response
-      if (response?.ok) {
-        let providerResults: ProviderResult[] = []
-        try {
-          const body = (await response.json()) as IpniIndexerResponse
-          // Extract provider results
-          providerResults = (body.MultihashResults ?? []).flatMap((r) => r.ProviderResults ?? [])
-          // Extract raw multiaddrs for display and normalized URIs for comparison.
-          // URI comparison is format-agnostic: both `/dns/host/tcp/443/https`
-          // and `/dns/host/https` normalize to `https://host`.
-          const rawAddrs = providerResults.flatMap((pr) => pr.Provider?.Addrs ?? [])
-          lastActualMultiaddrs = new Set(rawAddrs)
-          lastActualUris = new Set(rawAddrs.map(multiaddrToNormalizedUri))
-          lastFailureReason = undefined
-        } catch (parseError) {
-          // Clear actual multiaddrs on parse error
-          lastActualMultiaddrs = new Set()
-          lastActualUris = new Set()
-          lastFailureReason = `Failed to parse IPNI response body: ${getErrorMessage(parseError)}`
-          options?.logger?.warn({ error: parseError }, `${lastFailureReason}. Retrying...`)
-        }
-
-        // Check if we have provider results to validate
-        if (providerResults.length > 0) {
-          let isValid = false
-
-          if (hasProviderExpectations) {
-            // Find matching URIs and compute which are missing
-            const matchedUris = lastActualUris.intersection(expectedUris)
-            isValid = matchedUris.size === expectedUris.size
-
-            if (!isValid) {
-              // Compute only the missing serviceURLs for precise diagnostics
-              const missingUris = expectedUris.difference(matchedUris)
-              const missingServiceUrls = Array.from(missingUris).map((uri) => uriToServiceUrl.get(uri) ?? uri)
-              lastFailureReason = `Missing expected provider(s): ${missingServiceUrls.join(', ')}`
-              options?.logger?.info(
-                {
-                  missingServiceUrls,
-                  actualMultiaddrs: Array.from(lastActualMultiaddrs),
-                },
-                `${lastFailureReason}. Retrying...`
-              )
-            }
-          } else {
-            // Generic validation: just need any provider with addresses
-            isValid = lastActualUris.size > 0
-            if (!isValid) {
-              lastFailureReason = 'Expected at least one provider record'
-              options?.logger?.info(`${lastFailureReason}. Retrying...`)
-            }
-          }
-
-          if (isValid) {
-            // Validation succeeded!
-            resolve(true)
-            return
-          }
-        } else if (lastFailureReason == null) {
-          // Only set generic message if we don't already have a more specific reason (e.g., parse error)
-          lastFailureReason = 'IPNI response did not include any provider results'
-          // Track that we got an empty response
-          lastActualMultiaddrs = new Set()
-          lastActualUris = new Set()
-          options?.logger?.info(
-            { providerResultsCount: providerResults?.length ?? 0 },
-            `${lastFailureReason}. Retrying...`
-          )
-        }
-      } else if (response != null) {
-        lastActualMultiaddrs = new Set()
-        lastActualUris = new Set()
-        lastFailureReason = `IPNI indexer request failed with status ${response.status}`
-        options?.logger?.info(
-          { status: response.status, statusText: response.statusText },
-          `${lastFailureReason}. Retrying...`
-        )
-      }
-
-      // Retry or fail
-      if (++retryCount < maxAttempts) {
-        options?.logger?.info(
-          { retryCount, maxAttempts },
-          'IPFS CID "%s" not announced to IPNI yet (%d/%d). Retrying in %dms...',
-          cid.toString(),
-          retryCount,
-          maxAttempts,
-          delayMs
-        )
-        await new Promise((resolve) => setTimeout(resolve, delayMs))
-        await check()
-      } else {
-        // Max attempts reached - validation failed
-        const msgBase = `IPFS CID "${cid.toString()}" does not have expected IPNI ProviderResults after ${maxAttempts} attempt${maxAttempts === 1 ? '' : 's'}`
-        let msg = msgBase
-        if (lastFailureReason != null) {
-          msg = `${msgBase}. Last observation: ${lastFailureReason}`
-        }
-        if (hasProviderExpectations) {
-          msg = `${msg}. Expected serviceURLs: [${Array.from(uriToServiceUrl.values()).join(', ')}]. Actual multiaddrs in response: [${Array.from(lastActualMultiaddrs).join(', ')}]`
-        }
-        const error = new Error(msg)
-        options?.logger?.warn({ error }, msg)
-        throw error
-      }
+  while (true) {
+    if (options?.signal?.aborted) {
+      return { verified: false, reason: { type: 'aborted', attempts: retryCount }, attempts: retryCount }
     }
 
-    check().catch(reject)
+    options?.logger?.info(
+      { event: 'check-ipni-announce', ipfsRootCid: cid.toString() },
+      'Checking IPNI for announcement of IPFS CID "%s"',
+      cid.toString()
+    )
+
+    const emittedRetryMetadata = onRetryUpdate?.()
+    try {
+      options?.onProgress?.({
+        type: 'ipniProviderResults:retryUpdate',
+        data: {
+          retryCount: emittedRetryMetadata?.retryCount ?? retryCount,
+          attempt: emittedRetryMetadata?.attempt ?? retryCount + 1,
+          totalAttempts,
+          cid,
+          cidIndex,
+          cidCount,
+          cidAttempt: retryCount + 1,
+          cidMaxAttempts: maxAttempts,
+        },
+      })
+    } catch (error) {
+      options?.logger?.warn({ error }, 'Error in consumer onProgress callback for retryUpdate event')
+    }
+
+    const fetchOptions: RequestInit = {
+      headers: { Accept: 'application/json' },
+    }
+    if (options?.signal) {
+      fetchOptions.signal = options?.signal
+    }
+
+    let response: Response | undefined
+    try {
+      response = await fetch(`${ipniIndexerUrl}/cid/${cid}`, fetchOptions)
+    } catch (fetchError) {
+      if (options?.signal?.aborted) {
+        return { verified: false, reason: { type: 'aborted', attempts: retryCount + 1 }, attempts: retryCount + 1 }
+      }
+      lastActualMultiaddrs = new Set()
+      lastActualUris = new Set()
+      const message = getErrorMessage(fetchError)
+      lastReason = { type: 'fetch', attempts: retryCount + 1, message }
+      options?.logger?.warn({ error: fetchError }, `Failed to query IPNI indexer: ${message}. Retrying...`)
+    }
+
+    if (response?.ok) {
+      let providerResults: ProviderResult[] = []
+      try {
+        const body = (await response.json()) as IpniIndexerResponse
+        providerResults = (body.MultihashResults ?? []).flatMap((r) => r.ProviderResults ?? [])
+        const rawAddrs = providerResults.flatMap((pr) => pr.Provider?.Addrs ?? [])
+        lastActualMultiaddrs = new Set(rawAddrs)
+        lastActualUris = new Set(rawAddrs.map(multiaddrToNormalizedUri))
+        lastReason = null
+      } catch (parseError) {
+        lastActualMultiaddrs = new Set()
+        lastActualUris = new Set()
+        const message = getErrorMessage(parseError)
+        lastReason = { type: 'parse', attempts: retryCount + 1, message }
+        options?.logger?.warn({ error: parseError }, `Failed to parse IPNI response body: ${message}. Retrying...`)
+      }
+
+      if (providerResults.length > 0 && lastReason == null) {
+        let isValid = false
+
+        if (hasProviderExpectations) {
+          const matchedUris = lastActualUris.intersection(expectedUris)
+          isValid = matchedUris.size === expectedUris.size
+
+          if (!isValid) {
+            const missingUris = expectedUris.difference(matchedUris)
+            const missingServiceUrls = Array.from(missingUris).map((uri) => uriToServiceUrl.get(uri) ?? uri)
+            lastReason = {
+              type: 'missingProviders',
+              attempts: retryCount + 1,
+              missingServiceUrls,
+              actualMultiaddrs: Array.from(lastActualMultiaddrs),
+            }
+            options?.logger?.info(
+              { missingServiceUrls, actualMultiaddrs: Array.from(lastActualMultiaddrs) },
+              `Missing expected provider(s): ${missingServiceUrls.join(', ')}. Retrying...`
+            )
+          }
+        } else {
+          isValid = lastActualUris.size > 0
+          if (!isValid) {
+            lastReason = {
+              type: 'missingProviders',
+              attempts: retryCount + 1,
+              missingServiceUrls: [],
+              actualMultiaddrs: [],
+            }
+            options?.logger?.info('Expected at least one provider record. Retrying...')
+          }
+        }
+
+        if (isValid) {
+          return { verified: true, attempts: retryCount + 1 }
+        }
+      } else if (lastReason == null) {
+        lastReason = {
+          type: 'missingProviders',
+          attempts: retryCount + 1,
+          missingServiceUrls: hasProviderExpectations ? Array.from(uriToServiceUrl.values()) : [],
+          actualMultiaddrs: [],
+        }
+        lastActualMultiaddrs = new Set()
+        lastActualUris = new Set()
+        options?.logger?.info(
+          { providerResultsCount: providerResults?.length ?? 0 },
+          'IPNI response did not include any provider results. Retrying...'
+        )
+      }
+    } else if (response != null) {
+      lastActualMultiaddrs = new Set()
+      lastActualUris = new Set()
+      lastReason = {
+        type: 'http',
+        attempts: retryCount + 1,
+        status: response.status,
+        statusText: response.statusText,
+      }
+      options?.logger?.info(
+        { status: response.status, statusText: response.statusText },
+        `IPNI indexer request failed with status ${response.status}. Retrying...`
+      )
+    }
+
+    if (++retryCount < maxAttempts) {
+      options?.logger?.info(
+        { retryCount, maxAttempts },
+        'IPFS CID "%s" not announced to IPNI yet (%d/%d). Retrying in %dms...',
+        cid.toString(),
+        retryCount,
+        maxAttempts,
+        delayMs
+      )
+      try {
+        await abortableDelay(delayMs, options?.signal)
+      } catch {
+        return { verified: false, reason: { type: 'aborted', attempts: retryCount }, attempts: retryCount }
+      }
+      continue
+    }
+
+    const finalReason: IpniFailureReason = lastReason ?? {
+      type: 'timeout',
+      attempts: retryCount,
+    }
+    return { verified: false, reason: finalReason, attempts: retryCount }
+  }
+}
+
+/**
+ * Promise-based delay that rejects when `signal` aborts mid-sleep.
+ *
+ * Replaces `setTimeout` + `await` so an outer `AbortSignal.timeout(...)` does
+ * not have to wait for the next fetch boundary to take effect.
+ */
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('aborted'))
+      return
+    }
+    const timer = setTimeout(() => {
+      if (signal != null) {
+        signal.removeEventListener('abort', onAbort)
+      }
+      resolve()
+    }, ms)
+    const onAbort = (): void => {
+      clearTimeout(timer)
+      reject(new Error('aborted'))
+    }
+    if (signal != null) {
+      signal.addEventListener('abort', onAbort, { once: true })
+    }
   })
+}
+
+/**
+ * Build the legacy single-Error message + attach the structured outcome as
+ * `cause` so consumers that want per-CID detail can read `error.cause`.
+ *
+ * Message format is preserved verbatim from prior versions for callers that
+ * pattern-match on it (e.g. tests).
+ */
+function buildOutcomeError(
+  outcome: IpniValidationOutcome,
+  options: WaitForIpniProviderResultsOptions | undefined
+): Error {
+  const firstFailure = outcome.failed.find((f) => f.reason.type !== 'notAttempted') ?? outcome.failed[0]
+
+  if (firstFailure == null) {
+    const error = new Error('IPNI validation failed', { cause: outcome })
+    return error
+  }
+
+  if (firstFailure.reason.type === 'aborted') {
+    const error = new Error('Check IPNI announce aborted', {
+      cause: { signal: options?.signal, outcome },
+    })
+    return error
+  }
+
+  const expectedProviders = options?.expectedProviders?.filter((p) => p != null) ?? []
+  const { uriToServiceUrl } = deriveExpectedUris(expectedProviders, undefined)
+  const hasProviderExpectations = uriToServiceUrl.size > 0
+  const maxAttempts = options?.maxAttempts ?? 20
+
+  const cid = firstFailure.cid
+  const reason = firstFailure.reason
+  const attempts = 'attempts' in reason ? reason.attempts : maxAttempts
+
+  const msgBase = `IPFS CID "${cid.toString()}" does not have expected IPNI ProviderResults after ${attempts} attempt${attempts === 1 ? '' : 's'}`
+  let msg = msgBase
+  const lastObservation = formatLastObservation(reason)
+  if (lastObservation != null) {
+    msg = `${msgBase}. Last observation: ${lastObservation}`
+  }
+  if (hasProviderExpectations) {
+    const actualMultiaddrs = reason.type === 'missingProviders' ? reason.actualMultiaddrs : []
+    msg = `${msg}. Expected serviceURLs: [${Array.from(uriToServiceUrl.values()).join(', ')}]. Actual multiaddrs in response: [${actualMultiaddrs.join(', ')}]`
+  }
+
+  const error = new Error(msg, { cause: outcome })
+  options?.logger?.warn({ error }, msg)
+  return error
+}
+
+function formatLastObservation(reason: IpniFailureReason): string | undefined {
+  switch (reason.type) {
+    case 'missingProviders':
+      if (reason.missingServiceUrls.length > 0) {
+        return `Missing expected provider(s): ${reason.missingServiceUrls.join(', ')}`
+      }
+      return 'IPNI response did not include any provider results'
+    case 'fetch':
+      return `Failed to query IPNI indexer: ${reason.message}`
+    case 'parse':
+      return `Failed to parse IPNI response body: ${reason.message}`
+    case 'http':
+      return `IPNI indexer request failed with status ${reason.status}`
+    case 'timeout':
+      return reason.lastObservation
+    case 'aborted':
+    case 'notAttempted':
+      return undefined
+  }
 }
 
 /**
@@ -458,9 +647,6 @@ function deriveExpectedUris(
     }
 
     try {
-      // Normalize the service URL to match multiaddrToUri output format.
-      // multiaddrToUri never produces trailing slashes, so we strip them
-      // from the URL to ensure consistent comparison.
       const url = new URL(serviceURL)
       const normalized = url.href.replace(/\/+$/, '')
       uriToServiceUrl.set(normalized, serviceURL)

--- a/src/core/utils/validate-ipni-advertisement.ts
+++ b/src/core/utils/validate-ipni-advertisement.ts
@@ -50,6 +50,10 @@ interface ProviderResult {
  * `attempts` counts attempts started when the failure was observed: an abort
  * mid-fetch counts the in-flight attempt, while an abort between attempts
  * (before the loop or during the retry sleep) does not add one.
+ *
+ * `aborted.reason` carries the abort signal's `reason` (e.g. `AbortSignal.timeout`
+ * reports `"signal timed out"`) when it is meaningful; a plain
+ * `controller.abort()` leaves it unset.
  */
 export type IpniFailureReason =
   | {
@@ -61,7 +65,7 @@ export type IpniFailureReason =
   | { type: 'fetch'; attempts: number; message: string }
   | { type: 'parse'; attempts: number; message: string }
   | { type: 'http'; attempts: number; status: number; statusText?: string }
-  | { type: 'aborted'; attempts: number }
+  | { type: 'aborted'; attempts: number; reason?: string }
   | { type: 'notAttempted' }
 
 export interface IpniVerifiedEntry {
@@ -88,25 +92,24 @@ export interface IpniValidationOutcome {
   failed: IpniFailedEntry[]
 }
 
+export interface IpniRetryUpdateData {
+  retryCount: number
+  attempt: number
+  totalAttempts: number
+  cid: CID
+  cidIndex: number
+  cidCount: number
+  cidAttempt: number
+  cidMaxAttempts: number
+}
+
 export type ValidateIPNIProgressEvents =
-  | ProgressEvent<
-      'ipniProviderResults:retryUpdate',
-      {
-        retryCount: number
-        attempt: number
-        totalAttempts: number
-        cid: CID
-        cidIndex: number
-        cidCount: number
-        cidAttempt: number
-        cidMaxAttempts: number
-      }
-    >
+  | ProgressEvent<'ipniProviderResults:retryUpdate', IpniRetryUpdateData>
   | ProgressEvent<'ipniProviderResults:outcome', { outcome: IpniValidationOutcome }>
   | ProgressEvent<'ipniProviderResults:complete', { result: true; retryCount: number }>
   | ProgressEvent<'ipniProviderResults:failed', { error: Error }>
 
-export interface WaitForIpniProviderResultsOptions {
+export interface IpniValidationCoreOptions {
   /**
    * maximum number of attempts
    *
@@ -146,13 +149,6 @@ export interface WaitForIpniProviderResultsOptions {
   expectedProviders?: PDPProvider[] | undefined
 
   /**
-   * Callback for progress updates
-   *
-   * @default: undefined
-   */
-  onProgress?: ProgressEventHandler<ValidateIPNIProgressEvents>
-
-  /**
    * IPNI indexer URL to query for provider records to confirm that advertisements were processed.
    *
    * @default 'https://filecoinpin.contact'
@@ -163,6 +159,15 @@ export interface WaitForIpniProviderResultsOptions {
    * Child blocks that must also be validated against expected providers.
    */
   childBlocks?: CID[] | undefined
+}
+
+export interface WaitForIpniProviderResultsOptions extends IpniValidationCoreOptions {
+  /**
+   * Callback for progress updates
+   *
+   * @default: undefined
+   */
+  onProgress?: ProgressEventHandler<ValidateIPNIProgressEvents>
 }
 
 /**
@@ -178,6 +183,11 @@ export interface WaitForIpniProviderResultsOptions {
  * `verified` and `failed` lists. CIDs not yet walked at failure time appear in
  * `failed` with `reason.type === 'notAttempted'`.
  *
+ * Emits `ipniProviderResults:retryUpdate`, `:outcome`, and `:complete` or
+ * `:failed` progress events when `options.onProgress` is provided. The
+ * event-free core walk is exposed as
+ * {@link waitForIpniProviderResultsDetailed}.
+ *
  * Should not be called until you receive confirmation from the SP that the
  * piece has been parked (e.g. `onPieceAdded` in `synapse.storage.upload`).
  *
@@ -188,7 +198,13 @@ export async function waitForIpniProviderResults(
   ipfsRootCid: CID,
   options?: WaitForIpniProviderResultsOptions
 ): Promise<boolean> {
-  const outcome = await waitForIpniProviderResultsDetailed(ipfsRootCid, options)
+  const outcome = await runIpniValidationWalk(ipfsRootCid, options, (data) => {
+    try {
+      options?.onProgress?.({ type: 'ipniProviderResults:retryUpdate', data })
+    } catch (error) {
+      options?.logger?.warn({ error }, 'Error in consumer onProgress callback for retryUpdate event')
+    }
+  })
 
   try {
     options?.onProgress?.({ type: 'ipniProviderResults:outcome', data: { outcome } })
@@ -222,12 +238,32 @@ export async function waitForIpniProviderResults(
  * {@link IpniValidationOutcome} with full per-CID verified/failed lists.
  *
  * Use this when you need diagnostic visibility into which specific CIDs
- * verified, failed, or were aborted mid-walk. The boolean-returning
- * {@link waitForIpniProviderResults} is a thin wrapper around this function.
+ * verified, failed, or were aborted mid-walk. This function performs the
+ * validation walk and returns its outcome; it does not emit progress events.
+ * The boolean-returning {@link waitForIpniProviderResults} wraps the same
+ * walk and adds the `retryUpdate`/`outcome`/`complete`/`failed` event
+ * surface plus its throw-on-failure behavior.
  */
 export async function waitForIpniProviderResultsDetailed(
   ipfsRootCid: CID,
-  options?: WaitForIpniProviderResultsOptions
+  options?: IpniValidationCoreOptions
+): Promise<IpniValidationOutcome> {
+  return runIpniValidationWalk(ipfsRootCid, options)
+}
+
+/**
+ * Core validation walk shared by {@link waitForIpniProviderResults} and
+ * {@link waitForIpniProviderResultsDetailed}. Never throws on per-CID
+ * failures; always resolves to an {@link IpniValidationOutcome}.
+ *
+ * `onRetryUpdate` receives one entry per started attempt so the throwing
+ * wrapper can surface `retryUpdate` progress events. The detailed wrapper
+ * passes nothing: the walk stays event-free.
+ */
+async function runIpniValidationWalk(
+  ipfsRootCid: CID,
+  options: IpniValidationCoreOptions | undefined,
+  onRetryUpdate?: (data: IpniRetryUpdateData) => void
 ): Promise<IpniValidationOutcome> {
   const delayMs = options?.delayMs ?? 5000
   const maxAttempts = options?.maxAttempts ?? 20
@@ -272,10 +308,14 @@ export async function waitForIpniProviderResultsDetailed(
       hasProviderExpectations,
       cidIndex: index + 1,
       cidCount: cidsToValidate.length,
-      totalAttempts,
-      onRetryUpdate: () => {
+      onRetryUpdate: (data) => {
         totalChecks++
-        return { retryCount: totalChecks - 1, attempt: totalChecks }
+        onRetryUpdate?.({
+          retryCount: totalChecks - 1,
+          attempt: totalChecks,
+          totalAttempts,
+          ...data,
+        })
       },
       options,
     })
@@ -317,9 +357,8 @@ interface ValidateOneCidConfig {
   hasProviderExpectations: boolean
   cidIndex: number
   cidCount: number
-  totalAttempts: number
-  onRetryUpdate: (() => { retryCount: number; attempt: number }) | undefined
-  options: WaitForIpniProviderResultsOptions | undefined
+  onRetryUpdate: ((data: Omit<IpniRetryUpdateData, 'retryCount' | 'attempt' | 'totalAttempts'>) => void) | undefined
+  options: IpniValidationCoreOptions | undefined
 }
 
 async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<CidValidationResult> {
@@ -332,7 +371,6 @@ async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<C
     hasProviderExpectations,
     cidIndex,
     cidCount,
-    totalAttempts,
     onRetryUpdate,
     options,
   } = config
@@ -344,7 +382,7 @@ async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<C
 
   while (true) {
     if (options?.signal?.aborted) {
-      return { verified: false, reason: { type: 'aborted', attempts: retryCount }, attempts: retryCount }
+      return { verified: false, reason: abortedReason(options?.signal, retryCount), attempts: retryCount }
     }
 
     options?.logger?.info(
@@ -353,20 +391,13 @@ async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<C
       cid.toString()
     )
 
-    const emittedRetryMetadata = onRetryUpdate?.()
     try {
-      options?.onProgress?.({
-        type: 'ipniProviderResults:retryUpdate',
-        data: {
-          retryCount: emittedRetryMetadata?.retryCount ?? retryCount,
-          attempt: emittedRetryMetadata?.attempt ?? retryCount + 1,
-          totalAttempts,
-          cid,
-          cidIndex,
-          cidCount,
-          cidAttempt: retryCount + 1,
-          cidMaxAttempts: maxAttempts,
-        },
+      onRetryUpdate?.({
+        cid,
+        cidIndex,
+        cidCount,
+        cidAttempt: retryCount + 1,
+        cidMaxAttempts: maxAttempts,
       })
     } catch (error) {
       options?.logger?.warn({ error }, 'Error in consumer onProgress callback for retryUpdate event')
@@ -384,7 +415,7 @@ async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<C
       response = await fetch(`${ipniIndexerUrl}/cid/${cid}`, fetchOptions)
     } catch (fetchError) {
       if (options?.signal?.aborted) {
-        return { verified: false, reason: { type: 'aborted', attempts: retryCount + 1 }, attempts: retryCount + 1 }
+        return { verified: false, reason: abortedReason(options?.signal, retryCount + 1), attempts: retryCount + 1 }
       }
       lastActualMultiaddrs = new Set()
       lastActualUris = new Set()
@@ -406,7 +437,7 @@ async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<C
         // An abort can interrupt body consumption after headers arrive, which
         // rejects response.json(); classify it as aborted, not parse.
         if (options?.signal?.aborted) {
-          return { verified: false, reason: { type: 'aborted', attempts: retryCount + 1 }, attempts: retryCount + 1 }
+          return { verified: false, reason: abortedReason(options?.signal, retryCount + 1), attempts: retryCount + 1 }
         }
         lastActualMultiaddrs = new Set()
         lastActualUris = new Set()
@@ -493,7 +524,7 @@ async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<C
       try {
         await abortableDelay(delayMs, options?.signal)
       } catch {
-        return { verified: false, reason: { type: 'aborted', attempts: retryCount }, attempts: retryCount }
+        return { verified: false, reason: abortedReason(options?.signal, retryCount), attempts: retryCount }
       }
       continue
     }
@@ -509,6 +540,38 @@ async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<C
     }
     return { verified: false, reason: finalReason, attempts: retryCount }
   }
+}
+
+/**
+ * Build the `aborted` failure reason for a signal that is currently aborted.
+ *
+ * `signal.reason` is carried when it adds information beyond "this was
+ * aborted" — e.g. `AbortSignal.timeout(...)` reasons (`TimeoutError`:
+ * "signal timed out") or a caller-supplied `controller.abort('why')`. A
+ * plain `controller.abort()` sets `reason` to the default `AbortError`
+ * DOMException, which duplicates the `type: 'aborted'` discriminator and
+ * is omitted.
+ */
+function abortedReason(signal: AbortSignal | undefined, attempts: number): IpniFailureReason {
+  const message = signalAbortMessage(signal)
+  if (message != null) {
+    return { type: 'aborted', attempts, reason: message }
+  }
+  return { type: 'aborted', attempts }
+}
+
+function signalAbortMessage(signal: AbortSignal | undefined): string | undefined {
+  if (signal == null || !signal.aborted) {
+    return undefined
+  }
+  const reason = signal.reason
+  if (reason == null) {
+    return undefined
+  }
+  if (reason instanceof DOMException && reason.name === 'AbortError') {
+    return undefined
+  }
+  return getErrorMessage(reason)
 }
 
 /**
@@ -561,7 +624,10 @@ function buildOutcomeError(
   }
 
   if (firstFailure.reason.type === 'aborted') {
-    return new Error('Check IPNI announce aborted', { cause: outcome })
+    const why = firstFailure.reason.reason
+    return new Error(why != null ? `Check IPNI announce aborted: ${why}` : 'Check IPNI announce aborted', {
+      cause: outcome,
+    })
   }
 
   const expectedProviders = options?.expectedProviders?.filter((p) => p != null) ?? []

--- a/src/core/utils/validate-ipni-advertisement.ts
+++ b/src/core/utils/validate-ipni-advertisement.ts
@@ -403,6 +403,11 @@ async function validateOneCid(cid: CID, config: ValidateOneCidConfig): Promise<C
         lastActualUris = new Set(rawAddrs.map(multiaddrToNormalizedUri))
         lastReason = null
       } catch (parseError) {
+        // An abort can interrupt body consumption after headers arrive, which
+        // rejects response.json(); classify it as aborted, not parse.
+        if (options?.signal?.aborted) {
+          return { verified: false, reason: { type: 'aborted', attempts: retryCount + 1 }, attempts: retryCount + 1 }
+        }
         lastActualMultiaddrs = new Set()
         lastActualUris = new Set()
         const message = getErrorMessage(parseError)
@@ -539,8 +544,10 @@ function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
  * the structured outcome attached as `cause` so consumers that want per-CID
  * detail can read `error.cause`.
  *
- * The message format is part of the function's contract: callers and tests
- * pattern-match on it, so change it deliberately or not at all.
+ * The message prefix (`IPFS CID "..." does not have expected IPNI
+ * ProviderResults after N attempts`) and the expected-serviceURLs suffix are
+ * contractual: callers and tests pattern-match on them. The `Last
+ * observation:` tail is best-effort diagnostic prose and may change.
  */
 function buildOutcomeError(
   outcome: IpniValidationOutcome,

--- a/src/index-types.ts
+++ b/src/index-types.ts
@@ -50,6 +50,10 @@ export type {
 } from './core/upload/index.js'
 export type { AnyProgressEvent, ProgressEvent, ProgressEventHandler, Warning } from './core/utils/types.js'
 export type {
+  IpniFailedEntry,
+  IpniFailureReason,
+  IpniValidationOutcome,
+  IpniVerifiedEntry,
   ValidateIPNIProgressEvents,
   WaitForIpniProviderResultsOptions,
 } from './core/utils/validate-ipni-advertisement.js'

--- a/src/index-types.ts
+++ b/src/index-types.ts
@@ -51,6 +51,10 @@ export type {
 } from './core/upload/index.js'
 export type { AnyProgressEvent, ProgressEvent, ProgressEventHandler, Warning } from './core/utils/types.js'
 export type {
+  IpniFailedEntry,
+  IpniFailureReason,
+  IpniValidationOutcome,
+  IpniVerifiedEntry,
   ValidateIPNIProgressEvents,
   WaitForIpniProviderResultsOptions,
 } from './core/utils/validate-ipni-advertisement.js'

--- a/src/index-types.ts
+++ b/src/index-types.ts
@@ -53,6 +53,8 @@ export type { AnyProgressEvent, ProgressEvent, ProgressEventHandler, Warning } f
 export type {
   IpniFailedEntry,
   IpniFailureReason,
+  IpniRetryUpdateData,
+  IpniValidationCoreOptions,
   IpniValidationOutcome,
   IpniVerifiedEntry,
   ValidateIPNIProgressEvents,

--- a/src/test/unit/validate-ipni-advertisement.test.ts
+++ b/src/test/unit/validate-ipni-advertisement.test.ts
@@ -1,7 +1,11 @@
 import type { PDPProvider } from '@filoz/synapse-sdk'
 import { CID } from 'multiformats/cid'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { waitForIpniProviderResults } from '../../core/utils/validate-ipni-advertisement.js'
+import {
+  type IpniValidationOutcome,
+  waitForIpniProviderResults,
+  waitForIpniProviderResultsDetailed,
+} from '../../core/utils/validate-ipni-advertisement.js'
 
 describe('waitForIpniProviderResults', () => {
   const testCid = CID.parse('bafkreia5fn4rmshmb7cl7fufkpcw733b5anhuhydtqstnglpkzosqln5kq')
@@ -603,6 +607,149 @@ describe('waitForIpniProviderResults', () => {
 
       await vi.runAllTimersAsync()
       await expectPromise
+    })
+
+    it('should expose per-CID outcome via Error.cause on failure (issue #417)', async () => {
+      const childCid = CID.parse('bafkreia7wx2ue2r5x2bwsxns2r4jtrsu7dzw2r3abjtw3obqckm3w2b2mu')
+      // root verifies, child fails with http
+      mockFetch
+        .mockResolvedValueOnce(successResponse())
+        .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' })
+
+      const promise = waitForIpniProviderResults(testCid, { childBlocks: [childCid], maxAttempts: 1 })
+      let caught: Error | undefined
+      promise.catch((e) => {
+        caught = e
+      })
+      await vi.runAllTimersAsync()
+      await promise.catch(() => undefined)
+
+      expect(caught).toBeInstanceOf(Error)
+      const outcome = caught?.cause as IpniValidationOutcome
+      expect(outcome.success).toBe(false)
+      expect(outcome.verified).toHaveLength(1)
+      expect(outcome.verified[0]?.cid.toString()).toBe(testCid.toString())
+      expect(outcome.failed).toHaveLength(1)
+      expect(outcome.failed[0]?.cid.toString()).toBe(childCid.toString())
+      expect(outcome.failed[0]?.reason.type).toBe('http')
+    })
+
+    describe('detailed outcome (issue #417)', () => {
+      it('returns success outcome for single-CID success', async () => {
+        mockFetch.mockResolvedValueOnce(successResponse())
+        const promise = waitForIpniProviderResultsDetailed(testCid)
+        await vi.runAllTimersAsync()
+        const outcome = await promise
+
+        expect(outcome.success).toBe(true)
+        expect(outcome.verified).toEqual([{ cid: testCid, attempts: 1 }])
+        expect(outcome.failed).toEqual([])
+        expect(outcome.ipniIndexerUrl).toBe(defaultIndexerUrl)
+      })
+
+      it('returns partial verification: some CIDs verified before a failed one', async () => {
+        const childCid1 = CID.parse('bafkreia7wx2ue2r5x2bwsxns2r4jtrsu7dzw2r3abjtw3obqckm3w2b2mu')
+        const childCid2 = CID.parse('bafkreidm5pjnb6q4mwkj7s7g6kfjs5hr2ql6grnq2qg5fbq5cppxnpzqle')
+        mockFetch
+          .mockResolvedValueOnce(successResponse()) // root ✓
+          .mockResolvedValueOnce(emptyProviderResponse()) // child1 ✗
+
+        const promise = waitForIpniProviderResultsDetailed(testCid, {
+          childBlocks: [childCid1, childCid2],
+          maxAttempts: 1,
+        })
+        await vi.runAllTimersAsync()
+        const outcome = await promise
+
+        expect(outcome.success).toBe(false)
+        expect(outcome.verified.map((v) => v.cid.toString())).toEqual([testCid.toString()])
+        expect(outcome.failed.map((f) => f.cid.toString())).toEqual([childCid1.toString(), childCid2.toString()])
+        expect(outcome.failed[0]?.reason.type).toBe('missingProviders')
+        expect(outcome.failed[1]?.reason.type).toBe('notAttempted')
+      })
+
+      it('returns all-CIDs-missing outcome', async () => {
+        const childCid = CID.parse('bafkreia7wx2ue2r5x2bwsxns2r4jtrsu7dzw2r3abjtw3obqckm3w2b2mu')
+        mockFetch.mockResolvedValue(emptyProviderResponse())
+
+        const promise = waitForIpniProviderResultsDetailed(testCid, {
+          childBlocks: [childCid],
+          maxAttempts: 1,
+        })
+        await vi.runAllTimersAsync()
+        const outcome = await promise
+
+        expect(outcome.success).toBe(false)
+        expect(outcome.verified).toEqual([])
+        expect(outcome.failed).toHaveLength(2)
+        expect(outcome.failed[0]?.reason.type).toBe('missingProviders')
+        expect(outcome.failed[1]?.reason.type).toBe('notAttempted')
+      })
+
+      it('marks aborted-mid-walk CID with reason.type === aborted (signal-aware sleep)', async () => {
+        const childCid = CID.parse('bafkreia7wx2ue2r5x2bwsxns2r4jtrsu7dzw2r3abjtw3obqckm3w2b2mu')
+        const abortController = new AbortController()
+        // root succeeds, child returns ok:false then we abort during the inter-attempt sleep
+        mockFetch.mockResolvedValueOnce(successResponse()).mockResolvedValue({ ok: false })
+
+        const promise = waitForIpniProviderResultsDetailed(testCid, {
+          childBlocks: [childCid],
+          maxAttempts: 5,
+          delayMs: 10_000,
+          signal: abortController.signal,
+        })
+
+        // let root + first child fetch complete
+        await vi.advanceTimersByTimeAsync(0)
+        // child is now sleeping before its retry; abort interrupts the sleep
+        abortController.abort()
+        await vi.runAllTimersAsync()
+        const outcome = await promise
+
+        expect(outcome.success).toBe(false)
+        expect(outcome.verified.map((v) => v.cid.toString())).toEqual([testCid.toString()])
+        const childFail = outcome.failed.find((f) => f.cid.toString() === childCid.toString())
+        expect(childFail?.reason.type).toBe('aborted')
+      })
+
+      it('aborts during inter-attempt sleep without waiting for delayMs (signal-aware)', async () => {
+        const abortController = new AbortController()
+        mockFetch.mockResolvedValue({ ok: false })
+
+        const promise = waitForIpniProviderResultsDetailed(testCid, {
+          maxAttempts: 5,
+          delayMs: 60_000,
+          signal: abortController.signal,
+        })
+
+        // first attempt completes immediately
+        await vi.advanceTimersByTimeAsync(0)
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+
+        // we should now be inside the 60s inter-attempt sleep — abort and verify
+        // we resolve without advancing to delayMs
+        abortController.abort()
+        const outcome = await promise
+
+        expect(outcome.success).toBe(false)
+        expect(outcome.failed[0]?.reason.type).toBe('aborted')
+        // crucially: only one fetch — sleep was interrupted before retry
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+      })
+
+      it('emits ipniProviderResults.outcome event with full per-CID detail', async () => {
+        mockFetch.mockResolvedValueOnce(successResponse())
+        const onProgress = vi.fn()
+        const promise = waitForIpniProviderResults(testCid, { onProgress })
+        await vi.runAllTimersAsync()
+        await promise
+
+        const outcomeEvents = onProgress.mock.calls.filter(([e]) => e.type === 'ipniProviderResults.outcome')
+        expect(outcomeEvents).toHaveLength(1)
+        const outcome = outcomeEvents[0]?.[0].data.outcome as IpniValidationOutcome
+        expect(outcome.success).toBe(true)
+        expect(outcome.verified).toHaveLength(1)
+      })
     })
 
     it('should use custom IPNI indexer URL when provided', async () => {

--- a/src/test/unit/validate-ipni-advertisement.test.ts
+++ b/src/test/unit/validate-ipni-advertisement.test.ts
@@ -737,6 +737,25 @@ describe('waitForIpniProviderResults', () => {
         expect(mockFetch).toHaveBeenCalledTimes(1)
       })
 
+      it('attaches outcome via Error.cause on aborted failure (consistent with other failures)', async () => {
+        const abortController = new AbortController()
+        abortController.abort()
+
+        const promise = waitForIpniProviderResults(testCid, { signal: abortController.signal })
+        let caught: Error | undefined
+        promise.catch((e) => {
+          caught = e
+        })
+        await vi.runAllTimersAsync()
+        await promise.catch(() => undefined)
+
+        expect(caught).toBeInstanceOf(Error)
+        const cause = caught?.cause as IpniValidationOutcome
+        expect(cause).toBeDefined()
+        expect(cause.success).toBe(false)
+        expect(cause.failed[0]?.reason.type).toBe('aborted')
+      })
+
       it('emits ipniProviderResults.outcome event with full per-CID detail', async () => {
         mockFetch.mockResolvedValueOnce(successResponse())
         const onProgress = vi.fn()

--- a/src/test/unit/validate-ipni-advertisement.test.ts
+++ b/src/test/unit/validate-ipni-advertisement.test.ts
@@ -712,6 +712,69 @@ describe('waitForIpniProviderResults', () => {
         expect(childFail?.reason.type).toBe('aborted')
       })
 
+      it('carries a TimeoutError abort reason on aborted failures (AbortSignal.timeout-style)', async () => {
+        const abortController = new AbortController()
+        mockFetch.mockResolvedValue({ ok: false })
+
+        const promise = waitForIpniProviderResultsDetailed(testCid, {
+          maxAttempts: 5,
+          delayMs: 60_000,
+          signal: abortController.signal,
+        })
+
+        // first attempt completes; we are sleeping when the timeout fires
+        await vi.advanceTimersByTimeAsync(0)
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+        // abort with the same DOMException shape AbortSignal.timeout produces
+        abortController.abort(new DOMException('signal timed out', 'TimeoutError'))
+        const outcome = await promise
+
+        expect(outcome.success).toBe(false)
+        const abortedEntry = outcome.failed.find((f) => f.reason.type === 'aborted')
+        expect(abortedEntry?.reason.type).toBe('aborted')
+        if (abortedEntry?.reason.type === 'aborted') {
+          expect(abortedEntry.reason.reason).toBe('signal timed out')
+        }
+      })
+
+      it('carries a caller-supplied abort reason on aborted failures', async () => {
+        const abortController = new AbortController()
+        mockFetch.mockResolvedValue({ ok: false })
+
+        const promise = waitForIpniProviderResultsDetailed(testCid, {
+          maxAttempts: 5,
+          delayMs: 60_000,
+          signal: abortController.signal,
+        })
+        await vi.advanceTimersByTimeAsync(0)
+        abortController.abort('parent deadline exceeded')
+        const outcome = await promise
+
+        expect(outcome.success).toBe(false)
+        expect(outcome.failed[0]?.reason.type).toBe('aborted')
+        if (outcome.failed[0]?.reason.type === 'aborted') {
+          expect(outcome.failed[0].reason.reason).toBe('parent deadline exceeded')
+        }
+      })
+
+      it('omits the reason for a plain abort() (default AbortError adds no information)', async () => {
+        const abortController = new AbortController()
+        abortController.abort()
+
+        const promise = waitForIpniProviderResultsDetailed(testCid, {
+          maxAttempts: 1,
+          signal: abortController.signal,
+        })
+        await vi.runAllTimersAsync()
+        const outcome = await promise
+
+        expect(outcome.success).toBe(false)
+        expect(outcome.failed[0]?.reason.type).toBe('aborted')
+        if (outcome.failed[0]?.reason.type === 'aborted') {
+          expect(outcome.failed[0].reason.reason).toBeUndefined()
+        }
+      })
+
       it('aborts during inter-attempt sleep without waiting for delayMs (signal-aware)', async () => {
         const abortController = new AbortController()
         mockFetch.mockResolvedValue({ ok: false })
@@ -737,6 +800,22 @@ describe('waitForIpniProviderResults', () => {
         expect(mockFetch).toHaveBeenCalledTimes(1)
       })
 
+      it('includes the abort reason in the thrown error message when one is present', async () => {
+        const abortController = new AbortController()
+        abortController.abort('deadline reached')
+
+        const promise = waitForIpniProviderResults(testCid, { signal: abortController.signal })
+        let caught: Error | undefined
+        promise.catch((e) => {
+          caught = e
+        })
+        await vi.runAllTimersAsync()
+        await promise.catch(() => undefined)
+
+        expect(caught).toBeInstanceOf(Error)
+        expect(caught?.message).toBe('Check IPNI announce aborted: deadline reached')
+      })
+
       it('attaches outcome via Error.cause on aborted failure (consistent with other failures)', async () => {
         const abortController = new AbortController()
         abortController.abort()
@@ -754,6 +833,38 @@ describe('waitForIpniProviderResults', () => {
         expect(cause).toBeDefined()
         expect(cause.success).toBe(false)
         expect(cause.failed[0]?.reason.type).toBe('aborted')
+      })
+
+      it('emits ipniProviderResults:retryUpdate events from the wrapper while walking', async () => {
+        const childCid = CID.parse('bafkreia7wx2ue2r5x2bwsxns2r4jtrsu7dzw2r3abjtw3obqckm3w2b2mu')
+        // root succeeds, child fails with ok:false on every attempt
+        mockFetch.mockResolvedValueOnce(successResponse()).mockResolvedValue({ ok: false })
+
+        const onProgress = vi.fn()
+        const promise = waitForIpniProviderResults(testCid, {
+          childBlocks: [childCid],
+          maxAttempts: 3,
+          delayMs: 1000,
+          onProgress,
+        })
+        // attach the rejection handler before advancing timers so the
+        // rejection is never unhandled
+        const rejection = expect(promise).rejects.toThrow('does not have expected IPNI ProviderResults')
+        await vi.runAllTimersAsync()
+        await rejection
+
+        const retries = onProgress.mock.calls.filter(([e]) => e.type === 'ipniProviderResults:retryUpdate')
+        // root (1 attempt) + child (3 attempts)
+        expect(retries.map(([e]) => e.data.cid.toString())).toEqual([
+          testCid.toString(),
+          childCid.toString(),
+          childCid.toString(),
+          childCid.toString(),
+        ])
+        const childRetries = retries.filter(([e]) => e.data.cid.toString() === childCid.toString())
+        expect(childRetries.map(([e]) => e.data.cidAttempt)).toEqual([1, 2, 3])
+        expect(childRetries.map(([e]) => e.data.cidMaxAttempts)).toEqual([3, 3, 3])
+        expect(retries.map(([e]) => e.data.attempt).sort((a, b) => a - b)).toEqual([1, 2, 3, 4])
       })
 
       it('emits ipniProviderResults:outcome event with full per-CID detail', async () => {

--- a/src/test/unit/validate-ipni-advertisement.test.ts
+++ b/src/test/unit/validate-ipni-advertisement.test.ts
@@ -651,8 +651,8 @@ describe('waitForIpniProviderResults', () => {
         const childCid1 = CID.parse('bafkreia7wx2ue2r5x2bwsxns2r4jtrsu7dzw2r3abjtw3obqckm3w2b2mu')
         const childCid2 = CID.parse('bafkreidm5pjnb6q4mwkj7s7g6kfjs5hr2ql6grnq2qg5fbq5cppxnpzqle')
         mockFetch
-          .mockResolvedValueOnce(successResponse()) // root ✓
-          .mockResolvedValueOnce(emptyProviderResponse()) // child1 ✗
+          .mockResolvedValueOnce(successResponse()) // root verifies
+          .mockResolvedValueOnce(emptyProviderResponse()) // child1 fails
 
         const promise = waitForIpniProviderResultsDetailed(testCid, {
           childBlocks: [childCid1, childCid2],
@@ -726,14 +726,14 @@ describe('waitForIpniProviderResults', () => {
         await vi.advanceTimersByTimeAsync(0)
         expect(mockFetch).toHaveBeenCalledTimes(1)
 
-        // we should now be inside the 60s inter-attempt sleep — abort and verify
-        // we resolve without advancing to delayMs
+        // now inside the 60s inter-attempt sleep.. abort should resolve
+        // the promise without advancing to delayMs
         abortController.abort()
         const outcome = await promise
 
         expect(outcome.success).toBe(false)
         expect(outcome.failed[0]?.reason.type).toBe('aborted')
-        // crucially: only one fetch — sleep was interrupted before retry
+        // still one fetch: the abort interrupted the sleep before the retry
         expect(mockFetch).toHaveBeenCalledTimes(1)
       })
 

--- a/src/test/unit/validate-ipni-advertisement.test.ts
+++ b/src/test/unit/validate-ipni-advertisement.test.ts
@@ -1,7 +1,11 @@
 import type { PDPProvider } from '@filoz/synapse-sdk'
 import { CID } from 'multiformats/cid'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { waitForIpniProviderResults } from '../../core/utils/validate-ipni-advertisement.js'
+import {
+  type IpniValidationOutcome,
+  waitForIpniProviderResults,
+  waitForIpniProviderResultsDetailed,
+} from '../../core/utils/validate-ipni-advertisement.js'
 
 describe('waitForIpniProviderResults', () => {
   const testCid = CID.parse('bafkreia5fn4rmshmb7cl7fufkpcw733b5anhuhydtqstnglpkzosqln5kq')
@@ -603,6 +607,149 @@ describe('waitForIpniProviderResults', () => {
 
       await vi.runAllTimersAsync()
       await expectPromise
+    })
+
+    it('should expose per-CID outcome via Error.cause on failure (issue #417)', async () => {
+      const childCid = CID.parse('bafkreia7wx2ue2r5x2bwsxns2r4jtrsu7dzw2r3abjtw3obqckm3w2b2mu')
+      // root verifies, child fails with http
+      mockFetch
+        .mockResolvedValueOnce(successResponse())
+        .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' })
+
+      const promise = waitForIpniProviderResults(testCid, { childBlocks: [childCid], maxAttempts: 1 })
+      let caught: Error | undefined
+      promise.catch((e) => {
+        caught = e
+      })
+      await vi.runAllTimersAsync()
+      await promise.catch(() => undefined)
+
+      expect(caught).toBeInstanceOf(Error)
+      const outcome = caught?.cause as IpniValidationOutcome
+      expect(outcome.success).toBe(false)
+      expect(outcome.verified).toHaveLength(1)
+      expect(outcome.verified[0]?.cid.toString()).toBe(testCid.toString())
+      expect(outcome.failed).toHaveLength(1)
+      expect(outcome.failed[0]?.cid.toString()).toBe(childCid.toString())
+      expect(outcome.failed[0]?.reason.type).toBe('http')
+    })
+
+    describe('detailed outcome (issue #417)', () => {
+      it('returns success outcome for single-CID success', async () => {
+        mockFetch.mockResolvedValueOnce(successResponse())
+        const promise = waitForIpniProviderResultsDetailed(testCid)
+        await vi.runAllTimersAsync()
+        const outcome = await promise
+
+        expect(outcome.success).toBe(true)
+        expect(outcome.verified).toEqual([{ cid: testCid, attempts: 1 }])
+        expect(outcome.failed).toEqual([])
+        expect(outcome.ipniIndexerUrl).toBe(defaultIndexerUrl)
+      })
+
+      it('returns partial verification: some CIDs verified before a failed one', async () => {
+        const childCid1 = CID.parse('bafkreia7wx2ue2r5x2bwsxns2r4jtrsu7dzw2r3abjtw3obqckm3w2b2mu')
+        const childCid2 = CID.parse('bafkreidm5pjnb6q4mwkj7s7g6kfjs5hr2ql6grnq2qg5fbq5cppxnpzqle')
+        mockFetch
+          .mockResolvedValueOnce(successResponse()) // root ✓
+          .mockResolvedValueOnce(emptyProviderResponse()) // child1 ✗
+
+        const promise = waitForIpniProviderResultsDetailed(testCid, {
+          childBlocks: [childCid1, childCid2],
+          maxAttempts: 1,
+        })
+        await vi.runAllTimersAsync()
+        const outcome = await promise
+
+        expect(outcome.success).toBe(false)
+        expect(outcome.verified.map((v) => v.cid.toString())).toEqual([testCid.toString()])
+        expect(outcome.failed.map((f) => f.cid.toString())).toEqual([childCid1.toString(), childCid2.toString()])
+        expect(outcome.failed[0]?.reason.type).toBe('missingProviders')
+        expect(outcome.failed[1]?.reason.type).toBe('notAttempted')
+      })
+
+      it('returns all-CIDs-missing outcome', async () => {
+        const childCid = CID.parse('bafkreia7wx2ue2r5x2bwsxns2r4jtrsu7dzw2r3abjtw3obqckm3w2b2mu')
+        mockFetch.mockResolvedValue(emptyProviderResponse())
+
+        const promise = waitForIpniProviderResultsDetailed(testCid, {
+          childBlocks: [childCid],
+          maxAttempts: 1,
+        })
+        await vi.runAllTimersAsync()
+        const outcome = await promise
+
+        expect(outcome.success).toBe(false)
+        expect(outcome.verified).toEqual([])
+        expect(outcome.failed).toHaveLength(2)
+        expect(outcome.failed[0]?.reason.type).toBe('missingProviders')
+        expect(outcome.failed[1]?.reason.type).toBe('notAttempted')
+      })
+
+      it('marks aborted-mid-walk CID with reason.type === aborted (signal-aware sleep)', async () => {
+        const childCid = CID.parse('bafkreia7wx2ue2r5x2bwsxns2r4jtrsu7dzw2r3abjtw3obqckm3w2b2mu')
+        const abortController = new AbortController()
+        // root succeeds, child returns ok:false then we abort during the inter-attempt sleep
+        mockFetch.mockResolvedValueOnce(successResponse()).mockResolvedValue({ ok: false })
+
+        const promise = waitForIpniProviderResultsDetailed(testCid, {
+          childBlocks: [childCid],
+          maxAttempts: 5,
+          delayMs: 10_000,
+          signal: abortController.signal,
+        })
+
+        // let root + first child fetch complete
+        await vi.advanceTimersByTimeAsync(0)
+        // child is now sleeping before its retry; abort interrupts the sleep
+        abortController.abort()
+        await vi.runAllTimersAsync()
+        const outcome = await promise
+
+        expect(outcome.success).toBe(false)
+        expect(outcome.verified.map((v) => v.cid.toString())).toEqual([testCid.toString()])
+        const childFail = outcome.failed.find((f) => f.cid.toString() === childCid.toString())
+        expect(childFail?.reason.type).toBe('aborted')
+      })
+
+      it('aborts during inter-attempt sleep without waiting for delayMs (signal-aware)', async () => {
+        const abortController = new AbortController()
+        mockFetch.mockResolvedValue({ ok: false })
+
+        const promise = waitForIpniProviderResultsDetailed(testCid, {
+          maxAttempts: 5,
+          delayMs: 60_000,
+          signal: abortController.signal,
+        })
+
+        // first attempt completes immediately
+        await vi.advanceTimersByTimeAsync(0)
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+
+        // we should now be inside the 60s inter-attempt sleep — abort and verify
+        // we resolve without advancing to delayMs
+        abortController.abort()
+        const outcome = await promise
+
+        expect(outcome.success).toBe(false)
+        expect(outcome.failed[0]?.reason.type).toBe('aborted')
+        // crucially: only one fetch — sleep was interrupted before retry
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+      })
+
+      it('emits ipniProviderResults:outcome event with full per-CID detail', async () => {
+        mockFetch.mockResolvedValueOnce(successResponse())
+        const onProgress = vi.fn()
+        const promise = waitForIpniProviderResults(testCid, { onProgress })
+        await vi.runAllTimersAsync()
+        await promise
+
+        const outcomeEvents = onProgress.mock.calls.filter(([e]) => e.type === 'ipniProviderResults:outcome')
+        expect(outcomeEvents).toHaveLength(1)
+        const outcome = outcomeEvents[0]?.[0].data.outcome as IpniValidationOutcome
+        expect(outcome.success).toBe(true)
+        expect(outcome.verified).toHaveLength(1)
+      })
     })
 
     it('should use custom IPNI indexer URL when provided', async () => {

--- a/src/test/unit/validate-ipni-advertisement.test.ts
+++ b/src/test/unit/validate-ipni-advertisement.test.ts
@@ -769,6 +769,43 @@ describe('waitForIpniProviderResults', () => {
         expect(outcome.success).toBe(true)
         expect(outcome.verified).toHaveLength(1)
       })
+
+      it('emits outcome before failed on the failure path', async () => {
+        mockFetch.mockResolvedValue(emptyProviderResponse())
+        const onProgress = vi.fn()
+        const promise = waitForIpniProviderResults(testCid, { maxAttempts: 1, onProgress })
+        await vi.runAllTimersAsync()
+        await expect(promise).rejects.toThrow('does not have expected IPNI ProviderResults')
+
+        const types = onProgress.mock.calls.map(([e]) => e.type)
+        const outcomeIndex = types.indexOf('ipniProviderResults:outcome')
+        const failedIndex = types.indexOf('ipniProviderResults:failed')
+        expect(outcomeIndex).toBeGreaterThanOrEqual(0)
+        expect(failedIndex).toBeGreaterThanOrEqual(0)
+        expect(outcomeIndex).toBeLessThan(failedIndex)
+        expect(types).not.toContain('ipniProviderResults:complete')
+      })
+
+      it('classifies an abort during response body parsing as aborted, not parse', async () => {
+        const abortController = new AbortController()
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn(async () => {
+            abortController.abort()
+            throw new DOMException('The operation was aborted', 'AbortError')
+          }),
+        })
+
+        const promise = waitForIpniProviderResultsDetailed(testCid, {
+          maxAttempts: 1,
+          signal: abortController.signal,
+        })
+        await vi.runAllTimersAsync()
+        const outcome = await promise
+
+        expect(outcome.success).toBe(false)
+        expect(outcome.failed[0]?.reason.type).toBe('aborted')
+      })
     })
 
     it('should use custom IPNI indexer URL when provided', async () => {

--- a/src/test/unit/validate-ipni-advertisement.test.ts
+++ b/src/test/unit/validate-ipni-advertisement.test.ts
@@ -774,8 +774,11 @@ describe('waitForIpniProviderResults', () => {
         mockFetch.mockResolvedValue(emptyProviderResponse())
         const onProgress = vi.fn()
         const promise = waitForIpniProviderResults(testCid, { maxAttempts: 1, onProgress })
+        // attach the rejection handler before advancing timers so the
+        // rejection is never unhandled
+        const rejection = expect(promise).rejects.toThrow('does not have expected IPNI ProviderResults')
         await vi.runAllTimersAsync()
-        await expect(promise).rejects.toThrow('does not have expected IPNI ProviderResults')
+        await rejection
 
         const types = onProgress.mock.calls.map(([e]) => e.type)
         const outcomeIndex = types.indexOf('ipniProviderResults:outcome')

--- a/src/test/unit/validate-ipni-advertisement.test.ts
+++ b/src/test/unit/validate-ipni-advertisement.test.ts
@@ -737,6 +737,25 @@ describe('waitForIpniProviderResults', () => {
         expect(mockFetch).toHaveBeenCalledTimes(1)
       })
 
+      it('attaches outcome via Error.cause on aborted failure (consistent with other failures)', async () => {
+        const abortController = new AbortController()
+        abortController.abort()
+
+        const promise = waitForIpniProviderResults(testCid, { signal: abortController.signal })
+        let caught: Error | undefined
+        promise.catch((e) => {
+          caught = e
+        })
+        await vi.runAllTimersAsync()
+        await promise.catch(() => undefined)
+
+        expect(caught).toBeInstanceOf(Error)
+        const cause = caught?.cause as IpniValidationOutcome
+        expect(cause).toBeDefined()
+        expect(cause.success).toBe(false)
+        expect(cause.failed[0]?.reason.type).toBe('aborted')
+      })
+
       it('emits ipniProviderResults:outcome event with full per-CID detail', async () => {
         mockFetch.mockResolvedValueOnce(successResponse())
         const onProgress = vi.fn()


### PR DESCRIPTION
Closes #417.

### What changed

`waitForIpniProviderResults` now exposes a structured `IpniValidationOutcome` (`verified[]` / `failed[]` with a `reason` discriminator: `timeout` / `missingProviders` / `fetch` / `parse` / `http` / `aborted` / `notAttempted`). Existing callers keep the `Promise<boolean>` shape — on failure the outcome is attached to `Error.cause` so the legacy thrown-error path stays intact and tests/messages are unchanged.

New surface:
- `waitForIpniProviderResultsDetailed(cid, opts)` — non-throwing variant that always returns the outcome.
- `ipniProviderResults.outcome` progress event — emitted on every run with the full per-CID detail.
- Inter-attempt sleep is now signal-aware (`abortableDelay`), so an outer `AbortSignal.timeout(...)` interrupts the wait instead of having to ride out `delayMs` until the next fetch.

### How to verify

```
pnpm test
```

New tests cover: single-CID success outcome, partial verification (some CIDs verified before failure), all-CIDs-missing, timeout-mid-walk via abort during sleep, signal-aware sleep (no extra fetch after abort), and `Error.cause` carrying the outcome.

### Notes

- Public type exports added in `src/index-types.ts`: `IpniValidationOutcome`, `IpniFailureReason`, `IpniVerifiedEntry`, `IpniFailedEntry`.
- Walk still stops at the first per-CID failure to preserve existing throw semantics; later CIDs land in `failed` with `reason.type === 'notAttempted'` so consumers can distinguish "never checked" from "checked and failed".