### PR TITLE
ci: cancel stale PR runs, isolate browser job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,12 +45,12 @@ jobs:
         run: |
           pnpm run typecheck
           pnpm --dir upload-action run typecheck
+      - name: Build
+        run: pnpm run build
       - name: Run Unit Tests
         run: pnpm run test:unit
       - name: Run Integration Tests
         run: pnpm run test:integration
-      - name: Build
-        run: pnpm run build
 
   browser-test:
     runs-on: ubuntu-latest
@@ -73,6 +73,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm run build
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,16 @@
 name: Test
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -23,17 +34,51 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium
+      - name: Configure pnpm script shell
+        if: runner.os == 'Windows'
+        run: pnpm config set script-shell bash
       - name: Run Lint
+        if: runner.os == 'Linux'
         run: pnpm run lint
-      - name: Run Tests
-        run: |
-          pnpm config set script-shell bash
-          pnpm test
-      - name: Build
-        run: pnpm run build
       - name: Check TypeScript
+        if: runner.os == 'Linux'
         run: |
           pnpm run typecheck
           pnpm --dir upload-action run typecheck
+      - name: Run Unit Tests
+        run: pnpm run test:unit
+      - name: Run Integration Tests
+        run: pnpm run test:integration
+      - name: Build
+        run: pnpm run build
+
+  browser-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [lts/*, current]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+      - name: Set up pnpm
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+        with:
+          run_install: false
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium
+      - name: Run Browser Tests
+        run: pnpm run test:browser


### PR DESCRIPTION
Stacks on #462.

## What changed

CI was queuing for hours on every PR because each push fired two workflow runs (push + pull_request), nothing cancelled superseded runs, and the macOS hosted runner pool stayed saturated. This rewires `test.yml` to cut those multipliers without losing per-platform PR coverage.

- Trigger narrowed to `pull_request` plus `push` on `master`. PR commits already fire `pull_request: synchronize`, so dropping the unfiltered `push` trigger removes the duplicate run.
- Adds `concurrency: { cancel-in-progress: true }` keyed on `github.ref`, so a new push to a PR cancels the in-flight run instead of competing with it for macOS slots.
- Lint and `tsc` now run on Linux only. `build` still runs on every matrix cell, so `tsc` cross-platform coverage stays intact.
- Browser tests move to a dedicated `browser-test` job on `ubuntu-latest` only, with `actions/cache` for `~/.cache/ms-playwright`. Chromium behavior is host-OS independent for this suite, so running it on all 6 matrix cells via `pnpm test` was wasted runner time.
- Adds `permissions: contents: read` at workflow scope.

`package.json` is unchanged; the workflow now invokes `test:unit`, `test:integration`, and `test:browser` directly instead of going through the aggregate `pnpm test` script.

## How to verify

- Push to this branch and confirm only one workflow run appears per push.
- Force-push and confirm the prior in-flight run is cancelled rather than queued.
- Confirm macOS / Windows cells skip lint, typecheck, and playwright install steps.
- Confirm `browser-test (lts/*)` and `browser-test (current)` run the existing `.iso.test.ts` under chromium.

## Notes

- Pushes to non-`master` branches without an open PR no longer trigger CI. Open a draft PR to get coverage for in-flight branch work.
- Reviewed with codex, cursor, and gemini; their feedback is folded into the final diff (`--with-deps` dropped, `script-shell bash` hoisted to a single Windows-gated step, `permissions` added).