### PR TITLE
feat(cli)!: default network to mainnet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Bridges IPFS content to Filecoin storage providers with cryptographic guarantees
 
 **Stack**: filecoin-pin → synapse-sdk → FOC contracts (FWSS, FilecoinPay, PDPVerifier, SPRegistry) + Curio.
 
-**Status**: Supports Mainnet, Calibration testnet, and local devnet (foc-devnet). CLI defaults to Calibration.
+**Status**: Supports Mainnet, Calibration testnet, and local devnet (foc-devnet). CLI defaults to Mainnet.
 
 ## Design Philosophy
 
@@ -90,7 +90,7 @@ src/
 
 **Commands**: `payments setup --auto`, `add <path>`, `import <car-file>`, `payments status`, `data-set <id>`, `server`
 
-**Network**: `--network mainnet|calibration|devnet` (default: `calibration`). Devnet reads config from foc-devnet's `devnet-info.json` and auto-resolves private key and RPC URL.
+**Network**: `--network mainnet|calibration|devnet` (default: `mainnet`). Devnet reads config from foc-devnet's `devnet-info.json` and auto-resolves private key and RPC URL.
 
 **Required env**: `PRIVATE_KEY=0x...` (with USDFC tokens; not needed for devnet)
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,7 @@
 
 [![NPM](https://nodei.co/npm/filecoin-pin.svg?style=flat&data=n,v)](https://nodei.co/npm/filecoin-pin/)
 
-**Store IPFS content on Filecoin's decentralized storage network with verifiable persistence.**
-
-## Status
-
-**Ready for persistent, verifiable data on Filecoin Mainnet.**
-
-Register for updates and a later 2025 Q4 GA announcement at [filecoin.cloud](https://filecoin.cloud/).
+**Store your files on IPFS with Filecoin Pin, backed by [Filecoin’s decentralized storage network](https://filecoin.cloud/), with storage managed by your wallet through onchain payments.**
 
 ## What is Filecoin Pin?
 
@@ -111,7 +105,7 @@ Filecoin Pin's CLI collects telemetry.  A few things:
 * Telemetry always [has a way to be disabled](#how-to-disable-telemetry).
 * We don't collect Personal identifiable information (PII).
 * With our [end user affordance](#affordances) we expect to make telemetry on by default, requiring a consumer/user to opt out.  We are defaulting as "enabled" to help make sure we have a good pulse on the user experience and can address issues correctly.
-* In this [pre-v1 season](https://github.com/filecoin-project/filecoin-pin/issues/187), we are particularly focused on helping maintainers validate functionality and iron out problems throughout the whole Filecoin Onchain Cloud stack that `filecoin-pin` relies on. 
+* In this [pre-v1 season](https://github.com/filecoin-project/filecoin-pin/issues/187), we are particularly focused on helping maintainers validate functionality and iron out problems throughout the whole Filecoin Onchain Cloud stack that `filecoin-pin` relies on.
 
 ### How to disable CLI telemetry
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ filecoin-pin add myfile.txt
 # 3. Verify storage with cryptographic proofs
 filecoin-pin data-set <dataset-id>
 
-# To use Calibration testnet instead:
+# To use Calibration testnet (not persistent) instead:
 filecoin-pin add myfile.txt --network calibration
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Status
 
-**⚠️ Not ready yet for production** - Filecoin Pin supports both Filecoin Mainnet and Calibration testnet. The CLI defaults to Calibration testnet for safety, but you can use `--network mainnet` to connect to Mainnet, but filecoin-pin is not ready for production use yet.
+**Ready for persistent, verifiable data on Filecoin Mainnet.**
 
 Register for updates and a later 2025 Q4 GA announcement at [filecoin.cloud](https://filecoin.cloud/).
 
@@ -148,14 +148,14 @@ npm install -g filecoin-pin
 # 1. Configure payment permissions (one-time setup)
 filecoin-pin payments setup --auto
 
-# 2. Upload a file to Filecoin (defaults to Calibration testnet)
+# 2. Upload a file to Filecoin (defaults to Mainnet)
 filecoin-pin add myfile.txt
 
 # 3. Verify storage with cryptographic proofs
 filecoin-pin data-set <dataset-id>
 
-# To use Mainnet instead:
-filecoin-pin add myfile.txt --network mainnet
+# To use Calibration testnet instead:
+filecoin-pin add myfile.txt --network calibration
 ```
 
 For detailed guides, see:
@@ -169,17 +169,17 @@ The Pinning Server requires the use of environment variables, as detailed below.
 
 ### Network Selection
 
-Filecoin Pin supports **Mainnet**, **Calibration testnet**, and local **devnet** networks. By default, the CLI uses Calibration testnet.
+Filecoin Pin supports **Mainnet**, **Calibration testnet**, and local **devnet** networks. By default, the CLI uses Mainnet.
 
 **Using the CLI:**
 ```bash
-# Use Calibration testnet (default)
+# Use Mainnet (default)
 filecoin-pin add myfile.txt
 
-# Use Mainnet
+# Explicitly specify Mainnet
 filecoin-pin add myfile.txt --network mainnet
 
-# Explicitly specify Calibration
+# Use Calibration testnet
 filecoin-pin add myfile.txt --network calibration
 
 # Use a local foc-devnet (reads config from devnet-info.json, details below)
@@ -201,7 +201,7 @@ filecoin-pin add myfile.txt
 1. `--rpc-url` flag (highest priority)
 2. `RPC_URL` environment variable
 3. `--network` flag or `NETWORK` environment variable
-4. Default to Calibration testnet
+4. Default to Mainnet
 
 ### Local Development with foc-devnet
 
@@ -228,7 +228,7 @@ When using `--network devnet`, Filecoin Pin reads connection details from a runn
 * `--private-key`: Ethereum-style (`0x`) private key (wallet and signer), funded with USDFC
 * `--wallet-address`: Session key mode: owner wallet address
 * `--session-key`: Session key mode: scoped signing key registered to the wallet
-* `--network`: Filecoin network to use: `mainnet`, `calibration`, or `devnet` (default: `calibration`)
+* `--network`: Filecoin network to use: `mainnet`, `calibration`, or `devnet` (default: `mainnet`)
 * `--rpc-url`: Filecoin RPC endpoint (overrides `--network` if specified)
 
 Other arguments are possible for individual commands, use `--help` to find out more.
@@ -240,7 +240,7 @@ Other arguments are possible for individual commands, use `--help` to find out m
 PRIVATE_KEY=0x...              # Ethereum private key with USDFC tokens
 
 # Optional - Network Configuration
-NETWORK=mainnet                # Network to use: mainnet, calibration, or devnet (default: calibration)
+NETWORK=mainnet                # Network to use: mainnet, calibration, or devnet (default: mainnet)
 RPC_URL=wss://...              # Filecoin RPC endpoint (overrides NETWORK if specified)
                                # Mainnet: wss://wss.node.glif.io/apigw/lotus/rpc/v1
                                # Calibration: wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,13 +3,7 @@ import './instrument.js'
 import { Command } from 'commander'
 import pc from 'picocolors'
 
-import { addCommand } from './commands/add.js'
-import { dataSetCommand } from './commands/data-set.js'
-import { importCommand } from './commands/import.js'
-import { paymentsCommand } from './commands/payments.js'
-import { providerCommand } from './commands/provider.js'
-import { rmCommand } from './commands/rm.js'
-import { serverCommand } from './commands/server.js'
+import { ALL_CLI_COMMANDS } from './commands/index.js'
 import { checkForUpdate, type UpdateCheckStatus } from './common/version-check.js'
 import { version as packageVersion } from './core/utils/version.js'
 
@@ -22,13 +16,9 @@ const program = new Command()
   .option('--no-update-check', 'skip check for updates')
 
 // Add subcommands
-program.addCommand(serverCommand)
-program.addCommand(paymentsCommand)
-program.addCommand(dataSetCommand)
-program.addCommand(importCommand)
-program.addCommand(addCommand)
-program.addCommand(rmCommand)
-program.addCommand(providerCommand)
+for (const command of ALL_CLI_COMMANDS) {
+  program.addCommand(command)
+}
 
 // Default action - show help if no command specified
 program.action(() => {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,26 @@
+import type { Command } from 'commander'
+import { addCommand } from './add.js'
+import { dataSetCommand } from './data-set.js'
+import { importCommand } from './import.js'
+import { paymentsCommand } from './payments.js'
+import { providerCommand } from './provider.js'
+import { rmCommand } from './rm.js'
+import { serverCommand } from './server.js'
+
+export { addCommand, dataSetCommand, importCommand, paymentsCommand, providerCommand, rmCommand, serverCommand }
+
+/**
+ * Every top-level CLI command in the order they're registered on the program.
+ *
+ * Adding a new command? Append it here. cli.ts and the network-default tests
+ * iterate this list, so registration and coverage stay in sync.
+ */
+export const ALL_CLI_COMMANDS: readonly Command[] = [
+  serverCommand,
+  paymentsCommand,
+  dataSetCommand,
+  importCommand,
+  addCommand,
+  rmCommand,
+  providerCommand,
+]

--- a/src/common/get-rpc-url.ts
+++ b/src/common/get-rpc-url.ts
@@ -78,7 +78,7 @@ export function resolveDevnetConfig(): DevnetConfig {
  * 1. Explicit --rpc-url (highest priority)
  * 2. RPC_URL environment variable
  * 3. --network flag or NETWORK environment variable (converted to RPC URL)
- * 4. Default to calibration
+ * 4. Default to mainnet
  */
 export function getRpcUrl(options: CLIAuthOptions): string {
   if (options.rpcUrl) {
@@ -107,9 +107,9 @@ export function getRpcUrl(options: CLIAuthOptions): string {
     return wsUrl
   }
 
-  const defaultUrl = calibration.rpcUrls.default.webSocket?.[0] ?? calibration.rpcUrls.default.http[0]
+  const defaultUrl = mainnet.rpcUrls.default.webSocket?.[0] ?? mainnet.rpcUrls.default.http[0]
   if (!defaultUrl) {
-    throw new Error('No RPC URL available for calibration network')
+    throw new Error('No RPC URL available for mainnet network')
   }
   return defaultUrl
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,12 +51,18 @@ function getDataDirectory(): string {
 export function createConfig(): Config {
   const dataDir = getDataDirectory()
 
-  // Determine RPC URL: RPC_URL env var takes precedence, then NETWORK, then default to calibration
+  // Determine RPC URL: RPC_URL env var takes precedence, then NETWORK, then default to mainnet
   const rpcUrl = getRpcUrl({
     network: process.env.NETWORK,
     rpcUrl: process.env.RPC_URL,
   })
-  const chain = resolveChain(process.env.NETWORK, process.env.RPC_URL != null && process.env.RPC_URL !== '')
+  // Default chain to mainnet when NETWORK is unset, mirroring the CLI's Commander default
+  // and getRpcUrl's mainnet fallback. RPC_URL alone (without NETWORK) still resolves chain
+  // to mainnet; if the RPC points to a different chain, contract calls will fail loudly.
+  const chain = resolveChain(
+    process.env.NETWORK ?? 'mainnet',
+    process.env.RPC_URL != null && process.env.RPC_URL !== ''
+  )
 
   const config: Config = {
     // Application-specific configuration
@@ -68,7 +74,7 @@ export function createConfig(): Config {
     privateKey: process.env.PRIVATE_KEY,
     walletAddress: process.env.WALLET_ADDRESS,
     sessionKey: process.env.SESSION_KEY,
-    rpcUrl, // Determined from RPC_URL, NETWORK, or default to calibration
+    rpcUrl, // Determined from RPC_URL, NETWORK, or default to mainnet
     // Storage paths
     databasePath: process.env.DATABASE_PATH ?? join(dataDir, 'pins.db'),
     carStoragePath: process.env.CAR_STORAGE_PATH ?? join(dataDir, 'cars'),

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -61,9 +61,9 @@ export interface Config {
  * Common options for all Synapse configurations
  */
 interface BaseSynapseConfig {
-  /** RPC endpoint for the target Filecoin network. Defaults to calibration chain transport. */
+  /** RPC endpoint for the target Filecoin network. Defaults to mainnet chain transport. */
   rpcUrl?: string
-  /** Target chain. Defaults to calibration. */
+  /** Target chain. Defaults to mainnet. */
   chain?: Chain
   /** Enable CDN service for datasets */
   withCDN?: boolean
@@ -176,7 +176,7 @@ function checkSessionKeyPermissions(key: SessionKey<'Secp256k1'>, ownerAddress: 
  * @returns Initialized Synapse instance
  */
 export async function initializeSynapse(config: SynapseSetupConfig, logger?: Logger): Promise<Synapse> {
-  const chain = config.chain ?? calibration
+  const chain = config.chain ?? mainnet
   const rpcUrl = config.rpcUrl ?? chain.rpcUrls.default.webSocket?.[0] ?? chain.rpcUrls.default.http[0]
   const transport = rpcUrl ? createTransport(rpcUrl) : undefined
 

--- a/src/payments/interactive.ts
+++ b/src/payments/interactive.ts
@@ -7,9 +7,8 @@
  */
 
 import { cancel, confirm, isCancel, password, text } from '@clack/prompts'
-import { calibration, mainnet } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
-import { type Hex, parseUnits } from 'viem'
+import { parseUnits } from 'viem'
 import {
   calculateDepositCapacity,
   checkAndSetAllowances,
@@ -20,8 +19,9 @@ import {
   getPaymentStatus,
   validatePaymentRequirements,
 } from '../core/payments/index.js'
-import { getClientAddress, initializeSynapse, type PrivateKeyConfig } from '../core/synapse/index.js'
+import { getClientAddress, initializeSynapse } from '../core/synapse/index.js'
 import { formatUSDFC } from '../core/utils/format.js'
+import { parseCLIAuth } from '../utils/cli-auth.js'
 import { createSpinner, intro, outro } from '../utils/cli-helpers.js'
 import { isTTY, log } from '../utils/cli-logger.js'
 import { displayAccountInfo, displayDepositWarning, displayPricing } from './setup.js'
@@ -77,18 +77,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
     const s = createSpinner()
     s.start('Initializing connection...')
 
-    const defaultRpcUrl =
-      options.network === 'mainnet'
-        ? (mainnet.rpcUrls.default.webSocket?.[0] ?? mainnet.rpcUrls.default.http[0])
-        : (calibration.rpcUrls.default.webSocket?.[0] ?? calibration.rpcUrls.default.http[0])
-    const rpcUrl = options.rpcUrl || defaultRpcUrl
-
-    const config: PrivateKeyConfig = {
-      privateKey: privateKey as Hex,
-    }
-    if (rpcUrl) {
-      config.rpcUrl = rpcUrl
-    }
+    const config = parseCLIAuth({ ...options, privateKey })
     const synapse = await initializeSynapse(config)
     const network = synapse.chain.name
     const address = getClientAddress(synapse)

--- a/src/test/unit/cli-network-defaults.test.ts
+++ b/src/test/unit/cli-network-defaults.test.ts
@@ -1,29 +1,13 @@
 import type { Command } from 'commander'
 import { describe, expect, it } from 'vitest'
-import { addCommand } from '../../commands/add.js'
-import { dataSetCommand } from '../../commands/data-set.js'
-import { importCommand } from '../../commands/import.js'
-import { paymentsCommand } from '../../commands/payments.js'
-import { providerCommand } from '../../commands/provider.js'
-import { rmCommand } from '../../commands/rm.js'
-import { serverCommand } from '../../commands/server.js'
+import { ALL_CLI_COMMANDS } from '../../commands/index.js'
 
 function leafCommands(cmd: Command): Command[] {
   return cmd.commands.length === 0 ? [cmd] : cmd.commands.flatMap(leafCommands)
 }
 
-const roots: Array<[string, Command]> = [
-  ['add', addCommand],
-  ['import', importCommand],
-  ['rm', rmCommand],
-  ['server', serverCommand],
-  ['payments', paymentsCommand],
-  ['data-set', dataSetCommand],
-  ['provider', providerCommand],
-]
-
-const leaves = roots.flatMap(([root, cmd]) =>
-  leafCommands(cmd).map((leaf) => [`${root} ${leaf.name()}`.trim(), leaf] as const)
+const leaves = ALL_CLI_COMMANDS.flatMap((cmd) =>
+  leafCommands(cmd).map((leaf) => [`${cmd.name()} ${leaf.name()}`.trim(), leaf] as const)
 )
 
 describe('CLI --network default', () => {

--- a/src/test/unit/cli-network-defaults.test.ts
+++ b/src/test/unit/cli-network-defaults.test.ts
@@ -1,0 +1,35 @@
+import type { Command } from 'commander'
+import { describe, expect, it } from 'vitest'
+import { addCommand } from '../../commands/add.js'
+import { dataSetCommand } from '../../commands/data-set.js'
+import { importCommand } from '../../commands/import.js'
+import { paymentsCommand } from '../../commands/payments.js'
+import { providerCommand } from '../../commands/provider.js'
+import { rmCommand } from '../../commands/rm.js'
+import { serverCommand } from '../../commands/server.js'
+
+function leafCommands(cmd: Command): Command[] {
+  return cmd.commands.length === 0 ? [cmd] : cmd.commands.flatMap(leafCommands)
+}
+
+const roots: Array<[string, Command]> = [
+  ['add', addCommand],
+  ['import', importCommand],
+  ['rm', rmCommand],
+  ['server', serverCommand],
+  ['payments', paymentsCommand],
+  ['data-set', dataSetCommand],
+  ['provider', providerCommand],
+]
+
+const leaves = roots.flatMap(([root, cmd]) =>
+  leafCommands(cmd).map((leaf) => [`${root} ${leaf.name()}`.trim(), leaf] as const)
+)
+
+describe('CLI --network default', () => {
+  it.each(leaves)('%s defaults --network to mainnet', (label, leaf) => {
+    const networkOpt = leaf.options.find((o) => o.long === '--network')
+    expect(networkOpt, `${label} missing --network option`).toBeDefined()
+    expect(networkOpt?.defaultValue).toBe('mainnet')
+  })
+})

--- a/src/test/unit/cli-options.test.ts
+++ b/src/test/unit/cli-options.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it } from 'vitest'
-import { validateAndNormalizeAutoFundOptions } from '../../utils/cli-options.js'
+import { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { addNetworkOptions, validateAndNormalizeAutoFundOptions } from '../../utils/cli-options.js'
+
+describe('addNetworkOptions', () => {
+  const originalNetwork = process.env.NETWORK
+
+  beforeEach(() => {
+    delete process.env.NETWORK
+  })
+
+  afterEach(() => {
+    if (originalNetwork === undefined) delete process.env.NETWORK
+    else process.env.NETWORK = originalNetwork
+  })
+
+  it('defaults --network to mainnet', () => {
+    const command = addNetworkOptions(new Command()).exitOverride()
+    command.parse([], { from: 'user' })
+    expect(command.opts().network).toBe('mainnet')
+  })
+})
 
 describe('validateAndNormalizeAutoFundOptions', () => {
   it('throws when --min-runway-days is set without --auto-fund', () => {

--- a/src/test/unit/config.test.ts
+++ b/src/test/unit/config.test.ts
@@ -56,7 +56,7 @@ describe('Config', () => {
       expectedDataDir = join(home, '.filecoin-pin')
     }
 
-    const expectedRpcUrl = calibration.rpcUrls.default.webSocket?.[0] ?? calibration.rpcUrls.default.http[0]
+    const expectedRpcUrl = mainnet.rpcUrls.default.webSocket?.[0] ?? mainnet.rpcUrls.default.http[0]
 
     expect(config.port).toBe(3456)
     expect(config.host).toBe('localhost')

--- a/src/test/unit/config.test.ts
+++ b/src/test/unit/config.test.ts
@@ -86,8 +86,13 @@ describe('Config', () => {
     expect(createConfig().chain).toBe(calibration)
   })
 
-  it('skips chain resolution when NETWORK is not set', () => {
-    expect(createConfig().chain).toBeUndefined()
+  it('defaults chain to mainnet when NETWORK is not set', () => {
+    expect(createConfig().chain).toBe(mainnet)
+  })
+
+  it('defaults chain to mainnet when only RPC_URL is set', () => {
+    process.env.RPC_URL = 'wss://custom.example/rpc'
+    expect(createConfig().chain).toBe(mainnet)
   })
 
   it('does not load devnet-info.json when NETWORK=devnet but RPC_URL is set', () => {

--- a/src/test/unit/get-rpc-url.test.ts
+++ b/src/test/unit/get-rpc-url.test.ts
@@ -44,14 +44,14 @@ describe('getRpcUrl', () => {
     ).toBe(calibrationWsUrl)
   })
 
-  it('defaults to calibration when network is missing or blank', () => {
-    expect(getRpcUrl({})).toBe(calibrationWsUrl)
-    expect(getRpcUrl({ network: '' })).toBe(calibrationWsUrl)
-    expect(getRpcUrl({ network: '   ' })).toBe(calibrationWsUrl)
+  it('defaults to mainnet when network is missing or blank', () => {
+    expect(getRpcUrl({})).toBe(mainnetWsUrl)
+    expect(getRpcUrl({ network: '' })).toBe(mainnetWsUrl)
+    expect(getRpcUrl({ network: '   ' })).toBe(mainnetWsUrl)
   })
 
   it('treats empty rpcUrl as falsy and falls back to defaults', () => {
-    expect(getRpcUrl({ rpcUrl: '' })).toBe(calibrationWsUrl)
+    expect(getRpcUrl({ rpcUrl: '' })).toBe(mainnetWsUrl)
   })
 
   it('throws for unsupported networks', () => {

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -83,19 +83,17 @@ export function addContextSelectionOptions(command: Command): Command {
 }
 
 export function addNetworkOptions(command: Command): Command {
-  command
-    .addOption(
-      new Option(
-        '--network <network>',
-        'Filecoin network to use. "devnet" reads config from foc-devnet ' +
-          '(https://github.com/filecoin-project/foc-devnet, ' +
-          'env: FOC_DEVNET_BASEDIR or DEVNET_INFO_PATH, DEVNET_USER_INDEX)'
-      )
-        .choices(['mainnet', 'calibration', 'devnet'])
-        .env('NETWORK')
-        .default('calibration')
+  command.addOption(
+    new Option(
+      '--network <network>',
+      'Filecoin network to use. "devnet" reads config from foc-devnet ' +
+        '(https://github.com/filecoin-project/foc-devnet, ' +
+        'env: FOC_DEVNET_BASEDIR or DEVNET_INFO_PATH, DEVNET_USER_INDEX)'
     )
-    .addOption(new Option('--mainnet', 'Use mainnet (shorthand for --network mainnet)').implies({ network: 'mainnet' }))
+      .choices(['mainnet', 'calibration', 'devnet'])
+      .env('NETWORK')
+      .default('mainnet')
+  )
   return command
 }
 


### PR DESCRIPTION
### What changed

The CLI default network flips from Calibration to Mainnet. Commander option default in `addNetworkOptions()` is now `'mainnet'`, the `--mainnet` shorthand is dropped (redundant), and `getRpcUrl()` falls back to mainnet when no `--rpc-url`, `--network`, `RPC_URL`, or `NETWORK` is provided. Docs and unit tests updated to match. README Status section reframed to signal mainnet readiness.

Minimal alternative to #442. Only the default flip, no refactor of `get-rpc-url.ts` and no `chain` plumbing through `Config`. Server-side chain plumbing is split into #446.

### How to verify

- `pnpm run typecheck`
- `pnpm run lint:fix`
- `pnpm run test:unit`
- `pnpm exec tsx src/cli.ts --no-update-check add --help` shows `(default: "mainnet")`

### Notes / risks

Breaking change for anyone relying on the implicit Calibration default. Migration: pass `--network calibration` or set `NETWORK=calibration`.