### PR TITLE
feat(cli): add --cdn flag to add and import commands

### DIFF
--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -87,7 +87,7 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
   })
 
   // Check CDN status and warn if enabled
-  const withCDN = process.env.WITH_CDN === 'true'
+  const withCDN = process.env.WITH_CDN === 'true' || options.cdn === true
   if (withCDN) {
     const proceed = await warnAboutCDNPricingLimitations()
     if (!proceed) {

--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -87,7 +87,7 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
   })
 
   // Check CDN status and warn if enabled
-  const withCDN = process.env.WITH_CDN === 'true' || options.cdn === true
+  const withCDN = options.cdn === true
   if (withCDN) {
     const proceed = await warnAboutCDNPricingLimitations()
     if (!proceed) {

--- a/src/add/types.ts
+++ b/src/add/types.ts
@@ -13,6 +13,8 @@ export interface AddOptions extends CLIAuthOptions, CLIAutoFundOptions {
   dataSetMetadata?: Record<string, string>
   /** Skip IPNI advertisement verification after upload */
   skipIpniVerification?: boolean
+  /** Enable Filecoin Beam (CDN) for faster IPFS retrievals */
+  cdn?: boolean
 }
 
 export interface AddResult {

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -145,7 +145,7 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
   })
 
   // Check CDN status and warn if enabled
-  const withCDN = process.env.WITH_CDN === 'true' || options.cdn === true
+  const withCDN = options.cdn === true
   if (withCDN) {
     const proceed = await warnAboutCDNPricingLimitations()
     if (!proceed) {

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -145,7 +145,7 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
   })
 
   // Check CDN status and warn if enabled
-  const withCDN = process.env.WITH_CDN === 'true'
+  const withCDN = process.env.WITH_CDN === 'true' || options.cdn === true
   if (withCDN) {
     const proceed = await warnAboutCDNPricingLimitations()
     if (!proceed) {

--- a/src/import/types.ts
+++ b/src/import/types.ts
@@ -12,6 +12,8 @@ export interface ImportOptions extends CLIAuthOptions, CLIAutoFundOptions {
   dataSetMetadata?: Record<string, string>
   /** Skip IPNI advertisement verification after upload */
   skipIpniVerification?: boolean
+  /** Enable Filecoin Beam (CDN) for faster IPFS retrievals */
+  cdn?: boolean
 }
 
 export interface ImportResult {

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -102,12 +102,17 @@ export function addNetworkOptions(command: Command): Command {
  * Used by `add` and `import` commands.
  */
 export function addUploadOptions(command: Command): Command {
-  return command.addOption(
-    new Option(
-      '--skip-ipni-verification',
-      'Skip IPNI advertisement verification after upload (automatic for devnet)'
-    ).env('SKIP_IPNI_VERIFICATION')
-  )
+  return command
+    .addOption(
+      new Option(
+        '--skip-ipni-verification',
+        'Skip IPNI advertisement verification after upload (automatic for devnet)'
+      ).env('SKIP_IPNI_VERIFICATION')
+    )
+    .option(
+      '--cdn',
+      'Enable Filecoin Beam (CDN) for faster IPFS retrievals (alias for --data-set-metadata withCDN=true)'
+    )
 }
 
 /**

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -109,10 +109,7 @@ export function addUploadOptions(command: Command): Command {
         'Skip IPNI advertisement verification after upload (automatic for devnet)'
       ).env('SKIP_IPNI_VERIFICATION')
     )
-    .option(
-      '--cdn',
-      'Enable Filecoin Beam (CDN) for faster IPFS retrievals (alias for --data-set-metadata withCDN=true)'
-    )
+    .option('--cdn', 'Enable Filecoin Beam CDN service for this upload')
 }
 
 /**

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -109,7 +109,7 @@ export function addUploadOptions(command: Command): Command {
         'Skip IPNI advertisement verification after upload (automatic for devnet)'
       ).env('SKIP_IPNI_VERIFICATION')
     )
-    .option('--cdn', 'Enable Filecoin Beam CDN service for this upload')
+    .addOption(new Option('--cdn', 'Enable Filecoin Beam CDN service for this upload').env('WITH_CDN'))
 }
 
 /**


### PR DESCRIPTION
Adds `--cdn` as a shorthand alias for `--data-set-metadata withCDN=true` on both the add and import commands, making Filecoin Beam opt-in more discoverable. The existing `WITH_CDN` env var is preserved for backwards compatibility.

Closes #464