### PR TITLE
feat(cli)!: default network selection to mainnet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Bridges IPFS content to Filecoin storage providers with cryptographic guarantees
 
 **Stack**: filecoin-pin → synapse-sdk → FOC contracts (FWSS, FilecoinPay, PDPVerifier, SPRegistry) + Curio.
 
-**Status**: Supports Mainnet, Calibration testnet, and local devnet (foc-devnet). CLI defaults to Calibration.
+**Status**: Supports Mainnet, Calibration testnet, and local devnet (foc-devnet). CLI defaults to Mainnet.
 
 ## Design Philosophy
 
@@ -90,7 +90,7 @@ src/
 
 **Commands**: `payments setup --auto`, `add <path>`, `import <car-file>`, `payments status`, `data-set <id>`, `server`
 
-**Network**: `--network mainnet|calibration|devnet` (default: `calibration`). Devnet reads config from foc-devnet's `devnet-info.json` and auto-resolves private key and RPC URL.
+**Network**: `--network mainnet|calibration|devnet` (default: `mainnet`). Devnet reads config from foc-devnet's `devnet-info.json` and auto-resolves private key and RPC URL.
 
 **Required env**: `PRIVATE_KEY=0x...` (with USDFC tokens; not needed for devnet)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Status
 
-**⚠️ Not ready yet for production** - Filecoin Pin supports both Filecoin Mainnet and Calibration testnet. The CLI defaults to Calibration testnet for safety, but you can use `--network mainnet` to connect to Mainnet, but filecoin-pin is not ready for production use yet.
+**⚠️ Not ready yet for production** - Filecoin Pin supports both Filecoin Mainnet and Calibration testnet. The CLI defaults to Mainnet; use `--network calibration` to connect to Calibration testnet while evaluating. filecoin-pin is not ready for production use yet.
 
 Register for updates and a later 2025 Q4 GA announcement at [filecoin.cloud](https://filecoin.cloud/).
 
@@ -148,14 +148,14 @@ npm install -g filecoin-pin
 # 1. Configure payment permissions (one-time setup)
 filecoin-pin payments setup --auto
 
-# 2. Upload a file to Filecoin (defaults to Calibration testnet)
+# 2. Upload a file to Filecoin (defaults to Mainnet)
 filecoin-pin add myfile.txt
 
 # 3. Verify storage with cryptographic proofs
 filecoin-pin data-set <dataset-id>
 
-# To use Mainnet instead:
-filecoin-pin add myfile.txt --network mainnet
+# To use Calibration testnet instead:
+filecoin-pin add myfile.txt --network calibration
 ```
 
 For detailed guides, see:
@@ -169,18 +169,18 @@ The Pinning Server requires the use of environment variables, as detailed below.
 
 ### Network Selection
 
-Filecoin Pin supports **Mainnet**, **Calibration testnet**, and local **devnet** networks. By default, the CLI uses Calibration testnet.
+Filecoin Pin supports **Mainnet**, **Calibration testnet**, and local **devnet** networks. By default, the CLI uses Mainnet.
 
 **Using the CLI:**
 ```bash
-# Use Calibration testnet (default)
+# Use Mainnet (default)
 filecoin-pin add myfile.txt
-
-# Use Mainnet
-filecoin-pin add myfile.txt --network mainnet
 
 # Explicitly specify Calibration
 filecoin-pin add myfile.txt --network calibration
+
+# Explicitly specify Mainnet
+filecoin-pin add myfile.txt --network mainnet
 
 # Use a local foc-devnet (reads config from devnet-info.json, details below)
 filecoin-pin add myfile.txt --network devnet
@@ -192,7 +192,7 @@ filecoin-pin add myfile.txt --network devnet
 export NETWORK=mainnet
 filecoin-pin add myfile.txt
 
-# Or override RPC URL directly
+# Or override the RPC URL for the selected network
 export RPC_URL=wss://wss.node.glif.io/apigw/lotus/rpc/v1
 filecoin-pin add myfile.txt
 ```
@@ -201,7 +201,7 @@ filecoin-pin add myfile.txt
 1. `--rpc-url` flag (highest priority)
 2. `RPC_URL` environment variable
 3. `--network` flag or `NETWORK` environment variable
-4. Default to Calibration testnet
+4. Default to Mainnet
 
 ### Local Development with foc-devnet
 
@@ -228,8 +228,8 @@ When using `--network devnet`, Filecoin Pin reads connection details from a runn
 * `--private-key`: Ethereum-style (`0x`) private key (wallet and signer), funded with USDFC
 * `--wallet-address`: Session key mode: owner wallet address
 * `--session-key`: Session key mode: scoped signing key registered to the wallet
-* `--network`: Filecoin network to use: `mainnet`, `calibration`, or `devnet` (default: `calibration`)
-* `--rpc-url`: Filecoin RPC endpoint (overrides `--network` if specified)
+* `--network`: Filecoin network to use: `mainnet`, `calibration`, or `devnet` (default: `mainnet`)
+* `--rpc-url`: Filecoin RPC endpoint for the selected network
 
 Other arguments are possible for individual commands, use `--help` to find out more.
 
@@ -240,8 +240,8 @@ Other arguments are possible for individual commands, use `--help` to find out m
 PRIVATE_KEY=0x...              # Ethereum private key with USDFC tokens
 
 # Optional - Network Configuration
-NETWORK=mainnet                # Network to use: mainnet, calibration, or devnet (default: calibration)
-RPC_URL=wss://...              # Filecoin RPC endpoint (overrides NETWORK if specified)
+NETWORK=mainnet                # Network to use: mainnet, calibration, or devnet (default: mainnet)
+RPC_URL=wss://...              # Filecoin RPC endpoint for the selected network
                                # Mainnet: wss://wss.node.glif.io/apigw/lotus/rpc/v1
                                # Calibration: wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1
 

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -15,7 +15,7 @@ export const serverCommand = new Command('server')
 
 addNetworkOptions(serverCommand)
   .addOption(
-    new Option('--rpc-url <url>', 'RPC URL for Filecoin network (overrides --network)').env('RPC_URL')
+    new Option('--rpc-url <url>', 'RPC URL for the selected Filecoin network').env('RPC_URL')
     // default rpcUrl value is defined in ../common/get-rpc-url.ts
   )
   .action(async (options) => {
@@ -32,10 +32,10 @@ addNetworkOptions(serverCommand)
     if (options.accessToken) {
       process.env.ACCESS_TOKEN = options.accessToken
     }
-    // RPC URL takes precedence over network flag
     if (options.rpcUrl) {
       process.env.RPC_URL = options.rpcUrl
-    } else if (options.network) {
+    }
+    if (options.network) {
       process.env.NETWORK = options.network
     }
     if (options.carStorage) {

--- a/src/common/get-rpc-url.ts
+++ b/src/common/get-rpc-url.ts
@@ -11,6 +11,23 @@ const NETWORK_CHAINS = {
   mainnet,
   calibration,
 } as const
+
+export const DEFAULT_NETWORK = 'mainnet'
+
+export function normalizeNetworkName(network: string | undefined): string {
+  return network?.toLowerCase().trim() || DEFAULT_NETWORK
+}
+
+export function getChainForNetwork(network: string): Chain | undefined {
+  if (network === 'devnet') {
+    return resolveDevnetConfig().chain
+  }
+  if (network === 'mainnet' || network === 'calibration') {
+    return NETWORK_CHAINS[network]
+  }
+  return undefined
+}
+
 function getDefaultDevnetInfoPath(): string {
   const baseDir = process.env.FOC_DEVNET_BASEDIR?.trim() || join(homedir(), '.foc-devnet')
   return join(baseDir, 'state', 'latest', 'devnet-info.json')
@@ -78,40 +95,32 @@ export function resolveDevnetConfig(): DevnetConfig {
  * 1. Explicit --rpc-url (highest priority)
  * 2. RPC_URL environment variable
  * 3. --network flag or NETWORK environment variable (converted to RPC URL)
- * 4. Default to calibration
+ * 4. Default to mainnet
  */
 export function getRpcUrl(options: CLIAuthOptions): string {
   if (options.rpcUrl) {
     return options.rpcUrl
   }
 
-  const network = options.network?.toLowerCase().trim()
-  if (network) {
-    if (network === 'devnet') {
-      const devnet = resolveDevnetConfig()
-      const rpcUrl = devnet.chain.rpcUrls.default.http[0]
-      if (!rpcUrl) {
-        throw new Error('No RPC URL available in devnet-info.json')
-      }
-      return rpcUrl
+  const network = normalizeNetworkName(options.network)
+  if (network === 'devnet') {
+    const devnet = resolveDevnetConfig()
+    const rpcUrl = devnet.chain.rpcUrls.default.http[0]
+    if (!rpcUrl) {
+      throw new Error('No RPC URL available in devnet-info.json')
     }
-
-    if (network !== 'mainnet' && network !== 'calibration') {
-      throw new Error(`Invalid network: "${network}". Must be "mainnet", "calibration", or "devnet"`)
-    }
-    const chain = NETWORK_CHAINS[network]
-    const wsUrl = chain.rpcUrls.default.webSocket?.[0]
-    if (!wsUrl) {
-      throw new Error(`WebSocket RPC URL not available for network: "${network}"`)
-    }
-    return wsUrl
+    return rpcUrl
   }
 
-  const defaultUrl = calibration.rpcUrls.default.webSocket?.[0] ?? calibration.rpcUrls.default.http[0]
-  if (!defaultUrl) {
-    throw new Error('No RPC URL available for calibration network')
+  const chain = getChainForNetwork(network)
+  if (!chain) {
+    throw new Error(`Invalid network: "${network}". Must be "mainnet", "calibration", or "devnet"`)
   }
-  return defaultUrl
+  const wsUrl = chain.rpcUrls.default.webSocket?.[0]
+  if (!wsUrl) {
+    throw new Error(`WebSocket RPC URL not available for network: "${network}"`)
+  }
+  return wsUrl
 }
 
 export { DEVNET_CHAIN_ID, NETWORK_CHAINS }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { homedir, platform } from 'node:os'
 import { join } from 'node:path'
-import { getRpcUrl } from './common/get-rpc-url.js'
+import { getChainForNetwork, getRpcUrl, normalizeNetworkName } from './common/get-rpc-url.js'
 import type { Config } from './core/synapse/index.js'
 
 function getDataDirectory(): string {
@@ -34,19 +34,21 @@ function getDataDirectory(): string {
  * - WALLET_ADDRESS + SESSION_KEY: Session key auth
  *
  * Network:
- * - RPC_URL: Filecoin RPC endpoint — takes precedence over NETWORK
+ * - RPC_URL: Filecoin RPC endpoint — takes precedence for endpoint selection
  * - NETWORK: Filecoin network name (mainnet, calibration, devnet) — used if RPC_URL not set
  */
 export function createConfig(): Config {
   const dataDir = getDataDirectory()
 
-  // Determine RPC URL: RPC_URL env var takes precedence, then NETWORK, then default to calibration
+  // Determine RPC URL: RPC_URL takes precedence for endpoint selection, then NETWORK, then default to mainnet
+  const network = normalizeNetworkName(process.env.NETWORK)
   const rpcUrl = getRpcUrl({
     network: process.env.NETWORK,
     rpcUrl: process.env.RPC_URL,
   })
+  const chain = getChainForNetwork(network)
 
-  return {
+  const config: Config = {
     // Application-specific configuration
     port: parseInt(process.env.PORT ?? '3456', 10),
     host: process.env.HOST ?? 'localhost',
@@ -56,7 +58,7 @@ export function createConfig(): Config {
     privateKey: process.env.PRIVATE_KEY,
     walletAddress: process.env.WALLET_ADDRESS,
     sessionKey: process.env.SESSION_KEY,
-    rpcUrl, // Determined from RPC_URL, NETWORK, or default to calibration
+    rpcUrl, // Determined from RPC_URL, NETWORK, or default to mainnet
     // Storage paths
     databasePath: process.env.DATABASE_PATH ?? join(dataDir, 'pins.db'),
     carStoragePath: process.env.CAR_STORAGE_PATH ?? join(dataDir, 'cars'),
@@ -64,4 +66,8 @@ export function createConfig(): Config {
     // Logging
     logLevel: process.env.LOG_LEVEL ?? 'info',
   }
+  if (chain) {
+    config.chain = chain
+  }
+  return config
 }

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -51,6 +51,7 @@ export interface Config {
   sessionKey: string | undefined
   accessToken: string | undefined
   rpcUrl: string
+  chain?: Chain
   databasePath: string
   carStoragePath: string
   logLevel: string

--- a/src/filecoin-pinning-server.ts
+++ b/src/filecoin-pinning-server.ts
@@ -3,7 +3,7 @@ import { CID } from 'multiformats/cid'
 import type { Logger } from 'pino'
 import { isAddress, isHex } from 'viem'
 import type { Config } from './core/synapse/index.js'
-import { initializeSynapse, type SynapseSetupConfig } from './core/synapse/index.js'
+import { type Chain, initializeSynapse, type SynapseSetupConfig } from './core/synapse/index.js'
 import { FilecoinPinStore, type PinOptions } from './filecoin-pin-store.js'
 import type { ServiceInfo } from './server.js'
 
@@ -22,7 +22,10 @@ const DEFAULT_USER_INFO = {
 }
 
 function buildSynapseConfig(config: Config): SynapseSetupConfig {
-  const base = { rpcUrl: config.rpcUrl }
+  const base: { rpcUrl: string; chain?: Chain } = { rpcUrl: config.rpcUrl }
+  if (config.chain) {
+    base.chain = config.chain
+  }
 
   if (config.walletAddress && config.sessionKey) {
     if (!isAddress(config.walletAddress)) {

--- a/src/payments/interactive.ts
+++ b/src/payments/interactive.ts
@@ -7,9 +7,8 @@
  */
 
 import { cancel, confirm, isCancel, password, text } from '@clack/prompts'
-import { calibration, mainnet } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
-import { type Hex, parseUnits } from 'viem'
+import { parseUnits } from 'viem'
 import {
   calculateDepositCapacity,
   checkAndSetAllowances,
@@ -20,8 +19,9 @@ import {
   getPaymentStatus,
   validatePaymentRequirements,
 } from '../core/payments/index.js'
-import { getClientAddress, initializeSynapse, type PrivateKeyConfig } from '../core/synapse/index.js'
+import { getClientAddress, initializeSynapse } from '../core/synapse/index.js'
 import { formatUSDFC } from '../core/utils/format.js'
+import { parseCLIAuth } from '../utils/cli-auth.js'
 import { createSpinner, intro, outro } from '../utils/cli-helpers.js'
 import { isTTY, log } from '../utils/cli-logger.js'
 import { displayAccountInfo, displayDepositWarning, displayPricing } from './setup.js'
@@ -77,18 +77,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
     const s = createSpinner()
     s.start('Initializing connection...')
 
-    const defaultRpcUrl =
-      options.network === 'mainnet'
-        ? (mainnet.rpcUrls.default.webSocket?.[0] ?? mainnet.rpcUrls.default.http[0])
-        : (calibration.rpcUrls.default.webSocket?.[0] ?? calibration.rpcUrls.default.http[0])
-    const rpcUrl = options.rpcUrl || defaultRpcUrl
-
-    const config: PrivateKeyConfig = {
-      privateKey: privateKey as Hex,
-    }
-    if (rpcUrl) {
-      config.rpcUrl = rpcUrl
-    }
+    const config = parseCLIAuth({ ...options, privateKey })
     const synapse = await initializeSynapse(config)
     const network = synapse.chain.name
     const address = getClientAddress(synapse)

--- a/src/test/unit/cli-options.test.ts
+++ b/src/test/unit/cli-options.test.ts
@@ -1,5 +1,16 @@
+import { Command } from 'commander'
 import { describe, expect, it } from 'vitest'
-import { validateAndNormalizeAutoFundOptions } from '../../utils/cli-options.js'
+import { DEFAULT_NETWORK } from '../../common/get-rpc-url.js'
+import { addNetworkOptions, validateAndNormalizeAutoFundOptions } from '../../utils/cli-options.js'
+
+describe('addNetworkOptions', () => {
+  it('defaults shared CLI network options to mainnet', () => {
+    const command = addNetworkOptions(new Command())
+    const networkOption = command.options.find((option) => option.attributeName() === 'network')
+
+    expect(networkOption?.defaultValue).toBe(DEFAULT_NETWORK)
+  })
+})
 
 describe('validateAndNormalizeAutoFundOptions', () => {
   it('throws when --min-runway-days is set without --auto-fund', () => {

--- a/src/test/unit/cli-validation.test.ts
+++ b/src/test/unit/cli-validation.test.ts
@@ -1,5 +1,8 @@
+import { mainnet } from '@filoz/synapse-sdk'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { parseContextSelectionOptions } from '../../utils/cli-auth.js'
+import { parseCLIAuth, parseContextSelectionOptions } from '../../utils/cli-auth.js'
+
+const testPrivateKey = '0x0000000000000000000000000000000000000000000000000000000000000001'
 
 describe('parseContextSelectionOptions empty-list regression', () => {
   const originalEnv = { ...process.env }
@@ -21,5 +24,25 @@ describe('parseContextSelectionOptions empty-list regression', () => {
 
   it('throws on a comma-only data set list rather than returning []', () => {
     expect(() => parseContextSelectionOptions({ dataSetIds: ',,' })).toThrow(/Invalid data set ID/)
+  })
+})
+
+describe('parseCLIAuth network defaults', () => {
+  it('uses mainnet chain and RPC URL when no network is provided', () => {
+    const config = parseCLIAuth({ privateKey: testPrivateKey })
+    const expectedRpcUrl = mainnet.rpcUrls.default.webSocket?.[0] ?? mainnet.rpcUrls.default.http[0]
+
+    expect(config.chain?.id).toBe(mainnet.id)
+    expect(config.rpcUrl).toBe(expectedRpcUrl)
+  })
+
+  it('keeps the mainnet chain when only a custom RPC URL is provided', () => {
+    const config = parseCLIAuth({
+      privateKey: testPrivateKey,
+      rpcUrl: 'wss://custom.rpc.url/ws',
+    })
+
+    expect(config.chain?.id).toBe(mainnet.id)
+    expect(config.rpcUrl).toBe('wss://custom.rpc.url/ws')
   })
 })

--- a/src/test/unit/config.test.ts
+++ b/src/test/unit/config.test.ts
@@ -1,6 +1,6 @@
 import { homedir, platform } from 'node:os'
 import { join } from 'node:path'
-import { calibration } from '@filoz/synapse-sdk'
+import { mainnet } from '@filoz/synapse-sdk'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createConfig } from '../../config.js'
 
@@ -56,11 +56,12 @@ describe('Config', () => {
       expectedDataDir = join(home, '.filecoin-pin')
     }
 
-    const expectedRpcUrl = calibration.rpcUrls.default.webSocket?.[0] ?? calibration.rpcUrls.default.http[0]
+    const expectedRpcUrl = mainnet.rpcUrls.default.webSocket?.[0] ?? mainnet.rpcUrls.default.http[0]
 
     expect(config.port).toBe(3456)
     expect(config.host).toBe('localhost')
     expect(config.rpcUrl).toBe(expectedRpcUrl)
+    expect(config.chain?.id).toBe(mainnet.id)
     expect(config.databasePath).toBe(join(expectedDataDir, 'pins.db'))
     expect(config.carStoragePath).toBe(join(expectedDataDir, 'cars'))
     expect(config.logLevel).toBe('info')

--- a/src/test/unit/get-rpc-url.test.ts
+++ b/src/test/unit/get-rpc-url.test.ts
@@ -1,10 +1,10 @@
 import { calibration, mainnet } from '@filoz/synapse-sdk'
 import { describe, expect, it } from 'vitest'
-import { getRpcUrl } from '../../common/get-rpc-url.js'
+import { DEFAULT_NETWORK, getRpcUrl } from '../../common/get-rpc-url.js'
 import type { CLIAuthOptions } from '../../utils/cli-auth.js'
 
 // Extract expected WebSocket URLs from chain definitions
-const mainnetWsUrl = mainnet.rpcUrls.default.webSocket?.[0]
+const mainnetWsUrl = mainnet.rpcUrls.default.webSocket?.[0] ?? mainnet.rpcUrls.default.http[0]
 const calibrationWsUrl = calibration.rpcUrls.default.webSocket?.[0] ?? calibration.rpcUrls.default.http[0]
 
 /**
@@ -44,14 +44,15 @@ describe('getRpcUrl', () => {
     ).toBe(calibrationWsUrl)
   })
 
-  it('defaults to calibration when network is missing or blank', () => {
-    expect(getRpcUrl({})).toBe(calibrationWsUrl)
-    expect(getRpcUrl({ network: '' })).toBe(calibrationWsUrl)
-    expect(getRpcUrl({ network: '   ' })).toBe(calibrationWsUrl)
+  it('defaults to mainnet when network is missing or blank', () => {
+    expect(DEFAULT_NETWORK).toBe('mainnet')
+    expect(getRpcUrl({})).toBe(mainnetWsUrl)
+    expect(getRpcUrl({ network: '' })).toBe(mainnetWsUrl)
+    expect(getRpcUrl({ network: '   ' })).toBe(mainnetWsUrl)
   })
 
   it('treats empty rpcUrl as falsy and falls back to defaults', () => {
-    expect(getRpcUrl({ rpcUrl: '' })).toBe(calibrationWsUrl)
+    expect(getRpcUrl({ rpcUrl: '' })).toBe(mainnetWsUrl)
   })
 
   it('throws for unsupported networks', () => {

--- a/src/utils/cli-auth.ts
+++ b/src/utils/cli-auth.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Chain, Synapse } from '@filoz/synapse-sdk'
-import { getRpcUrl, NETWORK_CHAINS, resolveDevnetConfig } from '../common/get-rpc-url.js'
+import { getChainForNetwork, getRpcUrl, normalizeNetworkName, resolveDevnetConfig } from '../common/get-rpc-url.js'
 import type { SynapseSetupConfig } from '../core/synapse/index.js'
 import { initializeSynapse } from '../core/synapse/index.js'
 import { createLogger } from '../logger.js'
@@ -24,7 +24,7 @@ export interface CLIAuthOptions {
   sessionKey?: string | undefined
   /** View-only wallet address (no signing) */
   viewAddress?: string | undefined
-  /** Filecoin network: mainnet or calibration */
+  /** Filecoin network: mainnet, calibration, or devnet */
   network?: string | undefined
   /** RPC endpoint URL (overrides network if specified) */
   rpcUrl?: string | undefined
@@ -46,7 +46,7 @@ export interface CLIAuthOptions {
  * @returns Synapse setup config (validation happens in initializeSynapse)
  */
 export function parseCLIAuth(options: CLIAuthOptions): SynapseSetupConfig {
-  const network = options.network?.toLowerCase().trim()
+  const network = normalizeNetworkName(options.network)
   const isDevnet = network === 'devnet'
 
   // For devnet, fall back to the devnet user's private key if none provided
@@ -60,8 +60,8 @@ export function parseCLIAuth(options: CLIAuthOptions): SynapseSetupConfig {
   let chain: Chain | undefined
   if (isDevnet) {
     chain = resolveDevnetConfig().chain
-  } else if (network) {
-    chain = NETWORK_CHAINS[network as keyof typeof NETWORK_CHAINS]
+  } else {
+    chain = getChainForNetwork(network)
   }
 
   // Build config incrementally; initializeSynapse() validates the final shape

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -7,6 +7,7 @@
 import { type Command, InvalidArgumentError, Option } from 'commander'
 import { parseUnits } from 'viem'
 import { MIN_RUNWAY_DAYS } from '../common/constants.js'
+import { DEFAULT_NETWORK } from '../common/get-rpc-url.js'
 import { USDFC_DECIMALS } from '../core/payments/constants.js'
 
 /**
@@ -17,7 +18,7 @@ import { USDFC_DECIMALS } from '../core/payments/constants.js'
  * - --wallet-address for session key authentication
  * - --session-key for session key authentication
  * - --view-address for read-only authentication (no signing, requires wallet address)
- * - --network for network selection (mainnet or calibration)
+ * - --network for network selection (mainnet, calibration, or devnet)
  * - --rpc-url for network configuration (overrides --network)
  *
  * The function modifies the command in-place and returns it for chaining.
@@ -93,7 +94,7 @@ export function addNetworkOptions(command: Command): Command {
       )
         .choices(['mainnet', 'calibration', 'devnet'])
         .env('NETWORK')
-        .default('calibration')
+        .default(DEFAULT_NETWORK)
     )
     .addOption(new Option('--mainnet', 'Use mainnet (shorthand for --network mainnet)').implies({ network: 'mainnet' }))
   return command


### PR DESCRIPTION
BREAKING CHANGE: CLI commands now use Filecoin Mainnet when --network/NETWORK is omitted. Use --network calibration or NETWORK=calibration for Calibration testnet.

## Summary

- Change the shared CLI network default from Calibration to Mainnet.
- Centralize default network normalization with `DEFAULT_NETWORK = 'mainnet'`.
- Ensure CLI auth, server config, and interactive payment setup pass the matching Synapse chain along with the resolved RPC URL.
- Update README and AGENTS docs to describe Mainnet as the default.
- Update unit tests to cover the new default and custom RPC behavior.

## Testing

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test:unit`
- `pnpm exec tsx src/cli.ts --no-update-check add --help`
- `pnpm exec tsx src/cli.ts --no-update-check server --help`

## Notes

Users who want Calibration testnet now need to pass `--network calibration` or set `NETWORK=calibration`.