### PR TITLE
refactor: finish CLI command cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,15 @@ Leave your PR in draft status until it's ready for maintainer review. This helps
 ## Code Quality
 
 Keep comments concise and favor self-documenting code when possible. Use clear variable names, function names, and code structure to make your intent obvious.
+
+## CLI Command Structure
+
+One-shot CLI commands should keep Commander.js wiring separate from command behavior:
+
+- `src/commands/<command>.ts` parses Commander arguments/options, calls the runner, catches errors, and owns CLI exit codes.
+- `src/<command>/` contains business logic and user-facing terminal UI such as spinners, status output, cancellation messages, and cleanup.
+- Runner functions must throw errors instead of calling `process.exit()` or setting `process.exitCode`.
+- Command wiring should not print errors that the runner already displayed.
+- Use `finally` blocks for cleanup that must happen on both success and failure.
+
+The `server` command is long-running and manages its own process lifecycle, so this one-shot command pattern does not apply there.

--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -10,6 +10,7 @@ import { readFile, stat } from 'node:fs/promises'
 import pc from 'picocolors'
 import pino from 'pino'
 import { warnAboutCDNPricingLimitations } from '../common/cdn-warning.js'
+import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { DEVNET_CHAIN_ID } from '../common/get-rpc-url.js'
 import { displayUploadResults, performAutoFunding, performUpload, validatePaymentSetup } from '../common/upload-flow.js'
 import { carInputError, INPUT_IS_CAR, isCar } from '../core/car/index.js'
@@ -340,6 +341,15 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
 
     return result
   } catch (error) {
+    if (isCliFatal(error)) {
+      spinner.stop()
+      logger.error({ event: 'add.failed', error }, 'Add failed')
+      if (tempCarPath) {
+        await cleanupTempCar(tempCarPath, logger)
+      }
+      throw error
+    }
+
     const carInput = error instanceof Error && (error as { code?: string }).code === INPUT_IS_CAR
     const message = error instanceof Error ? error.message : 'Unknown error'
     spinner.stop(`${pc.red('✗')} ${carInput ? message : `Add failed: ${message}`}`)
@@ -356,6 +366,6 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
     }
 
     cancel(carInput ? 'Add cancelled' : 'Add failed')
-    throw error
+    throw new CliFatal(message, { cause: error instanceof Error ? error : undefined })
   }
 }

--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -22,6 +22,8 @@ import { getNetworkSlug } from '../core/upload/index.js'
 import { parseCLIAuth, parseContextSelectionOptions } from '../utils/cli-auth.js'
 import { cancel, createSpinner, formatFileSize, intro, outro } from '../utils/cli-helpers.js'
 import { log } from '../utils/cli-logger.js'
+import { validateAndNormalizeAutoFundOptions } from '../utils/cli-options.js'
+import { resolveMetadataOptions } from '../utils/cli-options-metadata.js'
 import type { AddOptions, AddResult } from './types.js'
 
 /**
@@ -64,6 +66,46 @@ async function validatePath(
       error: `Cannot access path: ${path} (${error?.message || 'unknown error'})`,
     }
   }
+}
+
+/**
+ * Normalize Commander options and run the add flow.
+ *
+ * Commander wiring calls this so option validation errors are displayed by the
+ * command UI layer and command files only own exit-code handling.
+ */
+export async function runAddFromCli(path: string, options: Record<string, any>): Promise<AddResult> {
+  let addOptions: AddOptions
+  try {
+    const autoFundOptions = validateAndNormalizeAutoFundOptions(options)
+    const {
+      metadata: _metadata,
+      dataSetMetadata: _dataSetMetadata,
+      datasetMetadata: _datasetMetadata,
+      '8004Type': _erc8004Type,
+      '8004Agent': _erc8004Agent,
+      autoFund: _autoFund,
+      minRunwayDays: _minRunwayDays,
+      maxBalance: _maxBalance,
+      ...addOptionsFromCli
+    } = options
+    const { pieceMetadata, dataSetMetadata } = resolveMetadataOptions(options, { includeErc8004: true })
+
+    addOptions = {
+      ...addOptionsFromCli,
+      ...autoFundOptions,
+      filePath: path,
+      ...(pieceMetadata && { pieceMetadata }),
+      ...(dataSetMetadata && { dataSetMetadata }),
+    }
+  } catch (error) {
+    log.line(`${pc.red('Error:')} ${error instanceof Error ? error.message : String(error)}`)
+    log.flush()
+    cancel('Add cancelled')
+    throw error
+  }
+
+  return await runAdd(addOptions)
 }
 
 /**
@@ -270,6 +312,7 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
       rootCid: rootCid.toString(),
       pieceCid: uploadResult.pieceCid,
       size: uploadResult.size,
+      requestedCopies,
       copies: uploadResult.copies,
       failedAttempts: uploadResult.failedAttempts,
     }
@@ -286,7 +329,6 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
       )
       log.flush()
       outro('Add completed with errors')
-      process.exitCode = 1
     } else if (uploadResult.failedAttempts.length > 0) {
       log.line('')
       log.line(pc.gray(`${uploadResult.failedAttempts.length} non-critical copy failure(s) during upload.`))

--- a/src/add/types.ts
+++ b/src/add/types.ts
@@ -22,6 +22,7 @@ export interface AddResult {
   rootCid: string
   pieceCid: string
   size: number
+  requestedCopies: number
   copies: CopyResult[]
   failedAttempts: FailedAttempt[]
 }

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,14 +1,12 @@
 import { Command } from 'commander'
-import { runAdd } from '../add/add.js'
-import type { AddOptions } from '../add/types.js'
+import { runAddFromCli } from '../add/add.js'
 import {
   addAuthOptions,
   addAutoFundOptions,
   addContextSelectionOptions,
   addUploadOptions,
-  validateAndNormalizeAutoFundOptions,
 } from '../utils/cli-options.js'
-import { addMetadataOptions, resolveMetadataOptions } from '../utils/cli-options-metadata.js'
+import { addMetadataOptions } from '../utils/cli-options-metadata.js'
 
 export const addCommand = new Command('add')
   .description('Add a file or directory to Filecoin via Synapse (creates UnixFS CAR)')
@@ -17,37 +15,11 @@ export const addCommand = new Command('add')
   .option('--copies <n>', 'Number of storage copies to create (default: 2)', Number.parseInt)
 
 addCommand.action(async (path: string, options: any) => {
-  let autoFundOptions: ReturnType<typeof validateAndNormalizeAutoFundOptions>
   try {
-    autoFundOptions = validateAndNormalizeAutoFundOptions(options)
-  } catch (error) {
-    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`)
-    process.exit(1)
-  }
-
-  try {
-    const {
-      metadata: _metadata,
-      dataSetMetadata: _dataSetMetadata,
-      datasetMetadata: _datasetMetadata,
-      '8004Type': _erc8004Type,
-      '8004Agent': _erc8004Agent,
-      autoFund: _autoFund,
-      minRunwayDays: _minRunwayDays,
-      maxBalance: _maxBalance,
-      ...addOptionsFromCli
-    } = options
-    const { pieceMetadata, dataSetMetadata } = resolveMetadataOptions(options, { includeErc8004: true })
-
-    const addOptions: AddOptions = {
-      ...addOptionsFromCli,
-      ...autoFundOptions,
-      filePath: path,
-      ...(pieceMetadata && { pieceMetadata }),
-      ...(dataSetMetadata && { dataSetMetadata }),
+    const result = await runAddFromCli(path, options)
+    if (result.copies.length < result.requestedCopies) {
+      process.exitCode = 1
     }
-
-    await runAdd(addOptions)
   } catch {
     process.exit(1)
   }

--- a/src/commands/data-set.ts
+++ b/src/commands/data-set.ts
@@ -1,8 +1,16 @@
 import { Command } from 'commander'
 import { runDataSetDetailsCommand, runDataSetListCommand, runTerminateDataSetCommand } from '../data-set/run.js'
-import type { DataSetCommandOptions, DataSetListCommandOptions } from '../data-set/types.js'
+import type { DataSetListCommandOptions } from '../data-set/types.js'
 import { addAuthOptions } from '../utils/cli-options.js'
 import { addMetadataOptions, resolveMetadataOptions } from '../utils/cli-options-metadata.js'
+
+// Strict integer parse: rejects partial matches like "12abc" that
+// `Number.parseInt` would accept. Returns NaN for any invalid input so
+// runner-side validation reports it via clack.
+function parseStrictId(value: string): number {
+  const n = Number(value)
+  return Number.isInteger(n) ? n : NaN
+}
 
 export const dataSetCommand = new Command('data-set')
   .alias('dataset')
@@ -13,15 +21,7 @@ export const dataSetShowCommand = new Command('show')
   .argument('<dataSetId>', 'Display detailed information about a data set')
   .action(async (dataSetId: string, options) => {
     try {
-      const commandOptions: DataSetCommandOptions = {
-        ...options,
-      }
-      const dataSetIdNumber = Number.parseInt(dataSetId, 10)
-      if (Number.isNaN(dataSetIdNumber)) {
-        throw new Error('Invalid data set ID')
-      }
-
-      await runDataSetDetailsCommand(dataSetIdNumber, commandOptions)
+      await runDataSetDetailsCommand(parseStrictId(dataSetId), { ...options })
     } catch {
       process.exit(1)
     }
@@ -59,15 +59,7 @@ export const dataSetTerminateCommand = new Command('terminate')
   .option('--wait', 'Wait for the termination transaction to be confirmed')
   .action(async (dataSetId: string, options) => {
     try {
-      const commandOptions: DataSetCommandOptions = {
-        ...options,
-      }
-      const dataSetIdNumber = Number.parseInt(dataSetId, 10)
-      if (Number.isNaN(dataSetIdNumber)) {
-        throw new Error('Invalid data set ID')
-      }
-
-      await runTerminateDataSetCommand(dataSetIdNumber, commandOptions)
+      await runTerminateDataSetCommand(parseStrictId(dataSetId), { ...options })
     } catch {
       process.exit(1)
     }

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,51 +1,23 @@
 import { Command } from 'commander'
-import { runCarImport } from '../import/import.js'
-import type { ImportOptions } from '../import/types.js'
+import { runCarImportFromCli } from '../import/import.js'
 import {
   addAuthOptions,
   addAutoFundOptions,
   addContextSelectionOptions,
   addUploadOptions,
-  validateAndNormalizeAutoFundOptions,
 } from '../utils/cli-options.js'
-import { addMetadataOptions, resolveMetadataOptions } from '../utils/cli-options-metadata.js'
+import { addMetadataOptions } from '../utils/cli-options-metadata.js'
 
 export const importCommand = new Command('import')
   .description('Import an existing CAR file to Filecoin via Synapse')
   .argument('<file>', 'Path to the CAR file to import')
   .option('--copies <n>', 'Number of storage copies to create (default: 2)', Number.parseInt)
   .action(async (file: string, options) => {
-    let autoFundOptions: ReturnType<typeof validateAndNormalizeAutoFundOptions>
     try {
-      autoFundOptions = validateAndNormalizeAutoFundOptions(options)
-    } catch (error) {
-      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`)
-      process.exit(1)
-    }
-
-    try {
-      const {
-        metadata: _metadata,
-        dataSetMetadata: _dataSetMetadata,
-        datasetMetadata: _datasetMetadata,
-        '8004Type': _erc8004Type,
-        '8004Agent': _erc8004Agent,
-        autoFund: _autoFund,
-        minRunwayDays: _minRunwayDays,
-        maxBalance: _maxBalance,
-        ...importOptionsFromCli
-      } = options
-
-      const { pieceMetadata, dataSetMetadata } = resolveMetadataOptions(options, { includeErc8004: true })
-      const importOptions: ImportOptions = {
-        ...importOptionsFromCli,
-        ...autoFundOptions,
-        filePath: file,
-        ...(pieceMetadata && { pieceMetadata }),
-        ...(dataSetMetadata && { dataSetMetadata }),
+      const result = await runCarImportFromCli(file, options)
+      if (result.copies.length < result.requestedCopies) {
+        process.exitCode = 1
       }
-
-      await runCarImport(importOptions)
     } catch {
       process.exit(1)
     }

--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander'
 import pc from 'picocolors'
 import { runRmAllPieces, runRmPiece } from '../rm/index.js'
+import { log } from '../utils/cli-logger.js'
 import { addAuthOptions } from '../utils/cli-options.js'
 
 export const rmCommand = new Command('rm')
@@ -13,9 +14,12 @@ rmCommand.addOption(new Option('--piece <cid>', 'Piece CID to remove').conflicts
 rmCommand.addOption(new Option('--all', 'Remove ALL pieces from the DataSet').conflicts('piece'))
 
 rmCommand.action(async (options) => {
-  // Validate: at least one of --piece or --all is required
+  // Validate: at least one of --piece or --all is required.
+  // This is a routing decision for the wrapper (which runner to dispatch to),
+  // so it lives here rather than in either runner.
   if (!options.piece && !options.all) {
-    console.error(pc.red('Error: Either --piece or --all is required'))
+    log.line(pc.red('Error: Either --piece or --all is required'))
+    log.flush()
     process.exit(1)
   }
 

--- a/src/common/cdn-warning.ts
+++ b/src/common/cdn-warning.ts
@@ -21,7 +21,6 @@ export async function warnAboutCDNPricingLimitations(): Promise<boolean> {
 
   if (shouldProceed === null) {
     cancel('Operation cancelled')
-    process.exitCode = 1
   }
 
   return Boolean(shouldProceed)

--- a/src/common/cli-errors.ts
+++ b/src/common/cli-errors.ts
@@ -1,0 +1,73 @@
+/**
+ * Sentinel error type for CLI runners that have already displayed the
+ * user-facing failure message via clack/log/console.
+ *
+ * # Why this exists
+ *
+ * CLI commands use a two-layer split (see `CONTRIBUTING.md`):
+ *
+ * - `src/<cmd>/` runners contain business logic and clack UI. They display
+ *   user-friendly error messages via clack BEFORE throwing.
+ * - `src/commands/<cmd>.ts` Commander wrappers catch errors and own exit
+ *   codes. They do NOT display errors (the runner already did).
+ *
+ * Runner code typically wraps work in a try/catch where the catch displays
+ * a generic `✗ <action> failed: <msg>` line for unexpected errors. Some
+ * inner branches need to display rich, contextual errors (cyan helpMessage,
+ * formatted balances, multi-line guidance) BEFORE throwing. Without a
+ * sentinel, the outer catch would re-display those errors as a generic
+ * `✗ <action> failed` line, producing duplicate stderr output.
+ *
+ * `CliFatal` solves this: inner branches that have already displayed the
+ * error throw `CliFatal`. The runner's outer catch checks `isCliFatal(err)`
+ * and skips its generic display when the error has already been reported.
+ * The Commander wrapper still catches and exits with code 1.
+ *
+ * # When to use
+ *
+ * Throw `CliFatal` ONLY at a CLI failure boundary where the error has
+ * already been shown to the user via `log.line` + `log.flush`,
+ * `console.error`, `cancel(...)`, or similar. The runner's outer catch
+ * will treat the error as "already reported" and not print anything
+ * additional.
+ *
+ * If your code has not displayed the error to the user, throw a regular
+ * `Error` instead — the runner's outer catch will format and display it.
+ *
+ * # Example (correct)
+ *
+ * ```ts
+ * if (!validation.isValid) {
+ *   const msg = validation.errorMessage ?? 'Payment validation failed'
+ *   log.line(`${pc.red('✗')} ${msg}`)
+ *   if (validation.helpMessage) {
+ *     log.line('')
+ *     log.line(`  ${pc.cyan(validation.helpMessage)}`)
+ *   }
+ *   log.flush()
+ *   cancel('Please fund your wallet and try again')
+ *   throw new CliFatal(msg)
+ * }
+ * ```
+ *
+ * # Example (wrong)
+ *
+ * ```ts
+ * // Don't throw CliFatal without displaying first — user sees nothing.
+ * if (!ok) throw new CliFatal('something failed')
+ * ```
+ */
+export class CliFatal extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'CliFatal'
+  }
+}
+
+/**
+ * Type guard for `CliFatal`. Used by runner outer catches to detect
+ * "error already displayed by inner branch — do not re-display."
+ */
+export function isCliFatal(error: unknown): error is CliFatal {
+  return error instanceof CliFatal
+}

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -163,7 +163,7 @@ export async function performAutoFunding(
     log.line(`${pc.red('Error:')} ${error instanceof Error ? error.message : String(error)}`)
     log.flush()
     cancel('Operation cancelled - auto-funding failed')
-    process.exit(1)
+    throw error
   }
 }
 
@@ -175,7 +175,7 @@ export async function performAutoFunding(
  * @param spinner - Optional spinner for progress
  * @param options - Optional configuration
  * @param options.suppressSuggestions - If true, don't display suggestion warnings
- * @returns true if validation passes, exits process if not
+ * @returns Resolves if validation passes, throws if not
  */
 export async function validatePaymentSetup(
   synapse: Synapse,
@@ -235,7 +235,7 @@ export async function validatePaymentSetup(
     log.flush()
 
     cancel('Operation cancelled - payment setup required')
-    process.exit(1)
+    throw new Error(validation.errorMessage)
   }
 
   if (allowances.updated) {
@@ -254,7 +254,7 @@ export async function validatePaymentSetup(
       displayPaymentIssues(capacity, fileSize, spinner)
     }
     cancel('Operation cancelled - insufficient payment capacity')
-    process.exit(1)
+    throw new Error('Insufficient payment capacity')
   }
 
   // Show warning if suggestions exist (even if upload is possible)

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -24,6 +24,7 @@ import type { Spinner } from '../utils/cli-helpers.js'
 import { cancel, formatFileSize } from '../utils/cli-helpers.js'
 import { log } from '../utils/cli-logger.js'
 import { createSpinnerFlow } from '../utils/multi-operation-spinner.js'
+import { CliFatal } from './cli-errors.js'
 
 export interface UploadFlowOptions {
   /**
@@ -158,12 +159,13 @@ export async function performAutoFunding(
       log.flush()
     }
   } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
     spinner?.stop(`${pc.red('✗')} Auto-funding failed`)
     log.line('')
-    log.line(`${pc.red('Error:')} ${error instanceof Error ? error.message : String(error)}`)
+    log.line(`${pc.red('Error:')} ${msg}`)
     log.flush()
     cancel('Operation cancelled - auto-funding failed')
-    throw error
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }
 
@@ -216,10 +218,11 @@ export async function validatePaymentSetup(
   const { validation, allowances, capacity, suggestions } = readiness
 
   if (!validation.isValid) {
+    const errorMsg = validation.errorMessage ?? 'Payment setup required'
     spinner?.stop(`${pc.red('✗')} Payment setup incomplete`)
 
     log.line('')
-    log.line(`${pc.red('✗')} ${validation.errorMessage}`)
+    log.line(`${pc.red('✗')} ${errorMsg}`)
 
     if (validation.helpMessage) {
       log.line('')
@@ -235,7 +238,7 @@ export async function validatePaymentSetup(
     log.flush()
 
     cancel('Operation cancelled - payment setup required')
-    throw new Error(validation.errorMessage)
+    throw new CliFatal(errorMsg)
   }
 
   if (allowances.updated) {
@@ -254,7 +257,7 @@ export async function validatePaymentSetup(
       displayPaymentIssues(capacity, fileSize, spinner)
     }
     cancel('Operation cancelled - insufficient payment capacity')
-    throw new Error('Insufficient payment capacity')
+    throw new CliFatal('Insufficient payment capacity')
   }
 
   // Show warning if suggestions exist (even if upload is possible)

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -1,6 +1,7 @@
 import { confirm, isCancel } from '@clack/prompts'
 import type { EnhancedDataSetInfo, Synapse } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
+import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { type DataSetSummary, getDetailedDataSet, listDataSets } from '../core/data-set/index.js'
 import { getClientAddress } from '../core/synapse/index.js'
 import { getCliSynapse } from '../utils/cli-auth.js'
@@ -21,6 +22,15 @@ export async function runDataSetDetailsCommand(dataSetId: number, options: DataS
   spinner.start('Connecting to Synapse...')
 
   try {
+    if (Number.isNaN(dataSetId) || dataSetId <= 0) {
+      spinner.stop(`${pc.red('✗')} Invalid data set ID`)
+      log.line('')
+      log.line(`${pc.red('Error:')} Provided data set ID is invalid or not a positive integer`)
+      log.flush()
+      cancel('Inspection failed')
+      throw new CliFatal('Invalid data set ID')
+    }
+
     const synapse = await getCliSynapse(options)
     const network = synapse.chain.name
     const address = getClientAddress(synapse)
@@ -34,14 +44,17 @@ export async function runDataSetDetailsCommand(dataSetId: number, options: DataS
 
     outro('Data set inspection complete')
   } catch (error) {
+    if (isCliFatal(error)) {
+      spinner.stop()
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : String(error)
     spinner.stop(`${pc.red('✗')} Failed to inspect data set`)
-
     log.line('')
-    log.line(`${pc.red('Error:')} ${error instanceof Error ? error.message : String(error)}`)
+    log.line(`${pc.red('Error:')} ${msg}`)
     log.flush()
-
     cancel('Inspection failed')
-    throw error
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }
 
@@ -53,10 +66,11 @@ export async function runDataSetListCommand(options: DataSetListCommandOptions):
   let synapse: Synapse | null = null
 
   try {
-    // Parse and validate provider ID
+    // Parse and validate provider ID. Reject non-integers so BigInt() does
+    // not throw a low-level RangeError downstream.
     const providerIdRaw = options.providerId != null ? Number(options.providerId) : undefined
-    if (providerIdRaw != null && Number.isNaN(providerIdRaw)) {
-      throw new Error('Invalid provider ID')
+    if (providerIdRaw != null && (!Number.isInteger(providerIdRaw) || providerIdRaw <= 0)) {
+      throw new Error(`Invalid provider ID: '${options.providerId}' (must be a positive integer)`)
     }
     const providerId = providerIdRaw != null ? BigInt(providerIdRaw) : undefined
     const metadataEntries = options.dataSetMetadata ? Object.entries(options.dataSetMetadata) : []
@@ -111,12 +125,17 @@ export async function runDataSetListCommand(options: DataSetListCommandOptions):
 
     outro('Data set list complete')
   } catch (error) {
+    if (isCliFatal(error)) {
+      spinner.stop()
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : String(error)
     spinner.stop(`${pc.red('✗')} Failed to list data sets`)
     log.line('')
-    log.line(`${pc.red('Error:')} ${error instanceof Error ? error.message : String(error)}`)
+    log.line(`${pc.red('Error:')} ${msg}`)
     log.flush()
     cancel('Listing failed')
-    throw error
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }
 
@@ -129,10 +148,10 @@ export async function runTerminateDataSetCommand(dataSetId: number, options: Dat
     if (Number.isNaN(dataSetId) || dataSetId <= 0) {
       spinner.stop(`${pc.red('✗')} Invalid data set ID`)
       log.line('')
-      log.line(`${pc.red('Error:')} Provided data set ID is invalid or not a number`)
+      log.line(`${pc.red('Error:')} Provided data set ID is invalid or not a positive integer`)
       log.flush()
       cancel('Termination failed')
-      throw new Error('Invalid data set ID')
+      throw new CliFatal('Invalid data set ID')
     }
 
     const synapse = await getCliSynapse(options)
@@ -149,7 +168,7 @@ export async function runTerminateDataSetCommand(dataSetId: number, options: Dat
       )
       log.flush()
       cancel('Termination failed')
-      throw new Error('Signing required for termination')
+      throw new CliFatal('Signing required for termination')
     }
 
     spinner.message('Fetching data set details...')
@@ -163,7 +182,7 @@ export async function runTerminateDataSetCommand(dataSetId: number, options: Dat
       log.line(`${pc.red('Error:')} Could not find data set with ID ${dataSetId}`)
       log.flush()
       cancel('Termination failed')
-      throw error
+      throw new CliFatal(`Data set ${dataSetId} not found`, { cause: error instanceof Error ? error : undefined })
     }
 
     if (dataSet.payer?.toLowerCase() !== address?.toLowerCase()) {
@@ -174,7 +193,7 @@ export async function runTerminateDataSetCommand(dataSetId: number, options: Dat
       log.line(`  Owner: ${dataSet.payer}`)
       log.flush()
       cancel('Termination failed')
-      throw new Error(errorMsg)
+      throw new CliFatal(errorMsg)
     }
 
     if (dataSet.pdpEndEpoch > 0) {
@@ -280,13 +299,16 @@ export async function runTerminateDataSetCommand(dataSetId: number, options: Dat
 
     outro(shouldWait ? 'Data set termination complete' : 'Termination transaction submitted')
   } catch (error) {
+    if (isCliFatal(error)) {
+      spinner.stop()
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : String(error)
     spinner.stop(`${pc.red('✗')} Failed to terminate data set`)
-
     log.line('')
-    log.line(`${pc.red('Error:')} ${error instanceof Error ? error.message : String(error)}`)
+    log.line(`${pc.red('Error:')} ${msg}`)
     log.flush()
-
     cancel('Termination failed')
-    throw error
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -17,20 +17,20 @@ import type { DataSetCommandOptions, DataSetListCommandOptions } from './types.j
  * @param options - Normalised CLI options
  */
 export async function runDataSetDetailsCommand(dataSetId: number, options: DataSetCommandOptions): Promise<void> {
+  if (Number.isNaN(dataSetId) || dataSetId <= 0) {
+    intro(pc.bold('Filecoin Onchain Cloud Data Set Details'))
+    log.line('')
+    log.line(`${pc.red('Error:')} Provided data set ID is invalid or not a positive integer`)
+    log.flush()
+    cancel('Inspection failed')
+    throw new CliFatal('Invalid data set ID')
+  }
+
   intro(pc.bold(`Filecoin Onchain Cloud Data Set Details for #${dataSetId}`))
   const spinner = createSpinner()
   spinner.start('Connecting to Synapse...')
 
   try {
-    if (Number.isNaN(dataSetId) || dataSetId <= 0) {
-      spinner.stop(`${pc.red('✗')} Invalid data set ID`)
-      log.line('')
-      log.line(`${pc.red('Error:')} Provided data set ID is invalid or not a positive integer`)
-      log.flush()
-      cancel('Inspection failed')
-      throw new CliFatal('Invalid data set ID')
-    }
-
     const synapse = await getCliSynapse(options)
     const network = synapse.chain.name
     const address = getClientAddress(synapse)
@@ -140,20 +140,20 @@ export async function runDataSetListCommand(options: DataSetListCommandOptions):
 }
 
 export async function runTerminateDataSetCommand(dataSetId: number, options: DataSetCommandOptions): Promise<void> {
+  if (Number.isNaN(dataSetId) || dataSetId <= 0) {
+    intro(pc.bold('Terminate Filecoin Onchain Cloud Data Set'))
+    log.line('')
+    log.line(`${pc.red('Error:')} Provided data set ID is invalid or not a positive integer`)
+    log.flush()
+    cancel('Termination failed')
+    throw new CliFatal('Invalid data set ID')
+  }
+
   intro(pc.bold(`Terminate Filecoin Onchain Cloud Data Set #${dataSetId}`))
   const spinner = createSpinner()
   spinner.start('Connecting to Synapse...')
 
   try {
-    if (Number.isNaN(dataSetId) || dataSetId <= 0) {
-      spinner.stop(`${pc.red('✗')} Invalid data set ID`)
-      log.line('')
-      log.line(`${pc.red('Error:')} Provided data set ID is invalid or not a positive integer`)
-      log.flush()
-      cancel('Termination failed')
-      throw new CliFatal('Invalid data set ID')
-    }
-
     const synapse = await getCliSynapse(options)
     const network = synapse.chain.name
     const address = getClientAddress(synapse)

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -13,6 +13,7 @@ import { CID } from 'multiformats/cid'
 import pc from 'picocolors'
 import pino from 'pino'
 import { warnAboutCDNPricingLimitations } from '../common/cdn-warning.js'
+import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { DEVNET_CHAIN_ID } from '../common/get-rpc-url.js'
 import { displayUploadResults, performAutoFunding, performUpload, validatePaymentSetup } from '../common/upload-flow.js'
 import { resolveDataSetIdsByMetadata } from '../core/data-set/index.js'
@@ -370,10 +371,16 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
 
     return result
   } catch (error) {
-    spinner.stop(`${pc.red('✗')} Import failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    if (isCliFatal(error)) {
+      spinner.stop()
+      logger.error({ event: 'import.failed', error }, 'Import failed')
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : 'Unknown error'
+    spinner.stop(`${pc.red('✗')} Import failed: ${msg}`)
     logger.error({ event: 'import.failed', error }, 'Import failed')
 
     cancel('Import failed')
-    throw error
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -23,6 +23,8 @@ import { getNetworkSlug } from '../core/upload/index.js'
 import { parseCLIAuth, parseContextSelectionOptions } from '../utils/cli-auth.js'
 import { cancel, createSpinner, formatFileSize, intro, outro } from '../utils/cli-helpers.js'
 import { log } from '../utils/cli-logger.js'
+import { validateAndNormalizeAutoFundOptions } from '../utils/cli-options.js'
+import { resolveMetadataOptions } from '../utils/cli-options-metadata.js'
 import type { ImportOptions, ImportResult } from './types.js'
 
 /**
@@ -122,6 +124,46 @@ async function validateFilePath(filePath: string): Promise<{ exists: boolean; st
       error: `Cannot access file: ${filePath} (${error?.message || 'unknown error'})`,
     }
   }
+}
+
+/**
+ * Normalize Commander options and run the CAR import flow.
+ *
+ * Commander wiring calls this so option validation errors are displayed by the
+ * command UI layer and command files only own exit-code handling.
+ */
+export async function runCarImportFromCli(file: string, options: Record<string, any>): Promise<ImportResult> {
+  let importOptions: ImportOptions
+  try {
+    const autoFundOptions = validateAndNormalizeAutoFundOptions(options)
+    const {
+      metadata: _metadata,
+      dataSetMetadata: _dataSetMetadata,
+      datasetMetadata: _datasetMetadata,
+      '8004Type': _erc8004Type,
+      '8004Agent': _erc8004Agent,
+      autoFund: _autoFund,
+      minRunwayDays: _minRunwayDays,
+      maxBalance: _maxBalance,
+      ...importOptionsFromCli
+    } = options
+
+    const { pieceMetadata, dataSetMetadata } = resolveMetadataOptions(options, { includeErc8004: true })
+    importOptions = {
+      ...importOptionsFromCli,
+      ...autoFundOptions,
+      filePath: file,
+      ...(pieceMetadata && { pieceMetadata }),
+      ...(dataSetMetadata && { dataSetMetadata }),
+    }
+  } catch (error) {
+    log.line(`${pc.red('Error:')} ${error instanceof Error ? error.message : String(error)}`)
+    log.flush()
+    cancel('Import cancelled')
+    throw error
+  }
+
+  return await runCarImport(importOptions)
 }
 
 /**
@@ -300,6 +342,7 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
       rootCid: rootCidString,
       pieceCid: uploadResult.pieceCid,
       size: uploadResult.size,
+      requestedCopies,
       copies: uploadResult.copies,
       failedAttempts: uploadResult.failedAttempts,
     }
@@ -316,7 +359,6 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
       )
       log.flush()
       outro('Import completed with errors')
-      process.exitCode = 1
     } else if (uploadResult.failedAttempts.length > 0) {
       log.line('')
       log.line(pc.gray(`${uploadResult.failedAttempts.length} non-critical copy failure(s) during upload.`))

--- a/src/import/types.ts
+++ b/src/import/types.ts
@@ -20,6 +20,7 @@ export interface ImportResult {
   rootCid: string
   pieceCid: string
   size: number
+  requestedCopies: number
   copies: CopyResult[]
   failedAttempts: FailedAttempt[]
 }

--- a/src/payments/auto.ts
+++ b/src/payments/auto.ts
@@ -40,7 +40,7 @@ export async function runAutoSetup(options: PaymentSetupOptions): Promise<void> 
     targetFilecoinPayBalance = parseUnits(options.deposit, 18)
   } catch {
     console.error(pc.red(`Error: Invalid deposit amount '${options.deposit}'`))
-    process.exit(1)
+    throw new Error(`Invalid deposit amount '${options.deposit}'`)
   }
 
   const spinner = createSpinner()
@@ -75,7 +75,7 @@ export async function runAutoSetup(options: PaymentSetupOptions): Promise<void> 
       }
       log.flush()
       cancel('Please fund your wallet and try again')
-      process.exit(1)
+      throw new Error(validation.errorMessage)
     }
 
     // Now safe to get payment status since we know account exists
@@ -110,7 +110,7 @@ export async function runAutoSetup(options: PaymentSetupOptions): Promise<void> 
             `✗ Insufficient USDFC for deposit (need ${formatUSDFC(neededFilecoinPayTopUp)} USDFC, have ${formatUSDFC(walletUsdfcBalance)} USDFC)`
           )
         )
-        process.exit(1)
+        throw new Error('Insufficient USDFC for deposit')
       }
 
       spinner.start(`Depositing ${formatUSDFC(neededFilecoinPayTopUp)} USDFC...`)
@@ -167,9 +167,6 @@ export async function runAutoSetup(options: PaymentSetupOptions): Promise<void> 
     spinner.stop() // Stop spinner without message
     console.error(pc.red('✗ Setup failed'))
     console.error(pc.red('Error:'), error instanceof Error ? error.message : error)
-
-    process.exitCode = 1
-  } finally {
-    process.exit()
+    throw error
   }
 }

--- a/src/payments/auto.ts
+++ b/src/payments/auto.ts
@@ -8,6 +8,7 @@
 
 import pc from 'picocolors'
 import { parseUnits } from 'viem'
+import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import {
   calculateDepositCapacity,
   checkAndSetAllowances,
@@ -34,13 +35,16 @@ export async function runAutoSetup(options: PaymentSetupOptions): Promise<void> 
   intro(pc.bold('Filecoin Onchain Cloud Payment Setup'))
   log.message(pc.gray('Running in auto mode...'))
 
-  // Parse and validate deposit amount
+  // Parse and validate deposit amount. Display happens here (before the
+  // outer try below), so throw CliFatal so the CLI wrapper exits without
+  // re-printing.
   let targetFilecoinPayBalance: bigint
   try {
     targetFilecoinPayBalance = parseUnits(options.deposit, 18)
   } catch {
-    console.error(pc.red(`Error: Invalid deposit amount '${options.deposit}'`))
-    throw new Error(`Invalid deposit amount '${options.deposit}'`)
+    log.line(pc.red(`Error: Invalid deposit amount '${options.deposit}'`))
+    log.flush()
+    throw new CliFatal(`Invalid deposit amount '${options.deposit}'`)
   }
 
   const spinner = createSpinner()
@@ -68,14 +72,15 @@ export async function runAutoSetup(options: PaymentSetupOptions): Promise<void> 
     // Validate payment requirements
     const validation = validatePaymentRequirements(filStatus.hasSufficientGas, walletUsdfcBalance, filStatus.isCalibnet)
     if (!validation.isValid) {
-      log.line(`${pc.red('✗')} ${validation.errorMessage}`)
+      const errorMsg = validation.errorMessage ?? 'Payment validation failed'
+      log.line(`${pc.red('✗')} ${errorMsg}`)
       if (validation.helpMessage) {
         log.line('')
         log.line(`  ${pc.cyan(validation.helpMessage)}`)
       }
       log.flush()
       cancel('Please fund your wallet and try again')
-      throw new Error(validation.errorMessage)
+      throw new CliFatal(errorMsg)
     }
 
     // Now safe to get payment status since we know account exists
@@ -105,12 +110,9 @@ export async function runAutoSetup(options: PaymentSetupOptions): Promise<void> 
       actualFilecoinPayTopUp = neededFilecoinPayTopUp
 
       if (neededFilecoinPayTopUp > walletUsdfcBalance) {
-        console.error(
-          pc.red(
-            `✗ Insufficient USDFC for deposit (need ${formatUSDFC(neededFilecoinPayTopUp)} USDFC, have ${formatUSDFC(walletUsdfcBalance)} USDFC)`
-          )
+        throw new Error(
+          `Insufficient USDFC for deposit (need ${formatUSDFC(neededFilecoinPayTopUp)} USDFC, have ${formatUSDFC(walletUsdfcBalance)} USDFC)`
         )
-        throw new Error('Insufficient USDFC for deposit')
       }
 
       spinner.start(`Depositing ${formatUSDFC(neededFilecoinPayTopUp)} USDFC...`)
@@ -164,9 +166,13 @@ export async function runAutoSetup(options: PaymentSetupOptions): Promise<void> 
       outro('Payment setup already configured - ready to use')
     }
   } catch (error) {
-    spinner.stop() // Stop spinner without message
-    console.error(pc.red('✗ Setup failed'))
-    console.error(pc.red('Error:'), error instanceof Error ? error.message : error)
-    throw error
+    if (isCliFatal(error)) {
+      spinner.stop()
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : String(error)
+    spinner.stop(`${pc.red('✗')} Setup failed: ${msg}`)
+    cancel('Setup failed')
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }

--- a/src/payments/deposit.ts
+++ b/src/payments/deposit.ts
@@ -8,6 +8,7 @@
 
 import pc from 'picocolors'
 import { parseUnits } from 'viem'
+import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import {
   calculateStorageRunway,
   checkFILBalance,
@@ -41,8 +42,9 @@ export async function runDeposit(options: DepositOptions): Promise<void> {
   const hasDays = options.days != null
 
   if ((hasAmount && hasDays) || (!hasAmount && !hasDays)) {
-    console.error(pc.red('Error: Specify exactly one of --amount <USDFC> or --days <N>'))
-    throw new Error('Error: Specify exactly one of --amount <USDFC> or --days <N>')
+    log.line(pc.red('Error: Specify exactly one of --amount <USDFC> or --days <N>'))
+    log.flush()
+    throw new CliFatal('Specify exactly one of --amount <USDFC> or --days <N>')
   }
 
   // Connect
@@ -71,7 +73,7 @@ export async function runDeposit(options: DepositOptions): Promise<void> {
       log.line(`  ${pc.cyan(help)}`)
       log.flush()
       cancel('Deposit aborted')
-      throw new Error('Insufficient FIL for gas fees')
+      throw new CliFatal('Insufficient FIL for gas fees')
     }
 
     let depositAmount: bigint = 0n
@@ -100,7 +102,7 @@ export async function runDeposit(options: DepositOptions): Promise<void> {
         log.line('Use --amount to deposit a specific USDFC value instead.')
         log.flush()
         cancel('Nothing to fund by duration')
-        throw new Error('No active spend detected')
+        throw new CliFatal('No active spend detected')
       }
 
       depositAmount = topUp
@@ -117,12 +119,9 @@ export async function runDeposit(options: DepositOptions): Promise<void> {
 
     // Ensure wallet has enough USDFC
     if (depositAmount > walletUsdfcBalance) {
-      console.error(
-        pc.red(
-          `✗ Insufficient USDFC (need ${formatUSDFC(depositAmount)} USDFC, have ${formatUSDFC(walletUsdfcBalance)} USDFC)`
-        )
+      throw new Error(
+        `Insufficient USDFC (need ${formatUSDFC(depositAmount)} USDFC, have ${formatUSDFC(walletUsdfcBalance)} USDFC)`
       )
-      throw new Error('Insufficient USDFC')
     }
 
     spinner.start(`Depositing ${formatUSDFC(depositAmount)} USDFC...`)
@@ -152,9 +151,13 @@ export async function runDeposit(options: DepositOptions): Promise<void> {
 
     outro('Deposit completed')
   } catch (error) {
-    spinner.stop()
-    console.error(pc.red('✗ Deposit failed'))
-    console.error(pc.red('Error:'), error instanceof Error ? error.message : error)
-    throw error
+    if (isCliFatal(error)) {
+      spinner.stop()
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : String(error)
+    spinner.stop(`${pc.red('✗')} Deposit failed: ${msg}`)
+    cancel('Deposit failed')
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }

--- a/src/payments/fund.ts
+++ b/src/payments/fund.ts
@@ -8,6 +8,7 @@ import { confirm } from '@clack/prompts'
 import type { Synapse } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
 import { parseUnits } from 'viem'
+import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { MIN_RUNWAY_DAYS } from '../common/constants.js'
 import {
   calculateStorageRunway,
@@ -38,10 +39,11 @@ async function ensureBelowThirtyDaysAllowed(opts: {
   const { spinner, warningLine1, warningLine2 } = opts
   if (!isInteractive()) {
     spinner.stop()
-    console.error(pc.red(warningLine1))
-    console.error(pc.red(warningLine2))
+    log.line(pc.red(warningLine1))
+    log.line(pc.red(warningLine2))
+    log.flush()
     cancel('Fund adjustment aborted')
-    throw new Error(`Unsafe target below ${DEFAULT_LOCKUP_DAYS}-day baseline`)
+    throw new CliFatal(`Unsafe target below ${DEFAULT_LOCKUP_DAYS}-day baseline`)
   }
 
   log.line(pc.yellow('⚠ Warning'))
@@ -71,12 +73,9 @@ async function performAdjustment(params: {
     const needed = delta
     const usdfcWallet = await checkUSDFCBalance(synapse)
     if (needed > usdfcWallet) {
-      console.error(
-        pc.red(
-          `✗ Insufficient USDFC in wallet (need ${formatUSDFC(needed)} USDFC, have ${formatUSDFC(usdfcWallet)} USDFC)`
-        )
+      throw new Error(
+        `Insufficient USDFC in wallet (need ${formatUSDFC(needed)} USDFC, have ${formatUSDFC(usdfcWallet)} USDFC)`
       )
-      throw new Error('Insufficient USDFC in wallet')
     }
     if (isTTY()) {
       // we will deposit `needed` USDFC, display confirmation to user unless not TTY or --auto flag was passed
@@ -227,12 +226,14 @@ export async function runFund(options: FundOptions): Promise<void> {
   const hasDays = options.days != null
   const hasAmount = options.amount != null
   if ((hasDays && hasAmount) || (!hasDays && !hasAmount)) {
-    console.error(pc.red('Error: Specify exactly one of --days <N> or --amount <USDFC>'))
-    throw new Error('Invalid fund options')
+    log.line(pc.red('Error: Specify exactly one of --days <N> or --amount <USDFC>'))
+    log.flush()
+    throw new CliFatal('Specify exactly one of --days <N> or --amount <USDFC>')
   }
   if (options.mode != null && !['exact', 'minimum'].includes(options.mode)) {
-    console.error(pc.red('Error: Invalid mode'))
-    throw new Error(`Invalid mode (must be "exact" or "minimum"), received: '${options.mode}'`)
+    log.line(pc.red(`Error: Invalid mode (must be "exact" or "minimum"), received: '${options.mode}'`))
+    log.flush()
+    throw new CliFatal(`Invalid mode (must be "exact" or "minimum"), received: '${options.mode}'`)
   }
 
   spinner.start('Connecting...')
@@ -247,16 +248,14 @@ export async function runFund(options: FundOptions): Promise<void> {
 
     const targetDays: number = hasDays ? Number(options.days) : 0
     if (hasDays && (!Number.isFinite(targetDays) || targetDays < 0)) {
-      console.error(pc.red('Error: --days must be a non-negative number'))
-      throw new Error('Invalid --days')
+      throw new Error('--days must be a non-negative number')
     }
 
     let targetDeposit: bigint = 0n
     try {
       targetDeposit = options.amount != null ? parseUnits(String(options.amount), 18) : 0n
     } catch {
-      console.error(pc.red(`Error: Invalid --amount '${options.amount}'`))
-      throw new Error('Invalid --amount')
+      throw new Error(`Invalid --amount '${options.amount}'`)
     }
 
     spinner.start('Calculating funding plan...')
@@ -275,7 +274,7 @@ export async function runFund(options: FundOptions): Promise<void> {
       log.line('Use --amount to set a target deposit instead.')
       log.flush()
       cancel('Fund adjustment aborted')
-      throw new Error('No active spend')
+      throw new CliFatal('No active spend')
     }
 
     let projectedRunwayTarget: number | null = null
@@ -342,14 +341,9 @@ export async function runFund(options: FundOptions): Promise<void> {
     }
 
     if (plan.walletShortfall != null && plan.walletShortfall > 0n) {
-      spinner.stop()
-      console.error(
-        pc.red(
-          `✗ Insufficient USDFC in wallet (need ${formatUSDFC(plan.delta)} USDFC, have ${formatUSDFC(planResult.status.walletUsdfcBalance)} USDFC)`
-        )
+      throw new Error(
+        `Insufficient USDFC in wallet (need ${formatUSDFC(plan.delta)} USDFC, have ${formatUSDFC(planResult.status.walletUsdfcBalance)} USDFC)`
       )
-      cancel('Fund adjustment aborted')
-      throw new Error('Insufficient USDFC in wallet')
     }
 
     await performAdjustment({
@@ -363,9 +357,13 @@ export async function runFund(options: FundOptions): Promise<void> {
     await printSummary(synapse)
     outro('Fund adjustment completed')
   } catch (error) {
-    spinner.stop()
-    console.error(pc.red('✗ Fund adjustment failed'))
-    console.error(pc.red('Error:'), error instanceof Error ? error.message : error)
-    throw error
+    if (isCliFatal(error)) {
+      spinner.stop()
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : String(error)
+    spinner.stop(`${pc.red('✗')} Fund adjustment failed: ${msg}`)
+    cancel('Fund adjustment failed')
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }

--- a/src/payments/interactive.ts
+++ b/src/payments/interactive.ts
@@ -37,7 +37,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
   if (!isTTY()) {
     console.error(pc.red('Error: Interactive mode requires a TTY terminal.'))
     console.error('Use --auto flag for non-interactive setup.')
-    process.exit(1)
+    throw new Error('Interactive mode requires a TTY terminal')
   }
 
   intro(pc.bold('Filecoin Onchain Cloud Payment Setup'))
@@ -66,7 +66,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
       if (isCancel(input)) {
         cancel('Setup cancelled')
-        process.exit(1)
+        throw new Error('Setup cancelled')
       }
 
       // Add 0x prefix if it was missing
@@ -102,7 +102,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
       }
       log.flush()
       cancel('Please fund your wallet and try again')
-      process.exit(1)
+      throw new Error(validation.errorMessage)
     }
 
     // Now safe to get payment status since we know account exists
@@ -161,7 +161,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
     if (isCancel(shouldDeposit)) {
       cancel('Setup cancelled')
-      process.exit(1)
+      throw new Error('Setup cancelled')
     }
 
     if (shouldDeposit) {
@@ -193,7 +193,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
       if (isCancel(amountStr)) {
         cancel('Setup cancelled')
-        process.exit(1)
+        throw new Error('Setup cancelled')
       }
 
       depositAmount = parseUnits(amountStr, 18)
@@ -262,8 +262,6 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
     }
   } catch (error) {
     console.error(`\n${pc.red('Error:')}`, error instanceof Error ? error.message : error)
-    process.exitCode = 1
-  } finally {
-    process.exit()
+    throw error
   }
 }

--- a/src/payments/interactive.ts
+++ b/src/payments/interactive.ts
@@ -9,6 +9,7 @@
 import { cancel, confirm, isCancel, password, text } from '@clack/prompts'
 import pc from 'picocolors'
 import { parseUnits } from 'viem'
+import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import {
   calculateDepositCapacity,
   checkAndSetAllowances,
@@ -35,12 +36,14 @@ import type { PaymentSetupOptions } from './types.js'
 export async function runInteractiveSetup(options: PaymentSetupOptions): Promise<void> {
   // Check for TTY support
   if (!isTTY()) {
-    console.error(pc.red('Error: Interactive mode requires a TTY terminal.'))
-    console.error('Use --auto flag for non-interactive setup.')
-    throw new Error('Interactive mode requires a TTY terminal')
+    log.line(pc.red('Error: Interactive mode requires a TTY terminal.'))
+    log.line('Use --auto flag for non-interactive setup.')
+    log.flush()
+    throw new CliFatal('Interactive mode requires a TTY terminal')
   }
 
   intro(pc.bold('Filecoin Onchain Cloud Payment Setup'))
+  const s = createSpinner()
 
   try {
     // Get private key
@@ -66,7 +69,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
       if (isCancel(input)) {
         cancel('Setup cancelled')
-        throw new Error('Setup cancelled')
+        throw new CliFatal('Setup cancelled')
       }
 
       // Add 0x prefix if it was missing
@@ -74,7 +77,6 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
     }
 
     // Initialize Synapse
-    const s = createSpinner()
     s.start('Initializing connection...')
 
     const config = parseCLIAuth({ ...options, privateKey })
@@ -95,14 +97,15 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
     // Validate payment requirements
     const validation = validatePaymentRequirements(filStatus.hasSufficientGas, walletUsdfcBalance, filStatus.isCalibnet)
     if (!validation.isValid) {
-      log.line(`${pc.red('✗')} ${validation.errorMessage}`)
+      const errorMsg = validation.errorMessage ?? 'Payment validation failed'
+      log.line(`${pc.red('✗')} ${errorMsg}`)
       if (validation.helpMessage) {
         log.line('')
         log.line(`  ${pc.cyan(validation.helpMessage)}`)
       }
       log.flush()
       cancel('Please fund your wallet and try again')
-      throw new Error(validation.errorMessage)
+      throw new CliFatal(errorMsg)
     }
 
     // Now safe to get payment status since we know account exists
@@ -161,7 +164,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
     if (isCancel(shouldDeposit)) {
       cancel('Setup cancelled')
-      throw new Error('Setup cancelled')
+      throw new CliFatal('Setup cancelled')
     }
 
     if (shouldDeposit) {
@@ -193,7 +196,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
       if (isCancel(amountStr)) {
         cancel('Setup cancelled')
-        throw new Error('Setup cancelled')
+        throw new CliFatal('Setup cancelled')
       }
 
       depositAmount = parseUnits(amountStr, 18)
@@ -261,7 +264,13 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
       outro('No changes made to payment setup')
     }
   } catch (error) {
-    console.error(`\n${pc.red('Error:')}`, error instanceof Error ? error.message : error)
-    throw error
+    if (isCliFatal(error)) {
+      s.stop()
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : String(error)
+    s.stop(`${pc.red('✗')} Setup failed: ${msg}`)
+    cancel('Setup failed')
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }

--- a/src/payments/withdraw.ts
+++ b/src/payments/withdraw.ts
@@ -4,6 +4,7 @@
 
 import pc from 'picocolors'
 import { parseUnits } from 'viem'
+import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { checkFILBalance, getPaymentStatus, withdrawUSDFC } from '../core/payments/index.js'
 import { initializeSynapse } from '../core/synapse/index.js'
 import { formatUSDFC } from '../core/utils/format.js'
@@ -23,12 +24,14 @@ export async function runWithdraw(options: WithdrawOptions): Promise<void> {
   try {
     amount = parseUnits(String(options.amount), 18)
   } catch {
-    console.error(pc.red(`Error: Invalid amount '${options.amount}'`))
-    throw new Error(`Invalid amount '${options.amount}'`)
+    log.line(pc.red(`Error: Invalid amount '${options.amount}'`))
+    log.flush()
+    throw new CliFatal(`Invalid amount '${options.amount}'`)
   }
   if (amount <= 0n) {
-    console.error(pc.red('Error: Amount must be greater than 0'))
-    throw new Error('Amount must be greater than 0')
+    log.line(pc.red('Error: Amount must be greater than 0'))
+    log.flush()
+    throw new CliFatal('Amount must be greater than 0')
   }
 
   spinner.start('Connecting...')
@@ -48,7 +51,7 @@ export async function runWithdraw(options: WithdrawOptions): Promise<void> {
       log.line(`  ${pc.cyan(help)}`)
       log.flush()
       cancel('Withdraw aborted')
-      throw new Error('Insufficient FIL for gas fees')
+      throw new CliFatal('Insufficient FIL for gas fees')
     }
 
     spinner.stop(`${pc.green('✓')} Connected`)
@@ -70,9 +73,13 @@ export async function runWithdraw(options: WithdrawOptions): Promise<void> {
 
     outro('Withdraw completed')
   } catch (error) {
-    spinner.stop()
-    console.error(pc.red('✗ Withdraw failed'))
-    console.error(pc.red('Error:'), error instanceof Error ? error.message : error)
-    throw error
+    if (isCliFatal(error)) {
+      spinner.stop()
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : String(error)
+    spinner.stop(`${pc.red('✗')} Withdraw failed: ${msg}`)
+    cancel('Withdraw failed')
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }

--- a/src/provider/run.ts
+++ b/src/provider/run.ts
@@ -1,6 +1,7 @@
 import { getEndorsedProviderIds } from '@filoz/synapse-core/endorsements'
 import { getApprovedProviderIds } from '@filoz/synapse-core/warm-storage'
 import pc from 'picocolors'
+import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { formatUSDFC } from '../core/utils/format.js'
 import { getCliSynapse } from '../utils/cli-auth.js'
 import { cancel, createSpinner, formatFileSize, intro, outro } from '../utils/cli-helpers.js'
@@ -45,11 +46,17 @@ export async function runProviderList(options: ProviderListOptions): Promise<voi
 
     outro('Provider list complete')
   } catch (error) {
+    if (isCliFatal(error)) {
+      spinner.stop()
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : String(error)
     spinner.stop(`${pc.red('✗')} Failed to list providers`)
     log.line('')
-    log.line(`${pc.red('Error:')} ${error instanceof Error ? error.message : String(error)}`)
+    log.line(`${pc.red('Error:')} ${msg}`)
+    log.flush()
     cancel('Listing failed')
-    throw error
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }
 
@@ -71,13 +78,17 @@ export async function runProviderShow(providerIdOrAddr: string, options: Provide
     if (!Number.isNaN(id) && id.toString() === providerIdOrAddr) {
       provider = await synapse.providers.getProvider({ providerId: BigInt(id) })
     } else {
-      spinner.stop(pc.yellow('Querying by address is not directly supported, trying as ID if numeric.'))
-      throw new Error('Please provide a numeric Provider ID')
+      spinner.stop(`${pc.red('✗')} Provider ID must be numeric (got: ${providerIdOrAddr})`)
+      log.line('')
+      log.line(pc.gray('Querying providers by address is not currently supported.'))
+      log.flush()
+      cancel('Inspection failed')
+      throw new CliFatal(`Provider ID must be numeric: ${providerIdOrAddr}`)
     }
 
     if (!provider) {
       spinner.stop(pc.red(`Provider ${providerIdOrAddr} not found or invalid.`))
-      throw new Error(`Provider ${providerIdOrAddr} not found`)
+      throw new CliFatal(`Provider ${providerIdOrAddr} not found`)
     }
 
     spinner.message('Checking endorsement and approval status...')
@@ -94,11 +105,17 @@ export async function runProviderShow(providerIdOrAddr: string, options: Provide
 
     outro('Provider inspection complete')
   } catch (error) {
+    if (isCliFatal(error)) {
+      spinner.stop()
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : String(error)
     spinner.stop(`${pc.red('✗')} Failed to show provider`)
     log.line('')
-    log.line(`${pc.red('Error:')} ${error instanceof Error ? error.message : String(error)}`)
+    log.line(`${pc.red('Error:')} ${msg}`)
+    log.flush()
     cancel('Inspection failed')
-    throw error
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }
 
@@ -187,11 +204,17 @@ export async function runProviderPing(
 
     outro('Ping complete')
   } catch (error) {
+    if (isCliFatal(error)) {
+      spinner.stop()
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : String(error)
     spinner.stop(`${pc.red('✗')} Ping failed`)
     log.line('')
-    log.line(`${pc.red('Error:')} ${error instanceof Error ? error.message : String(error)}`)
+    log.line(`${pc.red('Error:')} ${msg}`)
+    log.flush()
     cancel('Ping failed')
-    throw error
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }
 

--- a/src/test/unit/cli-errors.test.ts
+++ b/src/test/unit/cli-errors.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { CliFatal, isCliFatal } from '../../common/cli-errors.js'
+
+describe('CliFatal', () => {
+  it('is an Error subclass with name "CliFatal"', () => {
+    const err = new CliFatal('boom')
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(CliFatal)
+    expect(err.name).toBe('CliFatal')
+    expect(err.message).toBe('boom')
+  })
+
+  it('preserves the cause via ErrorOptions', () => {
+    const cause = new Error('underlying')
+    const err = new CliFatal('wrapper', { cause })
+    expect(err.cause).toBe(cause)
+  })
+})
+
+describe('isCliFatal', () => {
+  it('identifies CliFatal instances', () => {
+    expect(isCliFatal(new CliFatal('x'))).toBe(true)
+  })
+
+  it('rejects plain Error instances', () => {
+    expect(isCliFatal(new Error('plain'))).toBe(false)
+    expect(isCliFatal(new TypeError('typed'))).toBe(false)
+  })
+
+  it('rejects non-error values', () => {
+    expect(isCliFatal(null)).toBe(false)
+    expect(isCliFatal(undefined)).toBe(false)
+    expect(isCliFatal('string error')).toBe(false)
+    expect(isCliFatal({ message: 'fake' })).toBe(false)
+  })
+})
+
+describe('outer-catch contract', () => {
+  // Reference shape: runners' outer catch should skip generic display when
+  // an inner branch already displayed the error and threw CliFatal.
+  function simulatedOuterCatch(error: unknown, displaySpy: (msg: string) => void): void {
+    if (!isCliFatal(error)) {
+      const msg = error instanceof Error ? error.message : String(error)
+      displaySpy(`✗ Operation failed: ${msg}`)
+    }
+  }
+
+  it('does NOT display when inner branch threw CliFatal', () => {
+    const calls: string[] = []
+    simulatedOuterCatch(new CliFatal('already shown'), (m) => calls.push(m))
+    expect(calls).toEqual([])
+  })
+
+  it('DOES display when inner branch threw plain Error', () => {
+    const calls: string[] = []
+    simulatedOuterCatch(new Error('rpc died'), (m) => calls.push(m))
+    expect(calls).toEqual(['✗ Operation failed: rpc died'])
+  })
+
+  it('displays for non-Error throws', () => {
+    const calls: string[] = []
+    simulatedOuterCatch('string-throw', (m) => calls.push(m))
+    expect(calls).toEqual(['✗ Operation failed: string-throw'])
+  })
+})


### PR DESCRIPTION
## What changed

Completes the CLI command separation cleanup from #254. Add/import now normalize CLI options in runner-side helpers, business/shared upload and payment flows throw instead of exiting, and command wrappers own exit codes, including partial-copy outcomes.

Adds CONTRIBUTING guidance for one-shot CLI command boundaries so future commands keep Commander wiring separate from business logic.

## How to verify

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec vitest run --project unit src/test/unit/add.test.ts src/test/unit/import.test.ts src/test/unit/payments-setup.test.ts src/test/unit/payments-top-up.test.ts src/test/unit/payments-funding.test.ts src/test/unit/data-set.test.ts`
- `pnpm test`

Closes #254
