### PR TITLE
fix(server): pass resolved chain to Synapse

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,16 @@
 import { homedir, platform } from 'node:os'
 import { join } from 'node:path'
-import { getRpcUrl } from './common/get-rpc-url.js'
+import type { Chain } from '@filoz/synapse-sdk'
+import { getRpcUrl, NETWORK_CHAINS, resolveDevnetConfig } from './common/get-rpc-url.js'
 import type { Config } from './core/synapse/index.js'
+
+function resolveChain(network: string | undefined): Chain | undefined {
+  const normalized = network?.toLowerCase().trim()
+  if (!normalized) return undefined
+  if (normalized === 'devnet') return resolveDevnetConfig().chain
+  if (normalized === 'mainnet' || normalized === 'calibration') return NETWORK_CHAINS[normalized]
+  return undefined
+}
 
 function getDataDirectory(): string {
   const home = homedir()
@@ -45,8 +54,9 @@ export function createConfig(): Config {
     network: process.env.NETWORK,
     rpcUrl: process.env.RPC_URL,
   })
+  const chain = resolveChain(process.env.NETWORK)
 
-  return {
+  const config: Config = {
     // Application-specific configuration
     port: parseInt(process.env.PORT ?? '3456', 10),
     host: process.env.HOST ?? 'localhost',
@@ -64,4 +74,8 @@ export function createConfig(): Config {
     // Logging
     logLevel: process.env.LOG_LEVEL ?? 'info',
   }
+  if (chain) {
+    config.chain = chain
+  }
+  return config
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,11 +4,13 @@ import type { Chain } from '@filoz/synapse-sdk'
 import { getRpcUrl, NETWORK_CHAINS, resolveDevnetConfig } from './common/get-rpc-url.js'
 import type { Config } from './core/synapse/index.js'
 
-function resolveChain(network: string | undefined): Chain | undefined {
+function resolveChain(network: string | undefined, hasExplicitRpcUrl: boolean): Chain | undefined {
   const normalized = network?.toLowerCase().trim()
   if (!normalized) return undefined
-  if (normalized === 'devnet') return resolveDevnetConfig().chain
   if (normalized === 'mainnet' || normalized === 'calibration') return NETWORK_CHAINS[normalized]
+  // Devnet's chain comes from devnet-info.json. Skip the file load when the operator
+  // overrode RPC_URL — they may just have a stale NETWORK=devnet and the file may not exist.
+  if (normalized === 'devnet' && !hasExplicitRpcUrl) return resolveDevnetConfig().chain
   return undefined
 }
 
@@ -54,7 +56,7 @@ export function createConfig(): Config {
     network: process.env.NETWORK,
     rpcUrl: process.env.RPC_URL,
   })
-  const chain = resolveChain(process.env.NETWORK)
+  const chain = resolveChain(process.env.NETWORK, process.env.RPC_URL != null && process.env.RPC_URL !== '')
 
   const config: Config = {
     // Application-specific configuration

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -51,6 +51,7 @@ export interface Config {
   sessionKey: string | undefined
   accessToken: string | undefined
   rpcUrl: string
+  chain?: Chain
   databasePath: string
   carStoragePath: string
   logLevel: string

--- a/src/filecoin-pinning-server.ts
+++ b/src/filecoin-pinning-server.ts
@@ -2,7 +2,7 @@ import fastify, { type FastifyInstance, type FastifyRequest } from 'fastify'
 import { CID } from 'multiformats/cid'
 import type { Logger } from 'pino'
 import { isAddress, isHex } from 'viem'
-import type { Config } from './core/synapse/index.js'
+import type { Chain, Config } from './core/synapse/index.js'
 import { initializeSynapse, type SynapseSetupConfig } from './core/synapse/index.js'
 import { FilecoinPinStore, type PinOptions } from './filecoin-pin-store.js'
 import type { ServiceInfo } from './server.js'
@@ -22,7 +22,10 @@ const DEFAULT_USER_INFO = {
 }
 
 function buildSynapseConfig(config: Config): SynapseSetupConfig {
-  const base = { rpcUrl: config.rpcUrl }
+  const base: { rpcUrl: string; chain?: Chain } = { rpcUrl: config.rpcUrl }
+  if (config.chain) {
+    base.chain = config.chain
+  }
 
   if (config.walletAddress && config.sessionKey) {
     if (!isAddress(config.walletAddress)) {

--- a/src/test/unit/config.test.ts
+++ b/src/test/unit/config.test.ts
@@ -1,6 +1,6 @@
 import { homedir, platform } from 'node:os'
 import { join } from 'node:path'
-import { calibration } from '@filoz/synapse-sdk'
+import { calibration, mainnet } from '@filoz/synapse-sdk'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createConfig } from '../../config.js'
 
@@ -76,5 +76,25 @@ describe('Config', () => {
     expect(config.port).toBe(8080)
     expect(config.host).toBe('0.0.0.0')
     expect(config.logLevel).toBe('debug')
+  })
+
+  it('resolves chain from NETWORK so Synapse uses matching contracts', () => {
+    process.env.NETWORK = 'mainnet'
+    expect(createConfig().chain).toBe(mainnet)
+
+    process.env.NETWORK = 'calibration'
+    expect(createConfig().chain).toBe(calibration)
+  })
+
+  it('skips chain resolution when NETWORK is not set', () => {
+    expect(createConfig().chain).toBeUndefined()
+  })
+
+  it('does not load devnet-info.json when NETWORK=devnet but RPC_URL is set', () => {
+    process.env.NETWORK = 'devnet'
+    process.env.RPC_URL = 'wss://custom.example/rpc'
+    // Would throw "Failed to read devnet info" if we attempted the file load.
+    expect(() => createConfig()).not.toThrow()
+    expect(createConfig().chain).toBeUndefined()
   })
 })


### PR DESCRIPTION
### What changed

The pinning server's `createConfig()` resolves an RPC URL but never threads a `Chain` into Synapse. `initializeSynapse()` falls back to `calibration` whenever `config.chain` is undefined (`src/core/synapse/index.ts:178`), so running the server with `NETWORK=mainnet` or `NETWORK=devnet` silently mixes a non-calibration RPC URL with calibration contract addresses, breaking payments and uploads.

This PR adds an optional `chain` to `Config`, resolves it from `NETWORK` in `createConfig()` (mainnet, calibration, or devnet via `devnet-info.json`), and forwards it through `buildSynapseConfig()`. The CLI path already does this via `parseCLIAuth()`. This brings the server path into line.

`resolveChain()` skips the devnet-info.json load when `RPC_URL` is explicitly set, so a stale `NETWORK=devnet` env var will not crash startup.

### How to verify

- `pnpm run typecheck`
- `pnpm run lint:fix`
- `pnpm run test:unit`
- `NETWORK=mainnet PRIVATE_KEY=... filecoin-pin server`. The `synapse.init.success` log now reports `chain: "filecoin"` (mainnet) instead of `calibration`.

### Notes

Orthogonal to #445 (mainnet default flip). Bug exists on master today. The default flip in #445 just makes it the silent default for server users who do not set NETWORK.

No precedence change in `src/commands/server.ts`. `--rpc-url` still wins over `--network`.