### PR TITLE
refactor(cli): centralize command registry

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,13 +3,7 @@ import './instrument.js'
 import { Command } from 'commander'
 import pc from 'picocolors'
 
-import { addCommand } from './commands/add.js'
-import { dataSetCommand } from './commands/data-set.js'
-import { importCommand } from './commands/import.js'
-import { paymentsCommand } from './commands/payments.js'
-import { providerCommand } from './commands/provider.js'
-import { rmCommand } from './commands/rm.js'
-import { serverCommand } from './commands/server.js'
+import { ALL_CLI_COMMANDS } from './commands/index.js'
 import { checkForUpdate, type UpdateCheckStatus } from './common/version-check.js'
 import { version as packageVersion } from './core/utils/version.js'
 
@@ -22,13 +16,9 @@ const program = new Command()
   .option('--no-update-check', 'skip check for updates')
 
 // Add subcommands
-program.addCommand(serverCommand)
-program.addCommand(paymentsCommand)
-program.addCommand(dataSetCommand)
-program.addCommand(importCommand)
-program.addCommand(addCommand)
-program.addCommand(rmCommand)
-program.addCommand(providerCommand)
+for (const command of ALL_CLI_COMMANDS) {
+  program.addCommand(command)
+}
 
 // Default action - show help if no command specified
 program.action(() => {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,26 @@
+import type { Command } from 'commander'
+import { addCommand } from './add.js'
+import { dataSetCommand } from './data-set.js'
+import { importCommand } from './import.js'
+import { paymentsCommand } from './payments.js'
+import { providerCommand } from './provider.js'
+import { rmCommand } from './rm.js'
+import { serverCommand } from './server.js'
+
+export { addCommand, dataSetCommand, importCommand, paymentsCommand, providerCommand, rmCommand, serverCommand }
+
+/**
+ * Every top-level CLI command in the order they're registered on the program.
+ *
+ * Adding a new command? Append it here. cli.ts and the network-default tests
+ * iterate this list, so registration and coverage stay in sync.
+ */
+export const ALL_CLI_COMMANDS: readonly Command[] = [
+  serverCommand,
+  paymentsCommand,
+  dataSetCommand,
+  importCommand,
+  addCommand,
+  rmCommand,
+  providerCommand,
+]

--- a/src/test/unit/cli-network-defaults.test.ts
+++ b/src/test/unit/cli-network-defaults.test.ts
@@ -1,29 +1,13 @@
 import type { Command } from 'commander'
 import { describe, expect, it } from 'vitest'
-import { addCommand } from '../../commands/add.js'
-import { dataSetCommand } from '../../commands/data-set.js'
-import { importCommand } from '../../commands/import.js'
-import { paymentsCommand } from '../../commands/payments.js'
-import { providerCommand } from '../../commands/provider.js'
-import { rmCommand } from '../../commands/rm.js'
-import { serverCommand } from '../../commands/server.js'
+import { ALL_CLI_COMMANDS } from '../../commands/index.js'
 
 function leafCommands(cmd: Command): Command[] {
   return cmd.commands.length === 0 ? [cmd] : cmd.commands.flatMap(leafCommands)
 }
 
-const roots: Array<[string, Command]> = [
-  ['add', addCommand],
-  ['import', importCommand],
-  ['rm', rmCommand],
-  ['server', serverCommand],
-  ['payments', paymentsCommand],
-  ['data-set', dataSetCommand],
-  ['provider', providerCommand],
-]
-
-const leaves = roots.flatMap(([root, cmd]) =>
-  leafCommands(cmd).map((leaf) => [`${root} ${leaf.name()}`.trim(), leaf] as const)
+const leaves = ALL_CLI_COMMANDS.flatMap((cmd) =>
+  leafCommands(cmd).map((leaf) => [`${cmd.name()} ${leaf.name()}`.trim(), leaf] as const)
 )
 
 describe('CLI --network default', () => {


### PR DESCRIPTION
### What changed

Adds `src/commands/index.ts` re-exporting every command and exposing `ALL_CLI_COMMANDS`. `cli.ts` registers subcommands by iterating that array, and `cli-network-defaults.test.ts` walks the same array, so adding a new top-level command touches one list.

Stacked on #445.

### How to verify

- `pnpm run typecheck`
- `pnpm run lint:fix`
- `pnpm run test:unit`
- `pnpm exec tsx src/cli.ts --help` lists `server`, `payments`, `data-set`, `import`, `add`, `rm`, `provider`.