### PR TITLE
refactor!: rename onProgress event types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ src/
 
 ## Key Patterns
 
-**Synapse SDK**: Initialize via `initializeSynapse()` in `src/core/synapse/index.ts`. Upload via `executeUpload()` in `src/core/upload/index.ts` with progress events (`onStored`, `onPullProgress`, `onCopyComplete`, `onPiecesAdded`, `onPiecesConfirmed`). Returns `{pieceCid, size, copies, failures}`.
+**Synapse SDK**: Initialize via `initializeSynapse()` in `src/core/synapse/index.ts`. Upload via `executeUpload()` in `src/core/upload/index.ts` with progress events (`stored`, `pullProgress`, `copyComplete`, `piecesAdded`, `piecesConfirmed`). Returns `{pieceCid, size, copies, failures}`.
 
 **CAR files**: CARv1 streaming, handle 3 root cases (single/multiple/none), use zero CID for no roots. See `src/core/car/car-blockstore.ts`.
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,4 +1,5 @@
 * [Filecoin Pin glossary](glossary.md) - A unified place for the defining the plethora of terms for the various technologies coming together under Filecoin Pin (e.g., existing Filecoin blockchain and storage providers, new Filecoin initiatives including Filecoin Onchain Cloud, IPFS).
 * [Explainer: behind the scenes of adding a file](behind-the-scenes-of-adding-a-file.md) - Provides more technical info about what happens for a Filecoin Pin `add` as it uses the underlying [Synapse library](glossary.md#synapse) and [Filecoin Onchain Cloud](glossary.md#filecoin-onchain-cloud) offering.
 * [Content Routing FAQ](content-routing-faq.md) - Frequently asked questions about content routing with IPNI, which Filecoin Pin relies upon, including caching behavior, provider management, and indexer operations.
+* [Progress Events](progress-events.md) - Conventions for the typed `onProgress` event unions exposed by filecoin-pin's public APIs (naming, namespacing, consumer pattern).
 * [Builder Cookbook](https://docs.filecoin.io/builder-cookbook/filecoin-pin)

--- a/documentation/progress-events.md
+++ b/documentation/progress-events.md
@@ -1,68 +1,47 @@
 # Progress Events
 
-filecoin-pin exposes progress through a single `onProgress` handler per public function rather than a bag of granular `onX` callbacks. This document describes the convention, the rationale, and the rules for naming new event types.
-
-## Why one `onProgress` instead of many callbacks
-
-The synapse-sdk uses an object-of-callbacks shape (`{ callbacks: { onProviderSelected, onDataSetResolved, ... } }`). filecoin-pin wraps that into a single typed-event-union handler.
-
-Reasons:
-- One subscription point per call. Callers do not have to remember to wire a new callback every time we add an event.
-- Discriminated unions force exhaustive handling at the type level. New events show up as compile errors in `switch` statements without a `default`.
-- Stable surface area as the SDK evolves. We can map new SDK callbacks into existing event types or add new ones without changing the public function signature.
-- Easy fan-out and logging. Consumers can log every event with one line: `onProgress: (e) => log.info(e)`.
+Public functions in filecoin-pin report progress through a single `onProgress` handler that receives a discriminated union of typed events. This document describes the event shape, the naming convention, and the rules for adding new events.
 
 ## Shape
 
-Defined in `src/core/utils/types.ts`:
+Event and handler types are defined in [`src/core/utils/types.ts`](../src/core/utils/types.ts):
 
-```ts
-export type ProgressEvent<T extends string = string, D = undefined> = D extends undefined
-  ? { type: T }
-  : { type: T; data: D }
+- `ProgressEvent<Type, Data>` — discriminated event with a `type` string and optional `data` payload.
+- `ProgressEventHandler<Events>` — handler that receives a union of events.
+- `AnyProgressEvent` — base type used as the default constraint, shaped `{ type: string; data?: unknown }`.
 
-export type ProgressEventHandler<E extends AnyProgressEvent = AnyProgressEvent> = (event: E) => void
-```
-
-Each function exports a discriminated union of its events and accepts `onProgress?: ProgressEventHandler<MyEvents>`.
+Each public function exports a union of its events and accepts `onProgress?: ProgressEventHandler<MyEvents>`.
 
 ## Naming convention
 
 The `type` discriminator string follows these rules:
 
-1. **camelCase** for words. No kebab-case, no PascalCase, no `snake_case`.
-2. **No `on` prefix** on the type string. The handler is already called `onProgress`; the prefix is redundant. Use `stored`, not `onStored`.
-3. **Colon (`:`) namespace separator** when an event belongs to a logical sub-flow whose events would otherwise collide with other unions or be ambiguous in logs. Use `removePiece:submitting`, not `removePieceSubmitting`.
-4. **No dot (`.`) separator.** Dots imply a property path; we use them only inside `data`, never in `type`.
-5. **Both sides of the colon are camelCase.** `removePiece:confirmationFailed`, not `removePiece:confirmation-failed`.
+1. **camelCase** for words. No kebab-case, PascalCase, or `snake_case`.
+2. **No `on` prefix.** The handler is already named `onProgress`. Event types name the event, e.g. `stored`, `piecesAdded`.
+3. **Colon (`:`) for namespaces** when an event belongs to a multi-step sub-flow, e.g. `removePiece:submitting`, `removePiece:confirmationFailed`.
 
 ### When to use a colon namespace
 
-Use a namespace when:
-- The event union covers a multi-step operation that maps to a user-visible flow (`removePiece:`, `removeAll:`, `ipniProviderResults:`).
-- Multiple unions might be merged in a single log stream and you want to grep by subsystem.
+Use a namespace when the event union covers a multi-step operation that maps to a user-visible flow (`removePiece:`, `removeAll:`, `ipniProviderResults:`).
 
-Skip the namespace when:
-- The events already make the subsystem obvious from a single-word name (`stored`, `piecesAdded`, `copyComplete` from `UploadProgressEvents`).
-- The function is a single concept and the union has few entries (`checkingBalances`, `validatingCapacity` from `UploadReadinessProgressEvents`).
+Skip the namespace when a single-word name already identifies the subsystem (`stored`, `piecesAdded`, `copyComplete` in `UploadProgressEvents`).
 
-If in doubt, prefer no namespace. Add one later when collision or ambiguity shows up.
+When in doubt, omit the namespace.
 
 ## Examples
 
+The snippets below illustrate naming and namespace patterns. Canonical unions live with their feature module; see [`src/core/upload/synapse.ts`](../src/core/upload/synapse.ts) for `UploadProgressEvents` in context.
+
 ```ts
-// No namespace, drop `on` prefix
 export type UploadProgressEvents =
   | ProgressEvent<'stored', { providerId: bigint; pieceCid: PieceCID }>
   | ProgressEvent<'piecesAdded', { txHash: Hash; providerId: bigint }>
   | ProgressEvent<'providerSelected', { provider: PDPProvider }>
 
-// No namespace, multi-word camelCase
 export type UploadReadinessProgressEvents =
   | ProgressEvent<'checkingBalances'>
   | ProgressEvent<'validatingCapacity'>
 
-// Colon namespace for multi-step flow
 export type RemovePieceProgressEvents =
   | ProgressEvent<'removePiece:submitting', { pieceCid: string; dataSetId: bigint }>
   | ProgressEvent<'removePiece:confirmationFailed', { pieceCid: string; dataSetId: bigint; txHash: Hash; message: string }>
@@ -80,27 +59,25 @@ onProgress: (event) => {
     case 'providerSelected':
       log.info({ provider: event.data.provider.name }, 'provider selected')
       break
-    // exhaustive: no default needed if the union is closed
+    default: {
+      const _exhaustive: never = event
+      throw new Error(`unhandled event: ${(_exhaustive as AnyProgressEvent).type}`)
+    }
   }
 }
 ```
 
-Omit `default` to get a compile-time error when the union grows. If you need a default, do an exhaustiveness check:
-
-```ts
-default: {
-  const _exhaustive: never = event
-  throw new Error(`unhandled event: ${(_exhaustive as AnyProgressEvent).type}`)
-}
-```
+The `never` default is the way to get a compile-time error when a new event is added to the union but the consumer has not handled it. Without that pattern, TypeScript will not flag a non-exhaustive `switch`.
 
 ## Adding a new event
 
-1. Add a new `ProgressEvent<'eventName', { ...data }>` member to the relevant union.
-2. Emit it from the implementation.
-3. Update consumer `switch` statements that need to react to it. The compiler points out any missing cases when there is no `default`.
+Event unions are co-located with the function that emits them (e.g. `UploadProgressEvents` lives in [`src/core/upload/synapse.ts`](../src/core/upload/synapse.ts)).
+
+1. Add a new `ProgressEvent<'eventName', { ...data }>` member to the relevant union (omit the data type for events that carry no payload).
+2. Emit it from the implementation: `onProgress?.({ type: 'eventName', data: { ... } })`, or `onProgress?.({ type: 'eventName' })` for events with no payload.
+3. Update consumer `switch` statements that need to react to it.
 4. If the event represents a sub-flow, decide whether to introduce or reuse a colon namespace.
 
 ## Backwards compatibility
 
-Event `type` strings are part of the public API. Renaming or removing a type is a breaking change and requires a major version bump and CHANGELOG entry. Adding a new event type is non-breaking.
+Event `type` strings are part of the public API. Renaming or removing a type is a breaking change and requires a major version bump and CHANGELOG entry. Adding a new event type is runtime-compatible but can break consumers that use the `never` exhaustiveness pattern; this project treats it as a minor bump.

--- a/documentation/progress-events.md
+++ b/documentation/progress-events.md
@@ -1,0 +1,106 @@
+# Progress Events
+
+filecoin-pin exposes progress through a single `onProgress` handler per public function rather than a bag of granular `onX` callbacks. This document describes the convention, the rationale, and the rules for naming new event types.
+
+## Why one `onProgress` instead of many callbacks
+
+The synapse-sdk uses an object-of-callbacks shape (`{ callbacks: { onProviderSelected, onDataSetResolved, ... } }`). filecoin-pin wraps that into a single typed-event-union handler.
+
+Reasons:
+- One subscription point per call. Callers do not have to remember to wire a new callback every time we add an event.
+- Discriminated unions force exhaustive handling at the type level. New events show up as compile errors in `switch` statements without a `default`.
+- Stable surface area as the SDK evolves. We can map new SDK callbacks into existing event types or add new ones without changing the public function signature.
+- Easy fan-out and logging. Consumers can log every event with one line: `onProgress: (e) => log.info(e)`.
+
+## Shape
+
+Defined in `src/core/utils/types.ts`:
+
+```ts
+export type ProgressEvent<T extends string = string, D = undefined> = D extends undefined
+  ? { type: T }
+  : { type: T; data: D }
+
+export type ProgressEventHandler<E extends AnyProgressEvent = AnyProgressEvent> = (event: E) => void
+```
+
+Each function exports a discriminated union of its events and accepts `onProgress?: ProgressEventHandler<MyEvents>`.
+
+## Naming convention
+
+The `type` discriminator string follows these rules:
+
+1. **camelCase** for words. No kebab-case, no PascalCase, no `snake_case`.
+2. **No `on` prefix** on the type string. The handler is already called `onProgress`; the prefix is redundant. Use `stored`, not `onStored`.
+3. **Colon (`:`) namespace separator** when an event belongs to a logical sub-flow whose events would otherwise collide with other unions or be ambiguous in logs. Use `removePiece:submitting`, not `removePieceSubmitting`.
+4. **No dot (`.`) separator.** Dots imply a property path; we use them only inside `data`, never in `type`.
+5. **Both sides of the colon are camelCase.** `removePiece:confirmationFailed`, not `removePiece:confirmation-failed`.
+
+### When to use a colon namespace
+
+Use a namespace when:
+- The event union covers a multi-step operation that maps to a user-visible flow (`removePiece:`, `removeAll:`, `ipniProviderResults:`).
+- Multiple unions might be merged in a single log stream and you want to grep by subsystem.
+
+Skip the namespace when:
+- The events already make the subsystem obvious from a single-word name (`stored`, `piecesAdded`, `copyComplete` from `UploadProgressEvents`).
+- The function is a single concept and the union has few entries (`checkingBalances`, `validatingCapacity` from `UploadReadinessProgressEvents`).
+
+If in doubt, prefer no namespace. Add one later when collision or ambiguity shows up.
+
+## Examples
+
+```ts
+// No namespace, drop `on` prefix
+export type UploadProgressEvents =
+  | ProgressEvent<'stored', { providerId: bigint; pieceCid: PieceCID }>
+  | ProgressEvent<'piecesAdded', { txHash: Hash; providerId: bigint }>
+  | ProgressEvent<'providerSelected', { provider: PDPProvider }>
+
+// No namespace, multi-word camelCase
+export type UploadReadinessProgressEvents =
+  | ProgressEvent<'checkingBalances'>
+  | ProgressEvent<'validatingCapacity'>
+
+// Colon namespace for multi-step flow
+export type RemovePieceProgressEvents =
+  | ProgressEvent<'removePiece:submitting', { pieceCid: string; dataSetId: bigint }>
+  | ProgressEvent<'removePiece:confirmationFailed', { pieceCid: string; dataSetId: bigint; txHash: Hash; message: string }>
+  | ProgressEvent<'removePiece:complete', { txHash: Hash; confirmed: boolean }>
+```
+
+## Consumer pattern
+
+```ts
+onProgress: (event) => {
+  switch (event.type) {
+    case 'stored':
+      log.info({ providerId: event.data.providerId }, 'piece stored')
+      break
+    case 'providerSelected':
+      log.info({ provider: event.data.provider.name }, 'provider selected')
+      break
+    // exhaustive: no default needed if the union is closed
+  }
+}
+```
+
+Omit `default` to get a compile-time error when the union grows. If you need a default, do an exhaustiveness check:
+
+```ts
+default: {
+  const _exhaustive: never = event
+  throw new Error(`unhandled event: ${(_exhaustive as AnyProgressEvent).type}`)
+}
+```
+
+## Adding a new event
+
+1. Add a new `ProgressEvent<'eventName', { ...data }>` member to the relevant union.
+2. Emit it from the implementation.
+3. Update consumer `switch` statements that need to react to it. The compiler points out any missing cases when there is no `default`.
+4. If the event represents a sub-flow, decide whether to introduce or reuse a colon namespace.
+
+## Backwards compatibility
+
+Event `type` strings are part of the public API. Renaming or removing a type is a breaking change and requires a major version bump and CHANGELOG entry. Adding a new event type is non-breaking.

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -190,23 +190,23 @@ export async function validatePaymentSetup(
       if (!spinner) return
 
       switch (event.type) {
-        case 'checking-balances': {
+        case 'checkingBalances': {
           spinner.message('Checking payment setup requirements...')
           return
         }
-        case 'checking-allowances': {
+        case 'checkingAllowances': {
           spinner.message('Checking WarmStorage permissions...')
           return
         }
-        case 'configuring-allowances': {
+        case 'configuringAllowances': {
           spinner.message('Configuring WarmStorage permissions (one-time setup)...')
           return
         }
-        case 'validating-capacity': {
+        case 'validatingCapacity': {
           spinner.message('Validating payment capacity...')
           return
         }
-        case 'allowances-configured': {
+        case 'allowancesConfigured': {
           // No spinner change; we log once readiness completes.
           return
         }
@@ -336,7 +336,7 @@ export async function performUpload(
   // Start with upload operation
   flow.addOperation('upload', 'Uploading to Filecoin...')
 
-  // Track primary provider ID from onStored to label subsequent events
+  // Track primary provider ID from `stored` to label subsequent events
   let primaryProviderId: bigint | undefined
 
   function getRole(providerId: bigint): CopyRole {
@@ -374,22 +374,22 @@ export async function performUpload(
     ...(options.skipIpniVerification && { ipniValidation: { enabled: false } }),
     onProgress(event) {
       switch (event.type) {
-        case 'onStored': {
+        case 'stored': {
           primaryProviderId = event.data.providerId
           flow.completeOperation('upload', `${roleLabel('primary')} Stored on provider ${event.data.providerId}`, {
             type: 'success',
           })
-          // Commit happens later (onPiecesAdded), not here.
+          // Commit happens later (`piecesAdded`), not here.
           break
         }
-        case 'onPullProgress': {
+        case 'pullProgress': {
           flow.addOperation(
             `secondary-pull-${event.data.providerId}`,
             `${roleLabel('secondary')} Pulling to provider ${event.data.providerId}...`
           )
           break
         }
-        case 'onCopyComplete': {
+        case 'copyComplete': {
           flow.completeOperation(
             `secondary-pull-${event.data.providerId}`,
             `${roleLabel('secondary')} Stored on provider ${event.data.providerId}`,
@@ -397,7 +397,7 @@ export async function performUpload(
           )
           break
         }
-        case 'onCopyFailed': {
+        case 'copyFailed': {
           flow.completeOperation(
             `secondary-pull-${event.data.providerId}`,
             `${roleLabel('secondary')} Failed: provider ${event.data.providerId} - ${event.data.error.message}`,
@@ -405,7 +405,7 @@ export async function performUpload(
           )
           break
         }
-        case 'onPiecesAdded': {
+        case 'piecesAdded': {
           const role = getRole(event.data.providerId)
 
           const commitId = `commit-${event.data.providerId}`
@@ -431,7 +431,7 @@ export async function performUpload(
           )
           break
         }
-        case 'onPiecesConfirmed': {
+        case 'piecesConfirmed': {
           const role = getRole(event.data.providerId)
           flow.completeOperation(
             `chain-${event.data.providerId}`,
@@ -441,7 +441,7 @@ export async function performUpload(
           break
         }
 
-        case 'ipniProviderResults.retryUpdate': {
+        case 'ipniProviderResults:retryUpdate': {
           const attempt = event.data.attempt ?? (event.data.retryCount === 0 ? 1 : event.data.retryCount + 1)
           flow.addOperation(
             'ipni',
@@ -456,7 +456,7 @@ export async function performUpload(
           )
           break
         }
-        case 'ipniProviderResults.complete': {
+        case 'ipniProviderResults:complete': {
           flow.completeOperation('ipni', 'IPNI provider records found. IPFS retrieval possible.', {
             type: 'success',
             details: {
@@ -470,7 +470,7 @@ export async function performUpload(
           })
           break
         }
-        case 'ipniProviderResults.failed': {
+        case 'ipniProviderResults:failed': {
           flow.completeOperation('ipni', 'IPNI provider records not found.', {
             type: 'warning',
             details: {

--- a/src/core/payments/README.md
+++ b/src/core/payments/README.md
@@ -49,21 +49,14 @@ Below are examples of how we use our custom Synapse SDK abstractions from within
 
 ```typescript
 import { RPC_URLS } from '@filoz/synapse-sdk'
-import { setupSynapse } from 'filecoin-pin/core/synapse'
+import { initializeSynapse } from 'filecoin-pin/core/synapse'
 
 const config = {
   privateKey: process.env.PRIVATE_KEY,
   rpcUrl: RPC_URLS.calibration.websocket
 }
 
-const synapseService = await setupSynapse(config, logger, {
-  onProviderSelected: (provider) => {
-    console.log(`Selected provider: ${provider.name}`)
-  },
-  onDataSetResolved: (info) => {
-    console.log(`Dataset ID: ${info.dataSetId}`)
-  }
-})
+const synapse = await initializeSynapse(config, logger)
 ```
 
 ### Upload CAR File
@@ -84,7 +77,7 @@ const result = await uploadToSynapse(
   logger,
   {
     onProgress: (event) => {
-      if (event.type === 'onStored') {
+      if (event.type === 'stored') {
         console.log(`Stored on provider ${event.data.providerId}: ${event.data.pieceCid}`)
       }
     }

--- a/src/core/piece/remove-all-pieces.ts
+++ b/src/core/piece/remove-all-pieces.ts
@@ -19,12 +19,12 @@ import { removePiece } from './remove-piece.js'
  * Progress events emitted during batch piece removal
  */
 export type RemoveAllPiecesProgressEvents =
-  | ProgressEvent<'remove-all:fetching', { dataSetId: bigint }>
-  | ProgressEvent<'remove-all:fetched', { dataSetId: bigint; totalPieces: number }>
-  | ProgressEvent<'remove-all:removing', { current: number; total: number; pieceCid: string }>
-  | ProgressEvent<'remove-all:removed', { current: number; total: number; pieceCid: string; txHash: string }>
-  | ProgressEvent<'remove-all:failed', { current: number; total: number; pieceCid: string; error: string }>
-  | ProgressEvent<'remove-all:complete', { totalPieces: number; removedCount: number; failedCount: number }>
+  | ProgressEvent<'removeAll:fetching', { dataSetId: bigint }>
+  | ProgressEvent<'removeAll:fetched', { dataSetId: bigint; totalPieces: number }>
+  | ProgressEvent<'removeAll:removing', { current: number; total: number; pieceCid: string }>
+  | ProgressEvent<'removeAll:removed', { current: number; total: number; pieceCid: string; txHash: string }>
+  | ProgressEvent<'removeAll:failed', { current: number; total: number; pieceCid: string; error: string }>
+  | ProgressEvent<'removeAll:complete', { totalPieces: number; removedCount: number; failedCount: number }>
 
 /**
  * Result of a single piece removal attempt
@@ -106,10 +106,10 @@ export async function removeAllPieces(
   if (providedPieces) {
     // Use pre-fetched pieces (already filtered by caller)
     pieces = providedPieces.filter((p) => p.status === PieceStatus.ACTIVE)
-    onProgress?.({ type: 'remove-all:fetched', data: { dataSetId, totalPieces: pieces.length } })
+    onProgress?.({ type: 'removeAll:fetched', data: { dataSetId, totalPieces: pieces.length } })
   } else {
     // Fetch all pieces from the dataset
-    onProgress?.({ type: 'remove-all:fetching', data: { dataSetId } })
+    onProgress?.({ type: 'removeAll:fetching', data: { dataSetId } })
 
     const { pieces: allPieces } = await getDataSetPieces(synapse, storageContext, { logger })
 
@@ -121,13 +121,13 @@ export async function removeAllPieces(
       logger?.info({ skipped: skippedCount, total: allPieces.length }, 'Skipped pieces already pending removal')
     }
 
-    onProgress?.({ type: 'remove-all:fetched', data: { dataSetId, totalPieces: pieces.length } })
+    onProgress?.({ type: 'removeAll:fetched', data: { dataSetId, totalPieces: pieces.length } })
   }
 
   const totalPieces = pieces.length
 
   if (totalPieces === 0) {
-    onProgress?.({ type: 'remove-all:complete', data: { totalPieces: 0, removedCount: 0, failedCount: 0 } })
+    onProgress?.({ type: 'removeAll:complete', data: { totalPieces: 0, removedCount: 0, failedCount: 0 } })
     return {
       dataSetId,
       totalPieces: 0,
@@ -155,7 +155,7 @@ export async function removeAllPieces(
     const current = i + 1
     const pieceCid = piece.pieceCid
 
-    onProgress?.({ type: 'remove-all:removing', data: { current, total: totalPieces, pieceCid } })
+    onProgress?.({ type: 'removeAll:removing', data: { current, total: totalPieces, pieceCid } })
 
     try {
       const txHash = await removePiece(pieceCid, storageContext, {
@@ -167,7 +167,7 @@ export async function removeAllPieces(
       transactions.push({ pieceCid, txHash, success: true })
       removedCount++
 
-      onProgress?.({ type: 'remove-all:removed', data: { current, total: totalPieces, pieceCid, txHash } })
+      onProgress?.({ type: 'removeAll:removed', data: { current, total: totalPieces, pieceCid, txHash } })
 
       logger?.info({ pieceCid, txHash, current, total: totalPieces }, 'Piece removed successfully')
     } catch (error) {
@@ -175,13 +175,13 @@ export async function removeAllPieces(
       transactions.push({ pieceCid, txHash: '', success: false, error: errorMessage })
       failedCount++
 
-      onProgress?.({ type: 'remove-all:failed', data: { current, total: totalPieces, pieceCid, error: errorMessage } })
+      onProgress?.({ type: 'removeAll:failed', data: { current, total: totalPieces, pieceCid, error: errorMessage } })
 
       logger?.error({ pieceCid, error, current, total: totalPieces }, 'Failed to remove piece')
     }
   }
 
-  onProgress?.({ type: 'remove-all:complete', data: { totalPieces, removedCount, failedCount } })
+  onProgress?.({ type: 'removeAll:complete', data: { totalPieces, removedCount, failedCount } })
 
   return {
     dataSetId,

--- a/src/core/piece/remove-piece.ts
+++ b/src/core/piece/remove-piece.ts
@@ -18,14 +18,14 @@ import type { ProgressEvent, ProgressEventHandler } from '../utils/types.js'
  * Note: Errors are propagated via thrown exceptions, not events (similar to upload pattern)
  */
 export type RemovePieceProgressEvents =
-  | ProgressEvent<'remove-piece:submitting', { pieceCid: string; dataSetId: bigint }>
-  | ProgressEvent<'remove-piece:submitted', { pieceCid: string; dataSetId: bigint; txHash: Hash }>
-  | ProgressEvent<'remove-piece:confirming', { pieceCid: string; dataSetId: bigint; txHash: Hash }>
+  | ProgressEvent<'removePiece:submitting', { pieceCid: string; dataSetId: bigint }>
+  | ProgressEvent<'removePiece:submitted', { pieceCid: string; dataSetId: bigint; txHash: Hash }>
+  | ProgressEvent<'removePiece:confirming', { pieceCid: string; dataSetId: bigint; txHash: Hash }>
   | ProgressEvent<
-      'remove-piece:confirmation-failed',
+      'removePiece:confirmationFailed',
       { pieceCid: string; dataSetId: bigint; txHash: Hash; message: string }
     >
-  | ProgressEvent<'remove-piece:complete', { txHash: Hash; confirmed: boolean }>
+  | ProgressEvent<'removePiece:complete', { txHash: Hash; confirmed: boolean }>
 
 /**
  * Number of block confirmations to wait for when waitForConfirmation=true
@@ -93,14 +93,14 @@ export async function removePiece(
     throw new Error('A Synapse instance is required when waitForConfirmation is true')
   }
 
-  onProgress?.({ type: 'remove-piece:submitting', data: { pieceCid, dataSetId } })
+  onProgress?.({ type: 'removePiece:submitting', data: { pieceCid, dataSetId } })
   const txHash = await storageContext.deletePiece({ piece: pieceCid })
-  onProgress?.({ type: 'remove-piece:submitted', data: { pieceCid, dataSetId, txHash } })
+  onProgress?.({ type: 'removePiece:submitted', data: { pieceCid, dataSetId, txHash } })
 
   let isConfirmed = false
   if (isWaitForConfirmationOptions(options)) {
     const { synapse } = options
-    onProgress?.({ type: 'remove-piece:confirming', data: { pieceCid, dataSetId, txHash } })
+    onProgress?.({ type: 'removePiece:confirming', data: { pieceCid, dataSetId, txHash } })
     try {
       await synapse.client.waitForTransactionReceipt({
         hash: txHash,
@@ -111,13 +111,13 @@ export async function removePiece(
     } catch (error: unknown) {
       // Confirmation timeout is non-fatal - transaction may still succeed
       onProgress?.({
-        type: 'remove-piece:confirmation-failed',
+        type: 'removePiece:confirmationFailed',
         data: { pieceCid, dataSetId, txHash, message: getErrorMessage(error) },
       })
     }
   }
 
-  onProgress?.({ type: 'remove-piece:complete', data: { txHash, confirmed: isConfirmed } })
+  onProgress?.({ type: 'removePiece:complete', data: { txHash, confirmed: isConfirmed } })
   return txHash
 }
 

--- a/src/core/upload/index.ts
+++ b/src/core/upload/index.ts
@@ -51,11 +51,11 @@ export function getNetworkSlug(chain: Chain): string {
  * Options for evaluating whether an upload can proceed.
  */
 export type UploadReadinessProgressEvents =
-  | ProgressEvent<'checking-balances'>
-  | ProgressEvent<'checking-allowances'>
-  | ProgressEvent<'configuring-allowances'>
-  | ProgressEvent<'allowances-configured', { transactionHash?: string }>
-  | ProgressEvent<'validating-capacity'>
+  | ProgressEvent<'checkingBalances'>
+  | ProgressEvent<'checkingAllowances'>
+  | ProgressEvent<'configuringAllowances'>
+  | ProgressEvent<'allowancesConfigured', { transactionHash?: string }>
+  | ProgressEvent<'validatingCapacity'>
 
 export interface UploadReadinessOptions {
   /** Initialized Synapse instance. */
@@ -124,7 +124,7 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
   const sessionKeyMode = isSessionKeyMode(synapse)
   const canConfigureAllowances = autoConfigureAllowances && !sessionKeyMode
 
-  onProgress?.({ type: 'checking-balances' })
+  onProgress?.({ type: 'checkingBalances' })
 
   const filStatus = await checkFILBalance(synapse)
   const walletUsdfcBalance = await checkUSDFCBalance(synapse)
@@ -144,7 +144,7 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
     }
   }
 
-  onProgress?.({ type: 'checking-allowances' })
+  onProgress?.({ type: 'checkingAllowances' })
 
   const allowanceStatus = await checkAllowances(synapse)
   let allowancesUpdated = false
@@ -152,14 +152,14 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
 
   // Only try to configure allowances if not in session key mode
   if (allowanceStatus.needsUpdate && canConfigureAllowances) {
-    onProgress?.({ type: 'configuring-allowances' })
+    onProgress?.({ type: 'configuringAllowances' })
     const setResult = await setMaxAllowances(synapse)
     allowancesUpdated = true
     allowanceTxHash = setResult.transactionHash
-    onProgress?.({ type: 'allowances-configured', data: { transactionHash: allowanceTxHash } })
+    onProgress?.({ type: 'allowancesConfigured', data: { transactionHash: allowanceTxHash } })
   }
 
-  onProgress?.({ type: 'validating-capacity' })
+  onProgress?.({ type: 'validatingCapacity' })
 
   const capacityCheck = await validatePaymentCapacity(synapse, fileSize)
   const capacityStatus = determineCapacityStatus(capacityCheck)
@@ -324,18 +324,18 @@ export async function executeUpload(
     )
   }
 
-  // Collect providers from `onProviderSelected` events for IPNI validation
+  // Collect providers from `providerSelected` events for IPNI validation
   const selectedProviders: PDPProvider[] = []
   let ipniValidationPromise: Promise<boolean> | undefined
 
   const onProgress: ProgressEventHandler<UploadProgressEvents | ValidateIPNIProgressEvents> = (event) => {
     switch (event.type) {
-      case 'onProviderSelected': {
+      case 'providerSelected': {
         selectedProviders.push(event.data.provider)
         break
       }
-      case 'onPiecesAdded': {
-        // Begin IPNI validation on the first onPiecesAdded event
+      case 'piecesAdded': {
+        // Begin IPNI validation on the first piecesAdded event
         if (options.ipniValidation?.enabled !== false && ipniValidationPromise == null) {
           const {
             enabled: _enabled,

--- a/src/core/upload/synapse.ts
+++ b/src/core/upload/synapse.ts
@@ -15,14 +15,14 @@ import { APPLICATION_SOURCE } from '../synapse/constants.js'
 import type { ProgressEvent, ProgressEventHandler } from '../utils/types.js'
 
 export type UploadProgressEvents =
-  | ProgressEvent<'onStored', { providerId: bigint; pieceCid: PieceCID }>
-  | ProgressEvent<'onPiecesAdded', { txHash: Hash; providerId: bigint }>
-  | ProgressEvent<'onPiecesConfirmed', { dataSetId: bigint; providerId: bigint; pieceIds: bigint[] }>
-  | ProgressEvent<'onCopyComplete', { providerId: bigint; pieceCid: PieceCID }>
-  | ProgressEvent<'onCopyFailed', { providerId: bigint; pieceCid: PieceCID; error: Error }>
-  | ProgressEvent<'onPullProgress', { providerId: bigint; pieceCid: PieceCID; status: PullStatus }>
-  | ProgressEvent<'onProviderSelected', { provider: PDPProvider }>
-  | ProgressEvent<'onDataSetResolved', { dataSetId: bigint; provider: PDPProvider }>
+  | ProgressEvent<'stored', { providerId: bigint; pieceCid: PieceCID }>
+  | ProgressEvent<'piecesAdded', { txHash: Hash; providerId: bigint }>
+  | ProgressEvent<'piecesConfirmed', { dataSetId: bigint; providerId: bigint; pieceIds: bigint[] }>
+  | ProgressEvent<'copyComplete', { providerId: bigint; pieceCid: PieceCID }>
+  | ProgressEvent<'copyFailed', { providerId: bigint; pieceCid: PieceCID; error: Error }>
+  | ProgressEvent<'pullProgress', { providerId: bigint; pieceCid: PieceCID; status: PullStatus }>
+  | ProgressEvent<'providerSelected', { provider: PDPProvider }>
+  | ProgressEvent<'dataSetResolved', { dataSetId: bigint; provider: PDPProvider }>
 
 export type SynapseUploadData = Uint8Array | ReadableStream<Uint8Array>
 
@@ -189,7 +189,7 @@ export async function uploadToSynapse(
           },
           'Provider selected'
         )
-        onProgress?.({ type: 'onProviderSelected', data: { provider } })
+        onProgress?.({ type: 'providerSelected', data: { provider } })
       },
 
       onDataSetResolved: (info) => {
@@ -202,7 +202,7 @@ export async function uploadToSynapse(
           },
           'Data set resolved'
         )
-        onProgress?.({ type: 'onDataSetResolved', data: { dataSetId: info.dataSetId, provider: info.provider } })
+        onProgress?.({ type: 'dataSetResolved', data: { dataSetId: info.dataSetId, provider: info.provider } })
       },
 
       onStored: (providerId, pieceCid) => {
@@ -215,7 +215,7 @@ export async function uploadToSynapse(
           },
           'Piece stored on provider'
         )
-        onProgress?.({ type: 'onStored', data: { providerId, pieceCid } })
+        onProgress?.({ type: 'stored', data: { providerId, pieceCid } })
       },
 
       onPiecesAdded: (txHash, providerId, pieces) => {
@@ -229,7 +229,7 @@ export async function uploadToSynapse(
           },
           'Piece addition transaction submitted'
         )
-        onProgress?.({ type: 'onPiecesAdded', data: { txHash, providerId } })
+        onProgress?.({ type: 'piecesAdded', data: { txHash, providerId } })
       },
 
       onPiecesConfirmed: (dataSetId, providerId, pieces) => {
@@ -244,7 +244,7 @@ export async function uploadToSynapse(
           },
           'Piece addition confirmed on-chain'
         )
-        onProgress?.({ type: 'onPiecesConfirmed', data: { dataSetId, providerId, pieceIds } })
+        onProgress?.({ type: 'piecesConfirmed', data: { dataSetId, providerId, pieceIds } })
       },
 
       onCopyComplete: (providerId, pieceCid) => {
@@ -257,7 +257,7 @@ export async function uploadToSynapse(
           },
           'Secondary copy complete'
         )
-        onProgress?.({ type: 'onCopyComplete', data: { providerId, pieceCid } })
+        onProgress?.({ type: 'copyComplete', data: { providerId, pieceCid } })
       },
 
       onCopyFailed: (providerId, pieceCid, error) => {
@@ -271,7 +271,7 @@ export async function uploadToSynapse(
           },
           'Secondary copy failed'
         )
-        onProgress?.({ type: 'onCopyFailed', data: { providerId, pieceCid, error } })
+        onProgress?.({ type: 'copyFailed', data: { providerId, pieceCid, error } })
       },
 
       onPullProgress: (providerId, pieceCid, status) => {
@@ -285,7 +285,7 @@ export async function uploadToSynapse(
           },
           'Pull progress update'
         )
-        onProgress?.({ type: 'onPullProgress', data: { providerId, pieceCid, status } })
+        onProgress?.({ type: 'pullProgress', data: { providerId, pieceCid, status } })
       },
     },
   }

--- a/src/core/utils/validate-ipni-advertisement.ts
+++ b/src/core/utils/validate-ipni-advertisement.ts
@@ -40,7 +40,7 @@ interface ProviderResult {
 
 export type ValidateIPNIProgressEvents =
   | ProgressEvent<
-      'ipniProviderResults.retryUpdate',
+      'ipniProviderResults:retryUpdate',
       {
         retryCount: number
         attempt: number
@@ -52,8 +52,8 @@ export type ValidateIPNIProgressEvents =
         cidMaxAttempts: number
       }
     >
-  | ProgressEvent<'ipniProviderResults.complete', { result: true; retryCount: number }>
-  | ProgressEvent<'ipniProviderResults.failed', { error: Error }>
+  | ProgressEvent<'ipniProviderResults:complete', { result: true; retryCount: number }>
+  | ProgressEvent<'ipniProviderResults:failed', { error: Error }>
 
 export interface WaitForIpniProviderResultsOptions {
   /**
@@ -189,7 +189,7 @@ export async function waitForIpniProviderResults(
     try {
       // totalChecks is incremented before each emitted retryUpdate, so last retryCount is totalChecks - 1
       const retryCount = totalChecks > 0 ? totalChecks - 1 : 0
-      options?.onProgress?.({ type: 'ipniProviderResults.complete', data: { result: true, retryCount } })
+      options?.onProgress?.({ type: 'ipniProviderResults:complete', data: { result: true, retryCount } })
     } catch (error) {
       options?.logger?.warn({ error }, 'Error in consumer onProgress callback for complete event')
     }
@@ -197,7 +197,7 @@ export async function waitForIpniProviderResults(
     return true
   } catch (error) {
     try {
-      options?.onProgress?.({ type: 'ipniProviderResults.failed', data: { error: error as Error } })
+      options?.onProgress?.({ type: 'ipniProviderResults:failed', data: { error: error as Error } })
     } catch (callbackError) {
       options?.logger?.warn({ error: callbackError }, 'Error in consumer onProgress callback for failed event')
     }
@@ -261,7 +261,7 @@ async function waitForIpniProviderResultsForCid(
       const emittedRetryMetadata = onRetryUpdate?.()
       try {
         options?.onProgress?.({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: {
             retryCount: emittedRetryMetadata?.retryCount ?? retryCount,
             attempt: emittedRetryMetadata?.attempt ?? retryCount + 1,

--- a/src/rm/remove-all-pieces.ts
+++ b/src/rm/remove-all-pieces.ts
@@ -133,29 +133,29 @@ export async function runRmAllPieces(options: RmAllPiecesOptions): Promise<RmAll
 
     const onProgress = (event: RemoveAllPiecesProgressEvents): void => {
       switch (event.type) {
-        case 'remove-all:fetching':
+        case 'removeAll:fetching':
           spinner.message('Fetching pieces...')
           break
 
-        case 'remove-all:fetched':
+        case 'removeAll:fetched':
           totalPieces = event.data.totalPieces
           spinner.message(`Found ${totalPieces} pieces`)
           break
 
-        case 'remove-all:removing':
+        case 'removeAll:removing':
           currentPiece = event.data.current
           spinner.message(`Removing piece ${currentPiece}/${totalPieces}...`)
           break
 
-        case 'remove-all:removed':
+        case 'removeAll:removed':
           spinner.message(`${pc.green('✓')} Removed ${event.data.current}/${totalPieces}`)
           break
 
-        case 'remove-all:failed':
+        case 'removeAll:failed':
           spinner.message(`${pc.red('✗')} Failed ${event.data.current}/${totalPieces}: ${event.data.error}`)
           break
 
-        case 'remove-all:complete':
+        case 'removeAll:complete':
           // Main flow will handle stopping the spinner
           break
       }

--- a/src/rm/remove-piece.ts
+++ b/src/rm/remove-piece.ts
@@ -75,24 +75,24 @@ export async function runRmPiece(options: RmPieceOptions): Promise<RmPieceResult
     // Remove piece with progress tracking
     const onProgress = (event: RemovePieceProgressEvents): void => {
       switch (event.type) {
-        case 'remove-piece:submitting':
+        case 'removePiece:submitting':
           spinner.message('Submitting remove transaction...')
           break
 
-        case 'remove-piece:submitted':
+        case 'removePiece:submitted':
           spinner.message(`Transaction submitted: ${event.data.txHash}`)
           txHash = event.data.txHash
           break
 
-        case 'remove-piece:confirming':
+        case 'removePiece:confirming':
           spinner.message('Waiting for transaction confirmation...')
           break
 
-        case 'remove-piece:confirmation-failed':
+        case 'removePiece:confirmationFailed':
           spinner.message(`${pc.yellow('⚠')} Confirmation wait timed out: ${event.data.message}`)
           break
 
-        case 'remove-piece:complete':
+        case 'removePiece:complete':
           isConfirmed = event.data.confirmed
           txHash = event.data.txHash
           // Main flow will handle stopping the spinner

--- a/src/test/unit/remove-all-pieces.test.ts
+++ b/src/test/unit/remove-all-pieces.test.ts
@@ -86,13 +86,13 @@ describe('removeAllPieces', () => {
     const eventTypes = onProgress.mock.calls.map((call) => call[0].type)
 
     expect(eventTypes).toEqual([
-      'remove-all:fetching',
-      'remove-all:fetched',
-      'remove-all:removing',
-      'remove-all:removed',
-      'remove-all:removing',
-      'remove-all:removed',
-      'remove-all:complete',
+      'removeAll:fetching',
+      'removeAll:fetched',
+      'removeAll:removing',
+      'removeAll:removed',
+      'removeAll:removing',
+      'removeAll:removed',
+      'removeAll:complete',
     ])
   })
 
@@ -114,7 +114,7 @@ describe('removeAllPieces', () => {
     ])
 
     // Check failed event was emitted
-    const failedEvent = onProgress.mock.calls.find((call) => call[0].type === 'remove-all:failed')
+    const failedEvent = onProgress.mock.calls.find((call) => call[0].type === 'removeAll:failed')
     expect(failedEvent).toBeDefined()
     expect(failedEvent?.[0].data.error).toBe('Transaction failed')
   })

--- a/src/test/unit/remove-piece.test.ts
+++ b/src/test/unit/remove-piece.test.ts
@@ -65,19 +65,19 @@ describe('removePiece', () => {
       timeout: 120000,
     })
     expect(onProgress).toHaveBeenNthCalledWith(1, {
-      type: 'remove-piece:submitting',
+      type: 'removePiece:submitting',
       data: { pieceCid: 'bafkzcibpiece', dataSetId: 99n },
     })
     expect(onProgress).toHaveBeenNthCalledWith(2, {
-      type: 'remove-piece:submitted',
+      type: 'removePiece:submitted',
       data: { pieceCid: 'bafkzcibpiece', dataSetId: 99n, txHash: state.txHash },
     })
     expect(onProgress).toHaveBeenNthCalledWith(3, {
-      type: 'remove-piece:confirming',
+      type: 'removePiece:confirming',
       data: { pieceCid: 'bafkzcibpiece', dataSetId: 99n, txHash: state.txHash },
     })
     expect(onProgress).toHaveBeenNthCalledWith(4, {
-      type: 'remove-piece:complete',
+      type: 'removePiece:complete',
       data: { txHash: state.txHash, confirmed: true },
     })
   })
@@ -99,11 +99,11 @@ describe('removePiece', () => {
       timeout: 120000,
     })
     expect(onProgress).toHaveBeenCalledWith({
-      type: 'remove-piece:confirmation-failed',
+      type: 'removePiece:confirmationFailed',
       data: { pieceCid: 'bafkzcibpiece', dataSetId: 99n, txHash: state.txHash, message: 'timeout' },
     })
     expect(onProgress).toHaveBeenLastCalledWith({
-      type: 'remove-piece:complete',
+      type: 'removePiece:complete',
       data: { txHash: state.txHash, confirmed: false },
     })
   })
@@ -116,15 +116,15 @@ describe('removePiece', () => {
     expect(result).toBe(state.txHash)
     expect(mockWaitForTransactionReceipt).not.toHaveBeenCalled()
     expect(onProgress).toHaveBeenNthCalledWith(1, {
-      type: 'remove-piece:submitting',
+      type: 'removePiece:submitting',
       data: { pieceCid: 'bafkzcibpiece', dataSetId: 99n },
     })
     expect(onProgress).toHaveBeenNthCalledWith(2, {
-      type: 'remove-piece:submitted',
+      type: 'removePiece:submitted',
       data: { pieceCid: 'bafkzcibpiece', dataSetId: 99n, txHash: state.txHash },
     })
     expect(onProgress).toHaveBeenNthCalledWith(3, {
-      type: 'remove-piece:complete',
+      type: 'removePiece:complete',
       data: { txHash: state.txHash, confirmed: false },
     })
   })

--- a/src/test/unit/rm-cmd.test.ts
+++ b/src/test/unit/rm-cmd.test.ts
@@ -39,11 +39,11 @@ const {
 
   const mockRemovePiece = vi.fn(async (_pieceCid: string, _storage: any, opts: { onProgress?: any }) => {
     opts.onProgress?.({
-      type: 'remove-piece:submitted',
+      type: 'removePiece:submitted',
       data: { pieceCid: _pieceCid, dataSetId: Number(_storage.dataSetId), txHash: '0xtx' },
     })
     opts.onProgress?.({
-      type: 'remove-piece:complete',
+      type: 'removePiece:complete',
       data: { txHash: '0xtx', confirmed: true },
     })
     return '0xtx'

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -170,11 +170,11 @@ describe('synapse-service', () => {
         contextId: 'pin-789',
         onProgress(event) {
           switch (event.type) {
-            case 'onStored': {
+            case 'stored': {
               storedCallbackCalled = true
               break
             }
-            case 'onPiecesAdded': {
+            case 'piecesAdded': {
               piecesAddedCallbackCalled = true
               break
             }

--- a/src/test/unit/validate-ipni-advertisement.test.ts
+++ b/src/test/unit/validate-ipni-advertisement.test.ts
@@ -73,12 +73,12 @@ describe('waitForIpniProviderResults', () => {
       // Should emit retryUpdate for attempt 0 and a final complete(true)
       expect(onProgress).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: expect.objectContaining({ retryCount: 0 }),
         })
       )
       expect(onProgress).toHaveBeenCalledWith({
-        type: 'ipniProviderResults.complete',
+        type: 'ipniProviderResults:complete',
         data: { result: true, retryCount: 0 },
       })
     })
@@ -101,30 +101,30 @@ describe('waitForIpniProviderResults', () => {
       // Expect retryUpdate with counts 0,1,2,3 and final complete after all checks
       expect(onProgress).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: expect.objectContaining({ retryCount: 0 }),
         })
       )
       expect(onProgress).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: expect.objectContaining({ retryCount: 1 }),
         })
       )
       expect(onProgress).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: expect.objectContaining({ retryCount: 2 }),
         })
       )
       expect(onProgress).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: expect.objectContaining({ retryCount: 3 }),
         })
       )
       expect(onProgress).toHaveBeenCalledWith({
-        type: 'ipniProviderResults.complete',
+        type: 'ipniProviderResults:complete',
         data: { result: true, retryCount: 3 },
       })
     })
@@ -234,20 +234,20 @@ describe('waitForIpniProviderResults', () => {
 
       expect(onProgress).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: expect.objectContaining({ retryCount: 0 }),
         })
       )
       expect(onProgress).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: expect.objectContaining({ retryCount: 1 }),
         })
       )
-      const completeEvents = onProgress.mock.calls.filter(([event]) => event.type === 'ipniProviderResults.complete')
+      const completeEvents = onProgress.mock.calls.filter(([event]) => event.type === 'ipniProviderResults:complete')
       expect(completeEvents).toHaveLength(1)
       expect(completeEvents[0]?.[0]).toEqual({
-        type: 'ipniProviderResults.complete',
+        type: 'ipniProviderResults:complete',
         data: { result: true, retryCount: 1 },
       })
     })
@@ -269,22 +269,22 @@ describe('waitForIpniProviderResults', () => {
 
       expect(onProgress).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: expect.objectContaining({ retryCount: 0 }),
         })
       )
       expect(onProgress).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: expect.objectContaining({ retryCount: 1 }),
         })
       )
       expect(onProgress).toHaveBeenCalledWith({
-        type: 'ipniProviderResults.failed',
+        type: 'ipniProviderResults:failed',
         data: { error: expect.any(Error) },
       })
       expect(onProgress).not.toHaveBeenCalledWith({
-        type: 'ipniProviderResults.complete',
+        type: 'ipniProviderResults:complete',
         data: { result: true, retryCount: expect.any(Number) },
       })
     })
@@ -305,30 +305,30 @@ describe('waitForIpniProviderResults', () => {
       // Expect retryUpdate with counts 0,1,2 and final failed event (no complete event on failure)
       expect(onProgress).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: expect.objectContaining({ retryCount: 0 }),
         })
       )
       expect(onProgress).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: expect.objectContaining({ retryCount: 1 }),
         })
       )
       expect(onProgress).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'ipniProviderResults.retryUpdate',
+          type: 'ipniProviderResults:retryUpdate',
           data: expect.objectContaining({ retryCount: 2 }),
         })
       )
       // Should emit failed event, not complete(false)
       expect(onProgress).toHaveBeenCalledWith({
-        type: 'ipniProviderResults.failed',
+        type: 'ipniProviderResults:failed',
         data: { error: expect.any(Error) },
       })
       // Should NOT emit complete event
       expect(onProgress).not.toHaveBeenCalledWith({
-        type: 'ipniProviderResults.complete',
+        type: 'ipniProviderResults:complete',
         data: { result: false, retryCount: expect.any(Number) },
       })
     })

--- a/upload-action/src/filecoin.js
+++ b/upload-action/src/filecoin.js
@@ -210,42 +210,42 @@ export async function uploadCarToFilecoin(synapse, carPath, ipfsRootCid, options
     ...(providerIds != null && { providerIds }),
     onProgress: (event) => {
       switch (event.type) {
-        case 'onStored': {
+        case 'stored': {
           console.log(`✓ Data stored on provider ${event.data.providerId}`)
           console.log(`Piece CID: ${event.data.pieceCid}`)
           break
         }
-        case 'onPiecesAdded': {
+        case 'piecesAdded': {
           if (event.data.txHash) {
             console.log('✓ Piece registration transaction submitted')
             console.log(`Transaction hash: ${event.data.txHash}`)
           }
           break
         }
-        case 'onPiecesConfirmed': {
+        case 'piecesConfirmed': {
           console.log(`✓ Piece confirmed on-chain (data set ${event.data.dataSetId})`)
           break
         }
-        case 'onCopyComplete': {
+        case 'copyComplete': {
           console.log(`✓ Secondary copy complete on provider ${event.data.providerId}`)
           break
         }
-        case 'onCopyFailed': {
+        case 'copyFailed': {
           console.log(
             `Warning: Secondary copy failed on provider ${event.data.providerId}: ${event.data.error.message}`
           )
           break
         }
-        case 'ipniProviderResults.retryUpdate': {
+        case 'ipniProviderResults:retryUpdate': {
           const attempt = event.data.attempt ?? (event.data.retryCount === 0 ? 1 : event.data.retryCount + 1)
           console.log(`IPNI provider results check attempt #${attempt}...`)
           break
         }
-        case 'ipniProviderResults.complete': {
+        case 'ipniProviderResults:complete': {
           console.log(event.data.result ? '✓ IPNI provider results found' : 'IPNI provider results not found')
           break
         }
-        case 'ipniProviderResults.failed': {
+        case 'ipniProviderResults:failed': {
           console.log('IPNI provider results not found')
           console.log(`Error: ${event.data.error.message}`)
           break


### PR DESCRIPTION
Closes #91.

Unifies the `type` strings across every `onProgress` event union: camelCase, no `on` prefix, colon for namespaced flows. Covers upload, readiness, IPNI, and remove-piece/remove-all events. Updated `upload-action/src/filecoin.js` and a few stale doc/comment refs while I was in there.

New doc at `documentation/progress-events.md` describing the convention so we don't drift again.

Breaking for anyone matching `event.type`. Pre-major, so release-please will treat `feat!` as a minor bump.

## How to verify
`pnpm run build && pnpm test && pnpm run lint:fix`