### PR TITLE
fix: stream remaining upload paths and expose upload progress

### DIFF
--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -6,7 +6,8 @@
  */
 
 import { createReadStream } from 'node:fs'
-import { readFile, stat } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
+import { Readable } from 'node:stream'
 import pc from 'picocolors'
 import pino from 'pino'
 import { warnAboutCDNPricingLimitations } from '../common/cdn-warning.js'
@@ -244,11 +245,12 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
 
     spinner.stop(`${pc.green('✓')} ${isDirectory ? 'Directory' : 'File'} packed with root CID: ${rootCid.toString()}`)
 
-    // Read CAR data
-    spinner.start('Loading packed IPFS content ...')
-    const carData = await readFile(tempCarPath)
-    const carSize = carData.length
-    spinner.stop(`${pc.green('✓')} IPFS content loaded (${formatFileSize(carSize)})`)
+    // The CLI still materializes a full CAR on disk first. This only avoids
+    // buffering that CAR again in memory during upload.
+    spinner.start('Inspecting packed IPFS content...')
+    const { size: carSize } = await stat(tempCarPath)
+    const carData = Readable.toWeb(createReadStream(tempCarPath)) as ReadableStream<Uint8Array>
+    spinner.stop(`${pc.green('✓')} Packed IPFS content ready (${formatFileSize(carSize)})`)
 
     const autoFundOptions: Parameters<typeof performAutoFunding>[3] = {
       ...(dataSetMetadata && { metadata: dataSetMetadata }),

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -332,7 +332,7 @@ export async function performUpload(
   rootCid: CID,
   options: UploadFlowOptions
 ): Promise<UploadFlowResult> {
-  const { contextType, logger, spinner, pieceMetadata } = options
+  const { contextType, fileSize, logger, spinner, pieceMetadata } = options
 
   const flow = createSpinnerFlow(spinner)
 
@@ -341,12 +341,23 @@ export async function performUpload(
 
   // Track primary provider ID from `stored` to label subsequent events
   let primaryProviderId: bigint | undefined
+  let lastUploadPercent = -1
 
   function getRole(providerId: bigint): CopyRole {
     if (primaryProviderId == null || providerId === primaryProviderId) {
       return 'primary'
     }
     return 'secondary'
+  }
+
+  function getUploadProgressMessage(bytesUploaded: number): { percent: number; message: string } {
+    const totalBytes = Math.max(fileSize, 1)
+    const uploadedBytes = Math.min(bytesUploaded, totalBytes)
+    const percent = Math.min(100, Math.floor((uploadedBytes / totalBytes) * 100))
+    return {
+      percent,
+      message: `Uploading to Filecoin... ${formatFileSize(uploadedBytes)}/${formatFileSize(fileSize)} (${percent}%)`,
+    }
   }
 
   function getIpniAdvertisementMsg(details: {
@@ -377,6 +388,14 @@ export async function performUpload(
     ...(options.skipIpniVerification && { ipniValidation: { enabled: false } }),
     onProgress(event) {
       switch (event.type) {
+        case 'uploadProgress': {
+          const { percent, message } = getUploadProgressMessage(event.data.bytesUploaded)
+          if (percent > lastUploadPercent) {
+            lastUploadPercent = percent
+            flow.updateOperation('upload', message)
+          }
+          break
+        }
         case 'stored': {
           primaryProviderId = event.data.providerId
           flow.completeOperation('upload', `${roleLabel('primary')} Stored on provider ${event.data.providerId}`, {

--- a/src/core/upload/index.ts
+++ b/src/core/upload/index.ts
@@ -328,7 +328,7 @@ export async function executeUpload(
   const selectedProviders: PDPProvider[] = []
   let ipniValidationPromise: Promise<boolean> | undefined
 
-  const onProgress: ProgressEventHandler<UploadProgressEvents | ValidateIPNIProgressEvents> = (event) => {
+  const emitProgress: ProgressEventHandler<UploadProgressEvents | ValidateIPNIProgressEvents> = (event) => {
     switch (event.type) {
       case 'providerSelected': {
         selectedProviders.push(event.data.provider)
@@ -377,7 +377,7 @@ export async function executeUpload(
   }
 
   const uploadOptions: Parameters<typeof uploadToSynapse>[4] = {
-    onProgress,
+    onProgress: emitProgress,
   }
   if (contextId) {
     uploadOptions.contextId = contextId

--- a/src/core/upload/synapse.ts
+++ b/src/core/upload/synapse.ts
@@ -15,6 +15,7 @@ import { APPLICATION_SOURCE } from '../synapse/constants.js'
 import type { ProgressEvent, ProgressEventHandler } from '../utils/types.js'
 
 export type UploadProgressEvents =
+  | ProgressEvent<'uploadProgress', { bytesUploaded: number }>
   | ProgressEvent<'stored', { providerId: bigint; pieceCid: PieceCID }>
   | ProgressEvent<'piecesAdded', { txHash: Hash; providerId: bigint }>
   | ProgressEvent<'piecesConfirmed', { dataSetId: bigint; providerId: bigint; pieceIds: bigint[] }>
@@ -179,6 +180,18 @@ export async function uploadToSynapse(
     },
 
     callbacks: {
+      onProgress: (bytesUploaded) => {
+        logger.debug(
+          {
+            event: 'synapse.upload.progress',
+            contextId,
+            bytesUploaded,
+          },
+          'Upload progress update'
+        )
+        onProgress?.({ type: 'uploadProgress', data: { bytesUploaded } })
+      },
+
       onProviderSelected: (provider) => {
         logger.info(
           {

--- a/src/filecoin-pin-store.ts
+++ b/src/filecoin-pin-store.ts
@@ -1,6 +1,8 @@
 import { EventEmitter } from 'node:events'
-import { readFile, unlink } from 'node:fs/promises'
+import { createReadStream } from 'node:fs'
+import { unlink } from 'node:fs/promises'
 import { join } from 'node:path'
+import { Readable } from 'node:stream'
 import type { Synapse } from '@filoz/synapse-sdk'
 import type { Helia } from 'helia'
 import type { CID } from 'multiformats/cid'
@@ -305,9 +307,9 @@ export class FilecoinPinStore extends EventEmitter {
       // 3. Track the returned piece information in application state
       // 4. Handle errors gracefully with proper cleanup
       try {
-        // Read the CAR file (streaming not yet supported in Synapse)
-        // TODO: When Synapse supports streaming, this could be optimized
-        const carData = await readFile(pinStatus.filecoin.carFilePath)
+        // The pinning server still writes a full CAR to disk first, but the
+        // upload body no longer buffers that CAR in memory.
+        const carData = Readable.toWeb(createReadStream(pinStatus.filecoin.carFilePath)) as ReadableStream<Uint8Array>
 
         const uploadResult = await uploadToSynapse(this.synapse, carData, cid, this.logger, {
           contextId: pinId,

--- a/src/test/mocks/synapse-mocks.ts
+++ b/src/test/mocks/synapse-mocks.ts
@@ -66,6 +66,9 @@ export class MockStorageContext extends EventEmitter {
     // Simulate callback sequence matching real SDK behavior.
     // StorageManagerUploadOptions nests callbacks under `callbacks`.
     const callbacks = options?.callbacks
+    if (callbacks?.onProgress != null) {
+      callbacks.onProgress(getUploadSize(_data))
+    }
     if (callbacks?.onStored != null) {
       callbacks.onStored(providerId, pieceCid)
     }
@@ -94,6 +97,14 @@ export class MockStorageContext extends EventEmitter {
       failedAttempts: [],
     }
   }
+}
+
+function getUploadSize(data: SynapseUploadData): number {
+  if (data instanceof Uint8Array) {
+    return data.byteLength
+  }
+
+  return 1024
 }
 
 /**

--- a/src/test/unit/add.test.ts
+++ b/src/test/unit/add.test.ts
@@ -14,7 +14,10 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runAdd } from '../../add/add.js'
 
-const { mockFindDataSets } = vi.hoisted(() => ({ mockFindDataSets: vi.fn().mockResolvedValue([]) }))
+const { mockCarPath, mockFindDataSets } = vi.hoisted(() => ({
+  mockCarPath: 'test-add-files/mock.car',
+  mockFindDataSets: vi.fn().mockResolvedValue([]),
+}))
 
 // Mock the external dependencies at module level
 vi.mock('../../common/upload-flow.js', () => ({
@@ -72,7 +75,7 @@ vi.mock('../../core/unixfs/index.js', () => ({
       ? 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
       : 'bafybeihw4ytkqxrq7q7e3p2l5s5di7zjzkhxdmfwvqfylkdamdg3xybpbq'
     return Promise.resolve({
-      carPath: '/tmp/test.car',
+      carPath: mockCarPath,
       rootCid: {
         toString: () => cid,
       },
@@ -94,27 +97,11 @@ vi.mock('../../utils/cli-helpers.js', () => ({
   formatFileSize: vi.fn((size: number) => `${size} bytes`),
 }))
 
-// We need to partially mock fs/promises to keep real file operations for test setup
-// but mock readFile for the CAR reading part
-vi.mock('node:fs/promises', async () => {
-  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
-  return {
-    ...actual,
-    readFile: vi.fn((path: string) => {
-      // If it's reading the temp CAR, return mock data
-      if (path === '/tmp/test.car') {
-        return Promise.resolve(Buffer.from('mock-car-data'))
-      }
-      // Otherwise use real readFile
-      return actual.readFile(path)
-    }),
-  }
-})
-
 // Test CID constants (defined after vi.mock calls due to hoisting)
 const TEST_BARE_CID = 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
 const TEST_DIR_WRAPPED_CID = 'bafybeihw4ytkqxrq7q7e3p2l5s5di7zjzkhxdmfwvqfylkdamdg3xybpbq'
 const TEST_PIECE_CID = 'bafkzcibtest1234567890'
+const TEST_CAR_CONTENT = Buffer.from('mock-car-data')
 
 describe('Add Command', () => {
   const testDir = join(process.cwd(), 'test-add-files')
@@ -126,6 +113,7 @@ describe('Add Command', () => {
     // Create test directory and file
     await mkdir(testDir, { recursive: true })
     await writeFile(testFile, testContent)
+    await writeFile(join(process.cwd(), mockCarPath), TEST_CAR_CONTENT)
   })
 
   afterEach(async () => {
@@ -163,6 +151,12 @@ describe('Add Command', () => {
           // bare is not passed when undefined, due to spread operator
         })
       )
+
+      const { performUpload } = await import('../../common/upload-flow.js')
+      const uploadData = vi.mocked(performUpload).mock.calls[0]?.[1]
+      const uploadOptions = vi.mocked(performUpload).mock.calls[0]?.[3]
+      expect(uploadData).toBeInstanceOf(ReadableStream)
+      expect(uploadOptions?.fileSize).toBe(TEST_CAR_CONTENT.length)
     })
 
     it('should successfully add a file in bare mode when specified', async () => {

--- a/src/test/unit/filecoin-pin-store.unit.test.ts
+++ b/src/test/unit/filecoin-pin-store.unit.test.ts
@@ -1,27 +1,77 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { CID } from 'multiformats/cid'
 import * as raw from 'multiformats/codecs/raw'
 import { sha256 } from 'multiformats/hashes/sha2'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createConfig } from '../../config.js'
 import { FilecoinPinStore } from '../../filecoin-pin-store.js'
 import { createLogger } from '../../logger.js'
+
+const mocks = vi.hoisted(() => ({
+  createPinningHeliaNode: vi.fn(),
+  uploadToSynapse: vi.fn(),
+  unlink: vi.fn().mockResolvedValue(undefined),
+}))
 
 // Minimal mock since unit tests don't test background processing
 const mockSynapse = {} as any
 
 // Mock the heavy dependencies
 vi.mock('../../create-pinning-helia.js', () => ({
-  createPinningHeliaNode: vi.fn().mockResolvedValue({
-    helia: {
+  createPinningHeliaNode: mocks.createPinningHeliaNode,
+}))
+
+vi.mock('../../core/upload/index.js', () => ({
+  uploadToSynapse: mocks.uploadToSynapse,
+}))
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+  return {
+    ...actual,
+    unlink: mocks.unlink,
+  }
+})
+
+describe('FilecoinPinStore (Unit)', () => {
+  let pinStore: FilecoinPinStore
+  let testCID: CID
+  let testUser: any
+  let mockHelia: {
+    pins: { add: ReturnType<typeof vi.fn> }
+    stop: ReturnType<typeof vi.fn>
+    blockstore: { get: ReturnType<typeof vi.fn> }
+  }
+  let mockBlockstore: {
+    on: ReturnType<typeof vi.fn>
+    getStats: ReturnType<typeof vi.fn>
+    finalize: ReturnType<typeof vi.fn>
+    cleanup: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+
+    // Create test data
+    const testBlock = new TextEncoder().encode('Test block')
+    const hash = await sha256.digest(testBlock)
+    testCID = CID.create(1, raw.code, hash)
+    testUser = { id: 'test-user', name: 'Test User' }
+
+    mockHelia = {
       blockstore: {
         get: vi.fn(),
       },
       pins: {
-        add: vi.fn(),
+        add: vi.fn(async function* () {
+          // No pinned blocks are yielded in this unit-test mock.
+        }),
       },
-      stop: vi.fn(),
-    },
-    blockstore: {
+      stop: vi.fn().mockResolvedValue(undefined),
+    }
+
+    mockBlockstore = {
       on: vi.fn(),
       getStats: vi.fn().mockReturnValue({
         blocksWritten: 1,
@@ -37,22 +87,36 @@ vi.mock('../../create-pinning-helia.js', () => ({
         startTime: Date.now(),
         finalized: true,
       }),
-      cleanup: vi.fn(),
-    },
-  }),
-}))
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    }
 
-describe('FilecoinPinStore (Unit)', () => {
-  let pinStore: FilecoinPinStore
-  let testCID: CID
-  let testUser: any
+    await mkdir('./test-output', { recursive: true })
 
-  beforeEach(async () => {
-    // Create test data
-    const testBlock = new TextEncoder().encode('Test block')
-    const hash = await sha256.digest(testBlock)
-    testCID = CID.create(1, raw.code, hash)
-    testUser = { id: 'test-user', name: 'Test User' }
+    mocks.createPinningHeliaNode.mockImplementation(async ({ outputPath }: { outputPath: string }) => {
+      await writeFile(outputPath, new Uint8Array([1, 2, 3]))
+      return {
+        helia: mockHelia,
+        blockstore: mockBlockstore,
+      }
+    })
+
+    mocks.uploadToSynapse.mockResolvedValue({
+      pieceCid: 'bafkzcibtest1234567890',
+      size: 3,
+      requestedCopies: 1,
+      complete: true,
+      copies: [
+        {
+          providerId: 1n,
+          dataSetId: 123n,
+          pieceId: 789n,
+          role: 'primary',
+          retrievalUrl: 'https://provider.example/piece/test',
+          isNewDataSet: false,
+        },
+      ],
+      failedAttempts: [],
+    })
 
     // Create test config
     const config = {
@@ -70,6 +134,13 @@ describe('FilecoinPinStore (Unit)', () => {
     })
 
     await pinStore.start()
+  })
+
+  afterEach(async () => {
+    vi.clearAllTimers()
+    await pinStore.stop()
+    await rm('./test-output', { recursive: true, force: true })
+    vi.useRealTimers()
   })
 
   describe('Pin Operations', () => {
@@ -152,6 +223,54 @@ describe('FilecoinPinStore (Unit)', () => {
     it('should start with empty active pins', () => {
       const stats = pinStore.getActivePinStats()
       expect(stats).toHaveLength(0)
+    })
+
+    it('streams the finalized CAR file into Synapse upload', async () => {
+      vi.useFakeTimers()
+
+      const pinResult = await pinStore.pin(testUser, testCID, { name: 'Streaming Test' })
+
+      await vi.advanceTimersByTimeAsync(100)
+      await vi.waitFor(async () => {
+        expect((await pinStore.get(testUser, pinResult.id))?.status).toBe('pinned')
+      })
+
+      const uploadCall = mocks.uploadToSynapse.mock.calls.find((call) => call[4]?.contextId === pinResult.id)
+      const uploadData = uploadCall?.[1]
+      const finalPin = await pinStore.get(testUser, pinResult.id)
+
+      expect(uploadData).toBeInstanceOf(ReadableStream)
+      expect(uploadCall).toEqual([
+        mockSynapse,
+        expect.any(ReadableStream),
+        testCID,
+        expect.anything(),
+        expect.objectContaining({
+          contextId: pinResult.id,
+        }),
+      ])
+      expect(finalPin?.status).toBe('pinned')
+    })
+
+    it('preserves rollback cleanup when Synapse upload fails', async () => {
+      vi.useFakeTimers()
+      mocks.uploadToSynapse.mockRejectedValueOnce(new Error('upload failed'))
+
+      const pinResult = await pinStore.pin(testUser, testCID, { name: 'Failure Test' })
+
+      await vi.advanceTimersByTimeAsync(100)
+      await vi.waitFor(async () => {
+        expect((await pinStore.get(testUser, pinResult.id))?.status).toBe('failed')
+      })
+
+      const finalPin = await pinStore.get(testUser, pinResult.id)
+      const uploadCall = mocks.uploadToSynapse.mock.calls.find((call) => call[4]?.contextId === pinResult.id)
+
+      expect(finalPin?.status).toBe('failed')
+      expect(uploadCall?.[1]).toBeInstanceOf(ReadableStream)
+      expect(mockBlockstore.cleanup).toHaveBeenCalledTimes(1)
+      expect(mocks.unlink).toHaveBeenCalledWith(expect.stringContaining(`${testCID.toString()}-`))
+      expect(mockHelia.stop).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -214,6 +214,7 @@ describe('synapse-service', () => {
     })
 
     it('should call upload callbacks', async () => {
+      const progressEvents: number[] = []
       let storedCallbackCalled = false
       let piecesAddedCallbackCalled = false
 
@@ -222,6 +223,10 @@ describe('synapse-service', () => {
         contextId: 'pin-789',
         onProgress(event) {
           switch (event.type) {
+            case 'uploadProgress': {
+              progressEvents.push(event.data.bytesUploaded)
+              break
+            }
             case 'stored': {
               storedCallbackCalled = true
               break
@@ -234,8 +239,26 @@ describe('synapse-service', () => {
         },
       })
 
+      expect(progressEvents).toEqual([3])
       expect(storedCallbackCalled).toBe(true)
       expect(piecesAddedCallbackCalled).toBe(true)
+    })
+
+    it('should log byte-level upload progress events', async () => {
+      const debugSpy = vi.spyOn(logger, 'debug')
+      const data = new Uint8Array([1, 2, 3, 4])
+      const contextId = 'pin-progress'
+
+      await uploadToSynapse(mockSynapse as any, data, TEST_CID, logger, { contextId })
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'synapse.upload.progress',
+          contextId,
+          bytesUploaded: 4,
+        }),
+        'Upload progress update'
+      )
     })
 
     it('should throw immediately when signal is already aborted', async () => {

--- a/src/test/unit/upload-action.test.ts
+++ b/src/test/unit/upload-action.test.ts
@@ -170,6 +170,8 @@ describe('upload action Filecoin upload', () => {
 
     logSpy.mockRestore()
 
+    const uploadData = mocks.executeUpload.mock.calls[0]?.[1]
+
     expect(result).toMatchObject({
       dataSetId: '13018',
       pieceId: '0',
@@ -178,6 +180,47 @@ describe('upload action Filecoin upload', () => {
       requestedCopies: 2,
       complete: false,
     })
+    expect(uploadData).toBeInstanceOf(ReadableStream)
+  })
+
+  it('logs byte-level upload progress from executeUpload callbacks', async () => {
+    mocks.executeUpload.mockImplementation(async (_synapse, _data, _cid, options) => {
+      options.onProgress?.({ type: 'uploadProgress', data: { bytesUploaded: 2 } })
+      return {
+        pieceCid: 'bafkzcibe2hzbcd4t6clvsb3mfrezyxl75gl3gzcsqi42dd27gktq4nk75rr62ciuaq',
+        size: 3,
+        requestedCopies: 1,
+        complete: true,
+        copies: [
+          {
+            providerId: 2n,
+            dataSetId: 13018n,
+            pieceId: 1n,
+            role: 'primary',
+            retrievalUrl: 'https://calib2.ezpdpz.net/piece/test',
+            isNewDataSet: false,
+          },
+        ],
+        failedAttempts: [],
+        network: 'calibration',
+        ipniValidated: true,
+      }
+    })
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const { uploadCarToFilecoin } = (await import(filecoinModulePath)) as FilecoinModule
+
+    await uploadCarToFilecoin(
+      {},
+      carPath,
+      TEST_CID,
+      { withCDN: false },
+      { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() }
+    )
+
+    expect(logSpy).toHaveBeenCalledWith('Upload progress: 66% (2.0 B/3.0 B)')
+
+    logSpy.mockRestore()
   })
 })
 

--- a/src/test/unit/upload-flow.test.ts
+++ b/src/test/unit/upload-flow.test.ts
@@ -1,0 +1,127 @@
+import { CID } from 'multiformats/cid'
+import { describe, expect, it, vi } from 'vitest'
+import { performUpload } from '../../common/upload-flow.js'
+import { createLogger } from '../../logger.js'
+
+const mocks = vi.hoisted(() => ({
+  executeUpload: vi.fn(),
+}))
+
+vi.mock('../../core/upload/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../../core/upload/index.js')>('../../core/upload/index.js')
+  return {
+    ...actual,
+    executeUpload: mocks.executeUpload,
+  }
+})
+
+const TEST_CID = CID.parse('bafkreia5fn4rmshmb7cl7fufkpcw733b5anhuhydtqstnglpkzosqln5kq')
+
+describe('performUpload', () => {
+  it('updates the spinner with byte-level upload progress', async () => {
+    const spinner = {
+      start: vi.fn(),
+      message: vi.fn(),
+      stop: vi.fn(),
+      clear: vi.fn(),
+    }
+
+    mocks.executeUpload.mockImplementation(async (_synapse, _data, _rootCid, options) => {
+      options.onProgress?.({ type: 'uploadProgress', data: { bytesUploaded: 2 } })
+      options.onProgress?.({
+        type: 'stored',
+        data: {
+          providerId: 1n,
+          pieceCid: 'bafkzcibtest123',
+        },
+      })
+
+      return {
+        pieceCid: 'bafkzcibtest123',
+        size: 4,
+        requestedCopies: 1,
+        complete: true,
+        copies: [
+          {
+            providerId: 1n,
+            dataSetId: 123n,
+            pieceId: 456n,
+            role: 'primary',
+            retrievalUrl: 'https://provider.example/piece/test',
+            isNewDataSet: false,
+          },
+        ],
+        failedAttempts: [],
+        network: 'calibration',
+      }
+    })
+
+    await performUpload({ chain: { id: 314159, name: 'calibration' } } as any, new Uint8Array([1, 2, 3, 4]), TEST_CID, {
+      contextType: 'add',
+      fileSize: 4,
+      logger: createLogger({ logLevel: 'info' }),
+      spinner,
+      skipIpniVerification: true,
+    })
+
+    expect(spinner.start).toHaveBeenCalledWith('Uploading to Filecoin...')
+    expect(spinner.message).toHaveBeenCalledWith('Uploading to Filecoin... 2.0 B/4.0 B (50%)')
+    expect(spinner.stop).toHaveBeenCalledWith(expect.stringContaining('Stored on provider 1'))
+  })
+
+  it('deduplicates spinner updates for unchanged and clamped upload percentages', async () => {
+    const spinner = {
+      start: vi.fn(),
+      message: vi.fn(),
+      stop: vi.fn(),
+      clear: vi.fn(),
+    }
+
+    mocks.executeUpload.mockImplementation(async (_synapse, _data, _rootCid, options) => {
+      options.onProgress?.({ type: 'uploadProgress', data: { bytesUploaded: 1 } })
+      options.onProgress?.({ type: 'uploadProgress', data: { bytesUploaded: 1 } })
+      options.onProgress?.({ type: 'uploadProgress', data: { bytesUploaded: 2 } })
+      options.onProgress?.({ type: 'uploadProgress', data: { bytesUploaded: 4 } })
+      options.onProgress?.({ type: 'uploadProgress', data: { bytesUploaded: 8 } })
+      options.onProgress?.({
+        type: 'stored',
+        data: {
+          providerId: 1n,
+          pieceCid: 'bafkzcibtest123',
+        },
+      })
+
+      return {
+        pieceCid: 'bafkzcibtest123',
+        size: 4,
+        requestedCopies: 1,
+        complete: true,
+        copies: [
+          {
+            providerId: 1n,
+            dataSetId: 123n,
+            pieceId: 456n,
+            role: 'primary',
+            retrievalUrl: 'https://provider.example/piece/test',
+            isNewDataSet: false,
+          },
+        ],
+        failedAttempts: [],
+        network: 'calibration',
+      }
+    })
+
+    await performUpload({ chain: { id: 314159, name: 'calibration' } } as any, new Uint8Array([1, 2, 3, 4]), TEST_CID, {
+      contextType: 'add',
+      fileSize: 4,
+      logger: createLogger({ logLevel: 'info' }),
+      spinner,
+      skipIpniVerification: true,
+    })
+
+    expect(spinner.message).toHaveBeenCalledTimes(3)
+    expect(spinner.message).toHaveBeenNthCalledWith(1, 'Uploading to Filecoin... 1.0 B/4.0 B (25%)')
+    expect(spinner.message).toHaveBeenNthCalledWith(2, 'Uploading to Filecoin... 2.0 B/4.0 B (50%)')
+    expect(spinner.message).toHaveBeenNthCalledWith(3, 'Uploading to Filecoin... 4.0 B/4.0 B (100%)')
+  })
+})

--- a/upload-action/src/filecoin.js
+++ b/upload-action/src/filecoin.js
@@ -1,4 +1,5 @@
 import { createReadStream, promises as fs } from 'node:fs'
+import { Readable } from 'node:stream'
 import { CarReader } from '@ipld/car'
 import {
   calculateFilecoinPayFundingPlan,
@@ -180,6 +181,24 @@ export async function handlePayments(synapse, options, logger) {
 }
 
 /**
+ * Format byte counts for upload progress logs.
+ * @param {number} bytes
+ * @returns {string}
+ */
+function formatProgressSize(bytes) {
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']
+  let size = bytes
+  let unitIndex = 0
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex++
+  }
+
+  return `${size.toFixed(1)} ${units[unitIndex]}`
+}
+
+/**
  * Upload CAR to Filecoin using core upload functionality
  * @param {Synapse} synapse - Synapse instance
  * @param {string} carPath - Path to CAR file
@@ -189,8 +208,10 @@ export async function handlePayments(synapse, options, logger) {
  * @returns {Promise<UploadResult>} Upload result
  */
 export async function uploadCarToFilecoin(synapse, carPath, ipfsRootCid, options, logger) {
-  const carBytes = await fs.readFile(carPath)
+  const { size } = await fs.stat(carPath)
+  const carData = /** @type {ReadableStream<Uint8Array>} */ (Readable.toWeb(createReadStream(carPath)))
   const cid = CID.parse(ipfsRootCid)
+  let lastProgressBucket = -1
 
   /** @type {bigint[] | undefined} */
   const providerIds = options.providerIds != null && options.providerIds.length > 0 ? options.providerIds : undefined
@@ -203,13 +224,27 @@ export async function uploadCarToFilecoin(synapse, carPath, ipfsRootCid, options
 
   console.log('\nStarting upload to storage provider...')
   console.log('Uploading data to PDP server...')
+  logger.info({ event: 'upload.stream_ready', carPath, size }, 'Streaming CAR upload from disk')
 
-  const uploadResult = await executeUpload(synapse, carBytes, cid, {
+  const uploadResult = await executeUpload(synapse, carData, cid, {
     logger,
     contextId: `gha-upload-${Date.now()}`,
     ...(providerIds != null && { providerIds }),
     onProgress: (event) => {
       switch (event.type) {
+        case 'uploadProgress': {
+          const totalBytes = Math.max(size, 1)
+          const uploadedBytes = Math.min(event.data.bytesUploaded, totalBytes)
+          const percent = Math.min(100, Math.floor((uploadedBytes / totalBytes) * 100))
+          const bucket = percent === 100 ? 100 : Math.floor(percent / 10) * 10
+          if (bucket > lastProgressBucket) {
+            lastProgressBucket = bucket
+            console.log(
+              `Upload progress: ${percent}% (${formatProgressSize(uploadedBytes)}/${formatProgressSize(size)})`
+            )
+          }
+          break
+        }
         case 'stored': {
           console.log(`✓ Data stored on provider ${event.data.providerId}`)
           console.log(`Piece CID: ${event.data.pieceCid}`)


### PR DESCRIPTION
  Follow up to #428.
  Completes the remaining #325 follow-up.
  Fixes #326

  #428 updated the shared upload contract so `filecoin-pin` could pass streamed CAR data into the shared upload path, and it converted the `import` flow to use that contract.

  This PR finishes the remaining shipped Node-side call sites that were still reading full CAR files into memory before upload:
  - `add`
  - the pinning server
  - the GitHub Action

  It also picks up the byte-level upload progress callback work requested in #326 by forwarding Synapse's native `onProgress(bytesUploaded)` callback through `filecoin-pin`'s upload progress events, and
  then surfacing that progress in the visible consumers:
  - the CLI upload spinner
  - GitHub Action upload logs

  This follows the direction discussed in draft PR #287, but applies it to the current codebase rather than trying to revive that earlier branch directly.

  ## What changed

  ### Remaining streamed upload call sites

  - `src/add/add.ts`
    - replace `readFile(tempCarPath)` with `stat(tempCarPath)` plus `Readable.toWeb(createReadStream(tempCarPath))`
    - continue using the temp CAR on disk
    - use `stat().size` for payment sizing and CLI output

  - `src/filecoin-pin-store.ts`
    - stream the finalized CAR into `uploadToSynapse()`
    - preserve existing rollback and cleanup behavior on failure

  - `upload-action/src/filecoin.js`
    - stream the CAR from disk during upload instead of reading it fully into memory first

  ### Byte-level upload progress

  - `src/core/upload/synapse.ts`
    - forward the SDK's native `onProgress(bytesUploaded)` callback through `filecoin-pin`'s existing upload progress event stream as:
      - `onProgress: { bytesUploaded }`

  - `src/common/upload-flow.ts`
    - surface byte-level upload progress in the CLI spinner

  - `upload-action/src/filecoin.js`
    - surface coarse byte-level upload progress in GitHub Action logs

  ### Tests

  Updated unit coverage to reflect both changes:
  - stream-based upload inputs for `add`, pinning server, and upload action
  - byte-level progress callback forwarding at the shared upload layer
  - visible progress reporting in the CLI upload flow and GitHub Action logs
  - pinning-server rollback cleanup remains intact on upload failure

  ## Scope / non-goals

  This PR does **not** claim end-to-end streaming.

  What improves here:
  - the remaining shipped Node-side upload bodies are no longer buffered fully in memory before upload

  What is still true:
  - `add` still materializes a full temp CAR on disk first
  - the pinning server still finalizes a CAR on disk before upload
  - browser `add` still has the separate in-memory temp-CAR limitation

  So broader "true streaming" / large-file / browser follow-up work still belongs outside this PR, under the larger streaming issues such as #190 / #288.

  ## Test plan
```
  pnpm run lint
  cd upload-action && pnpm run lint
  pnpm vitest run --project unit src/test/unit/add.test.ts src/test/unit/import.test.ts src/test/unit/filecoin-pin-store.unit.test.ts src/test/unit/upload-action.test.ts src/test/unit/synapse-service.test.ts src/test/unit/upload-flow.test.ts
  ```