### PR TITLE
feat: detect CAR input in add and refuse to wrap

### DIFF
--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -5,12 +5,14 @@
  * It encodes content as UnixFS, creates CAR files, and uploads to Filecoin.
  */
 
+import { createReadStream } from 'node:fs'
 import { readFile, stat } from 'node:fs/promises'
 import pc from 'picocolors'
 import pino from 'pino'
 import { warnAboutCDNPricingLimitations } from '../common/cdn-warning.js'
 import { DEVNET_CHAIN_ID } from '../common/get-rpc-url.js'
 import { displayUploadResults, performAutoFunding, performUpload, validatePaymentSetup } from '../common/upload-flow.js'
+import { carInputError, INPUT_IS_CAR, isCar } from '../core/car/index.js'
 import { resolveDataSetIdsByMetadata } from '../core/data-set/index.js'
 import { normalizeMetadataConfig } from '../core/metadata/index.js'
 import { DEFAULT_COPIES } from '../core/synapse/constants.js'
@@ -113,6 +115,18 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
     const pathType = isDirectory ? 'Directory' : 'File'
     const sizeDisplay = isDirectory ? '' : ` (${formatFileSize(pathStat.size)})`
     spinner.stop(`${pc.green('✓')} ${pathType} validated${sizeDisplay}`)
+
+    // Fail fast on CAR-of-CAR before auth/payment checks run.
+    if (!isDirectory) {
+      const sniff = createReadStream(options.filePath)
+      try {
+        if (await isCar(sniff)) {
+          throw carInputError(options.filePath)
+        }
+      } finally {
+        sniff.destroy()
+      }
+    }
 
     // Validate context selection options early (before expensive operations)
     const contextSelection = parseContextSelectionOptions(options)
@@ -284,7 +298,14 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
 
     return result
   } catch (error) {
-    spinner.stop(`${pc.red('✗')} Add failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    const carInput = error instanceof Error && (error as { code?: string }).code === INPUT_IS_CAR
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    spinner.stop(`${pc.red('✗')} ${carInput ? message : `Add failed: ${message}`}`)
+    if (carInput) {
+      log.line('')
+      log.line(pc.cyan(`  filecoin-pin import ${options.filePath}`))
+      log.flush()
+    }
     logger.error({ event: 'add.failed', error }, 'Add failed')
 
     // Always cleanup temp CAR even on error
@@ -292,7 +313,7 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
       await cleanupTempCar(tempCarPath, logger)
     }
 
-    cancel('Add failed')
+    cancel(carInput ? 'Add cancelled' : 'Add failed')
     throw error
   }
 }

--- a/src/core/car/browser.ts
+++ b/src/core/car/browser.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './browser-car-blockstore.js'
+export { carInputError, INPUT_IS_CAR, isCar } from './is-car.js'

--- a/src/core/car/index.ts
+++ b/src/core/car/index.ts
@@ -1,1 +1,2 @@
 export * from './car-blockstore.js'
+export { carInputError, INPUT_IS_CAR, isCar } from './is-car.js'

--- a/src/core/car/is-car.ts
+++ b/src/core/car/is-car.ts
@@ -40,6 +40,13 @@ async function* fromReadableStream(stream: ReadableStream<Uint8Array>): AsyncIte
       if (value) yield value
     }
   } finally {
+    // Detection bails before the source is drained; cancel() tells the
+    // producer to stop, releaseLock() alone leaves it running until GC.
+    try {
+      await reader.cancel()
+    } catch {
+      // Stream may already be errored; releaseLock() still needs to run.
+    }
     reader.releaseLock()
   }
 }

--- a/src/core/car/is-car.ts
+++ b/src/core/car/is-car.ts
@@ -1,0 +1,45 @@
+import { asyncIterableReader, createDecoder } from '@ipld/car/decoder'
+
+export const INPUT_IS_CAR = 'INPUT_IS_CAR'
+
+/**
+ * Returns true iff `source` begins with a valid CARv1 or CARv2 header.
+ * Consumes only header bytes; the source is left partially drained and the
+ * caller is expected to discard it.
+ *
+ * Accepts either an `AsyncIterable<Uint8Array>` (Node streams, async
+ * generators) or a `ReadableStream<Uint8Array>` (Web streams). The
+ * `ReadableStream` form covers browsers where `Symbol.asyncIterator` on
+ * web streams is not yet universal.
+ */
+export async function isCar(source: AsyncIterable<Uint8Array> | ReadableStream<Uint8Array>): Promise<boolean> {
+  const iter =
+    (source as any)[Symbol.asyncIterator] != null
+      ? (source as AsyncIterable<Uint8Array>)
+      : fromReadableStream(source as ReadableStream<Uint8Array>)
+  try {
+    await createDecoder(asyncIterableReader(iter)).header()
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function carInputError(filePath?: string): Error & { code: typeof INPUT_IS_CAR } {
+  const where = filePath ? `: ${filePath}` : ''
+  const err = new Error(`Input appears to be a CAR file${where}. Use 'filecoin-pin import' to upload it as-is.`)
+  return Object.assign(err, { code: INPUT_IS_CAR as typeof INPUT_IS_CAR })
+}
+
+async function* fromReadableStream(stream: ReadableStream<Uint8Array>): AsyncIterable<Uint8Array> {
+  const reader = stream.getReader()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) return
+      if (value) yield value
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}

--- a/src/core/unixfs/browser-car-builder.ts
+++ b/src/core/unixfs/browser-car-builder.ts
@@ -10,6 +10,7 @@ import { CarReader, CarWriter } from '@ipld/car'
 import toBuffer from 'it-to-buffer'
 import { CID } from 'multiformats/cid'
 import { CARWritingBlockstore } from '../car/browser-car-blockstore.js'
+import { carInputError, isCar } from '../car/is-car.js'
 
 // Placeholder CID used during CAR creation (will be replaced with actual root)
 const PLACEHOLDER_CID = CID.parse('bafyaaiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
@@ -33,6 +34,13 @@ export interface CreateCarResult {
  */
 export async function createCarFromFile(file: File, options: CreateCarOptions = {}): Promise<CreateCarResult> {
   const { bare = false } = options
+
+  // Refuse to wrap an existing CAR in a new UnixFS DAG. `Blob.stream()`
+  // returns a fresh stream on each call, so the upload path below is
+  // unaffected by the sniff.
+  if (await isCar(file.stream())) {
+    throw carInputError(file.name)
+  }
 
   const onProgress = options.onProgress
   let bytesProcessed = 0

--- a/src/core/unixfs/car-builder.ts
+++ b/src/core/unixfs/car-builder.ts
@@ -15,7 +15,7 @@ import { globSource, unixfs } from '@helia/unixfs'
 import { CarWriter } from '@ipld/car'
 import { CID } from 'multiformats/cid'
 import type { Logger } from 'pino'
-import { CARWritingBlockstore } from '../car/index.js'
+import { CARWritingBlockstore, carInputError, isCar } from '../car/index.js'
 
 // Spinner type for progress reporting
 export type Spinner = {
@@ -146,6 +146,17 @@ async function createCar(
  */
 async function createCarFromSingleFile(filePath: string, options: CreateCarOptions = {}): Promise<CreateCarResult> {
   const { logger, bare = false } = options
+
+  // Refuse to wrap an existing CAR in a new UnixFS DAG. Sniff a fresh stream
+  // and discard it; the upload pipeline below opens its own.
+  const sniff = createReadStream(filePath)
+  try {
+    if (await isCar(sniff)) {
+      throw carInputError(filePath)
+    }
+  } finally {
+    sniff.destroy()
+  }
 
   return createCar(filePath, { ...options, type: 'file' }, async (fs) => {
     const fileStream = createReadStream(filePath)

--- a/src/test/unit/is-car.test.ts
+++ b/src/test/unit/is-car.test.ts
@@ -1,0 +1,84 @@
+import { Readable } from 'node:stream'
+import { CarWriter } from '@ipld/car'
+import { CID } from 'multiformats/cid'
+import * as raw from 'multiformats/codecs/raw'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { describe, expect, it } from 'vitest'
+import { carInputError, INPUT_IS_CAR, isCar } from '../../core/car/is-car.js'
+
+async function buildCar(roots: CID[], blocks: { cid: CID; bytes: Uint8Array }[]): Promise<Uint8Array> {
+  const { writer, out } = CarWriter.create(roots)
+  const chunks: Uint8Array[] = []
+  const drain = (async () => {
+    for await (const c of out) chunks.push(c)
+  })()
+  for (const block of blocks) {
+    await writer.put(block)
+  }
+  await writer.close()
+  await drain
+  return Buffer.concat(chunks)
+}
+
+const cidA = CID.create(1, raw.code, await sha256.digest(new TextEncoder().encode('hello')))
+const cidB = CID.create(1, raw.code, await sha256.digest(new TextEncoder().encode('world')))
+
+const validSingleRoot = await buildCar([cidA], [{ cid: cidA, bytes: new TextEncoder().encode('hello') }])
+const validMultiRoot = await buildCar(
+  [cidA, cidB],
+  [
+    { cid: cidA, bytes: new TextEncoder().encode('hello') },
+    { cid: cidB, bytes: new TextEncoder().encode('world') },
+  ]
+)
+// Header-only: roots declared but no blocks written. Detection only inspects the header.
+const headerOnly = await buildCar([cidA], [])
+const garbage = new Uint8Array(64).fill(0xff)
+const text = new TextEncoder().encode('this is a plain text file, not a CAR\n')
+const empty = new Uint8Array(0)
+
+describe('isCar', () => {
+  it.each([
+    { description: 'valid CAR with single root', data: validSingleRoot, expected: true },
+    { description: 'valid CAR with multiple roots', data: validMultiRoot, expected: true },
+    { description: 'CAR header with no blocks', data: headerOnly, expected: true },
+    { description: 'plain text', data: text, expected: false },
+    { description: 'binary garbage', data: garbage, expected: false },
+    { description: 'empty input', data: empty, expected: false },
+  ])('returns $expected for $description', async ({ data, expected }) => {
+    expect(await isCar(Readable.from(data))).toBe(expected)
+  })
+
+  it('accepts a Web ReadableStream', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(validSingleRoot)
+        controller.close()
+      },
+    })
+    expect(await isCar(stream)).toBe(true)
+  })
+
+  it('does not consume the entire source', async () => {
+    let yielded = 0
+    async function* trickle() {
+      yield validSingleRoot
+      yielded++
+      yield new Uint8Array([0xde, 0xad, 0xbe, 0xef])
+      yielded++
+    }
+    expect(await isCar(trickle())).toBe(true)
+    // Header fits in the first chunk; the trailing chunk should never be requested.
+    expect(yielded).toBe(0)
+  })
+})
+
+describe('carInputError', () => {
+  it('tags the error with INPUT_IS_CAR', () => {
+    const err = carInputError('/tmp/foo.car')
+    expect(err.code).toBe(INPUT_IS_CAR)
+    expect(err.message).toContain('/tmp/foo.car')
+    expect(err.message).toContain('appears to be')
+    expect(err.message).toContain('filecoin-pin import')
+  })
+})

--- a/src/test/unit/is-car.test.ts
+++ b/src/test/unit/is-car.test.ts
@@ -60,16 +60,17 @@ describe('isCar', () => {
   })
 
   it('does not consume the entire source', async () => {
-    let yielded = 0
+    // Increment BEFORE each yield so `pulls` counts iterator advances, not
+    // post-yield resumes.
+    let pulls = 0
     async function* trickle() {
+      pulls++
       yield validSingleRoot
-      yielded++
+      pulls++
       yield new Uint8Array([0xde, 0xad, 0xbe, 0xef])
-      yielded++
     }
     expect(await isCar(trickle())).toBe(true)
-    // Header fits in the first chunk; the trailing chunk should never be requested.
-    expect(yielded).toBe(0)
+    expect(pulls).toBe(1)
   })
 })
 


### PR DESCRIPTION
Sniff the CAR header via @ipld/car/decoder in createCarFrom* and throw with code: INPUT_IS_CAR. The add CLI catches early and points users at 'filecoin-pin import'.

Closes: #199

---

I saw https://github.com/filecoin-project/filecoin-pin/pull/275 was closed and figured this was a very easy addition to fire off. Low priority but it does resolve a footgun.