### PR TITLE
refactor(data-set): drop StorageContext requirement from getDataSetPieces

### DIFF
--- a/src/core/data-set/calculate-actual-storage.ts
+++ b/src/core/data-set/calculate-actual-storage.ts
@@ -146,7 +146,7 @@ export async function calculateActualStorage(
         providerMap.set(ds.providerId, ds.provider)
       }
     }
-    const missingProviderIds = [...new Set(dataSets.filter((ds) => ds.provider == null).map((ds) => ds.providerId))]
+    const missingProviderIds = [...new Set(dataSets.map((ds) => ds.providerId))].filter((id) => !providerMap.has(id))
     if (missingProviderIds.length > 0) {
       try {
         const fetched = await synapse.providers.getProviders({ providerIds: missingProviderIds })

--- a/src/core/data-set/calculate-actual-storage.ts
+++ b/src/core/data-set/calculate-actual-storage.ts
@@ -1,4 +1,4 @@
-import type { Synapse } from '@filoz/synapse-sdk'
+import type { PDPProvider, Synapse } from '@filoz/synapse-sdk'
 import PQueue from 'p-queue'
 import type { Logger } from 'pino'
 import { getClientAddress } from '../synapse/index.js'
@@ -139,14 +139,29 @@ export async function calculateActualStorage(
 
     logger?.info({ dataSetCount: dataSets.length, address }, 'Calculating actual storage across data sets')
 
+    // Build provider map; trust pre-filled entries and only fetch the missing ones
+    const providerMap = new Map<bigint, PDPProvider>()
+    for (const ds of dataSets) {
+      if (ds.provider != null) {
+        providerMap.set(ds.providerId, ds.provider)
+      }
+    }
+    const missingProviderIds = [...new Set(dataSets.filter((ds) => ds.provider == null).map((ds) => ds.providerId))]
+    if (missingProviderIds.length > 0) {
+      try {
+        const fetched = await synapse.providers.getProviders({ providerIds: missingProviderIds })
+        for (const provider of fetched) {
+          providerMap.set(provider.id, provider)
+        }
+      } catch (error) {
+        logger?.warn({ error, missingProviderIds }, 'Failed to enrich provider info for actual storage calculation')
+      }
+    }
+
     const processDataSet = async (dataSet: (typeof dataSets)[number]): Promise<void> => {
       signal?.throwIfAborted()
 
       try {
-        const storageContext = await synapse.storage.createContext({ dataSetId: dataSet.dataSetId })
-
-        signal?.throwIfAborted()
-
         const getPiecesOptions: { logger?: Logger; signal?: AbortSignal } = {}
         if (logger) {
           getPiecesOptions.logger = logger
@@ -154,7 +169,8 @@ export async function calculateActualStorage(
         if (signal) {
           getPiecesOptions.signal = signal
         }
-        const result = await getDataSetPieces(synapse, storageContext, getPiecesOptions)
+        const serviceURL = providerMap.get(dataSet.providerId)?.pdp?.serviceURL ?? ''
+        const result = await getDataSetPieces(synapse, dataSet.dataSetId, serviceURL, getPiecesOptions)
 
         if (result.totalSizeBytes) {
           totalBytes += result.totalSizeBytes

--- a/src/core/data-set/get-data-set-pieces.ts
+++ b/src/core/data-set/get-data-set-pieces.ts
@@ -77,6 +77,7 @@ export async function getDataSetPieces(
     let offset = 0n
     let hasMore = true
     while (hasMore) {
+      options?.signal?.throwIfAborted()
       const result = await getActivePieces(synapse.client, {
         dataSetId,
         offset,

--- a/src/core/data-set/get-data-set-pieces.ts
+++ b/src/core/data-set/get-data-set-pieces.ts
@@ -6,38 +6,37 @@
  * @module core/data-set/get-data-set-pieces
  */
 
+import { getActivePieces, getScheduledRemovals } from '@filoz/synapse-core/pdp-verifier'
 import { getSizeFromPieceCID } from '@filoz/synapse-core/piece'
 import { getDataSet as getProviderDataSet } from '@filoz/synapse-core/sp'
 import { getAllPieceMetadata } from '@filoz/synapse-core/warm-storage'
 import { type DataSetPieceData, METADATA_KEYS, type Synapse } from '@filoz/synapse-sdk'
-import type { StorageContext } from '@filoz/synapse-sdk/storage'
 import { reconcilePieceStatus } from '../piece/piece-status.js'
 import type { Warning } from '../utils/types.js'
 import { type DataSetPiecesResult, type GetDataSetPiecesOptions, type PieceInfo, PieceStatus } from './types.js'
 
+const ACTIVE_PIECES_BATCH_SIZE = 100n
+
 /**
- * Get all pieces for a dataset from a StorageContext
+ * Get all pieces for a dataset.
  *
- * Uses StorageContext.getPieces() async generator to retrieve all pieces.
- * Optionally fetches metadata for each piece from WarmStorage.
+ * Fetches on-chain pieces via PDPVerifier and provider-side pieces from the
+ * service URL, reconciles statuses, and optionally enriches with metadata.
  *
  * @param synapse - Initialized Synapse instance
- * @param storageContext - Storage context bound to a dataset
+ * @param dataSetId - Dataset ID to fetch pieces for
+ * @param serviceURL - Provider PDP service URL for orphan detection
  * @param options - Optional configuration
  * @returns Pieces and warnings
  */
 export async function getDataSetPieces(
   synapse: Synapse,
-  storageContext: StorageContext,
+  dataSetId: bigint,
+  serviceURL: string,
   options?: GetDataSetPiecesOptions
 ): Promise<DataSetPiecesResult> {
   const logger = options?.logger
   const includeMetadata = options?.includeMetadata ?? false
-
-  if (storageContext.dataSetId == null) {
-    throw new Error('Storage context does not have a dataset ID')
-  }
-  const dataSetId = storageContext.dataSetId
 
   const pieces: PieceInfo[] = []
   const warnings: Warning[] = []
@@ -47,11 +46,8 @@ export async function getDataSetPieces(
   let providerPiecesById: Map<bigint, DataSetPieceData> | null = null
 
   const [scheduledRemovalsResult, providerPiecesResult] = await Promise.allSettled([
-    storageContext.getScheduledRemovals(),
-    getProviderDataSet({
-      serviceURL: storageContext.provider.pdp?.serviceURL ?? '',
-      dataSetId,
-    }),
+    getScheduledRemovals(synapse.client, { dataSetId }),
+    getProviderDataSet({ serviceURL, dataSetId }),
   ])
 
   if (scheduledRemovalsResult.status === 'fulfilled') {
@@ -76,37 +72,45 @@ export async function getDataSetPieces(
     })
   }
 
-  // Fetch on-chain pieces and reconcile with provider data
+  // Fetch on-chain pieces (paginated) and reconcile with provider data
   try {
-    for await (const piece of storageContext.getPieces()) {
-      const pieceId = piece.pieceId
-      const pieceCid = piece.pieceCid
-      const { status, warning } = reconcilePieceStatus({
-        pieceId,
-        pieceCid,
-        scheduledRemovals,
-        providerPiecesById,
+    let offset = 0n
+    let hasMore = true
+    while (hasMore) {
+      const result = await getActivePieces(synapse.client, {
+        dataSetId,
+        offset,
+        limit: ACTIVE_PIECES_BATCH_SIZE,
       })
-      const pieceInfo: PieceInfo = {
-        pieceId,
-        pieceCid: pieceCid.toString(),
-        status,
-      }
-      if (warning) {
-        warnings.push(warning)
-      }
+      for (const piece of result.pieces) {
+        const { status, warning } = reconcilePieceStatus({
+          pieceId: piece.id,
+          pieceCid: piece.cid,
+          scheduledRemovals,
+          providerPiecesById,
+        })
+        const pieceInfo: PieceInfo = {
+          pieceId: piece.id,
+          pieceCid: piece.cid.toString(),
+          status,
+        }
+        if (warning) {
+          warnings.push(warning)
+        }
 
-      // Calculate piece size from CID
-      try {
-        pieceInfo.size = getSizeFromPieceCID(pieceCid)
-      } catch (error) {
-        logger?.warn(
-          { pieceId: piece.pieceId.toString(), pieceCid: piece.pieceCid.toString(), error },
-          'Failed to calculate piece size from CID'
-        )
-      }
+        try {
+          pieceInfo.size = getSizeFromPieceCID(piece.cid)
+        } catch (error) {
+          logger?.warn(
+            { pieceId: piece.id.toString(), pieceCid: piece.cid.toString(), error },
+            'Failed to calculate piece size from CID'
+          )
+        }
 
-      pieces.push(pieceInfo)
+        pieces.push(pieceInfo)
+      }
+      hasMore = result.hasMore
+      offset += ACTIVE_PIECES_BATCH_SIZE
     }
 
     // Leftover entries in providerPiecesById are pieces the provider reports

--- a/src/core/data-set/get-detailed-data-set.ts
+++ b/src/core/data-set/get-detailed-data-set.ts
@@ -18,7 +18,6 @@ export async function getDetailedDataSet(
   options?: ListDataSetsOptions
 ): Promise<DataSetSummary> {
   const logger = options?.logger
-  const withProviderDetails = options?.withProviderDetails ?? true
 
   try {
     const pdpDataSet = await getPdpDataSet(synapse.client, { dataSetId })
@@ -43,7 +42,7 @@ export async function getDetailedDataSet(
       isLive: pdpDataSet.live,
       isManaged: pdpDataSet.managed,
       withCDN: pdpDataSet.cdn,
-      provider: withProviderDetails ? pdpDataSet.provider : undefined,
+      provider: pdpDataSet.provider,
       pieces: piecesResult.pieces,
       createdWithFilecoinPin,
     }

--- a/src/core/data-set/get-detailed-data-set.ts
+++ b/src/core/data-set/get-detailed-data-set.ts
@@ -21,16 +21,13 @@ export async function getDetailedDataSet(
   const withProviderDetails = options?.withProviderDetails ?? true
 
   try {
-    const [storageContext, pdpDataSet] = await Promise.all([
-      synapse.storage.createContext({ dataSetId }),
-      getPdpDataSet(synapse.client, { dataSetId }),
-    ])
+    const pdpDataSet = await getPdpDataSet(synapse.client, { dataSetId })
 
     if (pdpDataSet == null) {
       throw new Error(`Data set ${dataSetId} not found`)
     }
 
-    const piecesResult = await getDataSetPieces(synapse, storageContext, {
+    const piecesResult = await getDataSetPieces(synapse, dataSetId, pdpDataSet.provider.pdp?.serviceURL ?? '', {
       includeMetadata: true,
       logger,
     })

--- a/src/core/data-set/list-data-sets.ts
+++ b/src/core/data-set/list-data-sets.ts
@@ -1,18 +1,18 @@
 /**
  * List Data Sets
  *
- * Functions for listing and summarizing datasets with optional provider enrichment.
+ * Functions for listing and summarizing datasets.
  *
  * @module core/data-set/list-data-sets
  */
 
-import type { PDPProvider, Synapse } from '@filoz/synapse-sdk'
+import type { Synapse } from '@filoz/synapse-sdk'
 import { DEFAULT_DATA_SET_METADATA } from '../synapse/constants.js'
 import { getClientAddress } from '../synapse/index.js'
 import type { DataSetSummary, ListDataSetsOptions } from './types.js'
 
 /**
- * List all datasets for an address with optional provider enrichment
+ * List all datasets for an address
  *
  * Example usage:
  * ```typescript
@@ -21,9 +21,6 @@ import type { DataSetSummary, ListDataSetsOptions } from './types.js'
  *
  * for (const ds of datasets) {
  *   console.log(`Dataset ${ds.dataSetId}: ${ds.currentPieceCount} pieces`)
- *   if (ds.provider) {
- *     console.log(`  Provider: ${ds.provider.name}`)
- *   }
  * }
  * ```
  *
@@ -32,25 +29,12 @@ import type { DataSetSummary, ListDataSetsOptions } from './types.js'
  * @returns Array of dataset summaries
  */
 export async function listDataSets(synapse: Synapse, options?: ListDataSetsOptions): Promise<DataSetSummary[]> {
-  const logger = options?.logger
   const address = options?.address ?? getClientAddress(synapse)
   const filter = options?.filter
 
   const dataSets = await synapse.storage.findDataSets({ address })
 
   const filteredDataSets = filter ? dataSets.filter(filter) : dataSets
-
-  // Fetch provider info for unique provider IDs
-  let providerMap: Map<bigint, PDPProvider> = new Map()
-  const uniqueProviderIds = new Set(filteredDataSets.map((ds) => ds.providerId))
-  if (uniqueProviderIds.size > 0) {
-    try {
-      const providers = await synapse.providers.getProviders({ providerIds: Array.from(uniqueProviderIds) })
-      providerMap = new Map(providers.map((provider) => [provider.id, provider]))
-    } catch (error) {
-      logger?.warn({ error }, 'Failed to fetch provider info for provider enrichment')
-    }
-  }
 
   return filteredDataSets.map((ds) => {
     const createdWithFilecoinPin = Object.entries(DEFAULT_DATA_SET_METADATA).every(
@@ -60,7 +44,7 @@ export async function listDataSets(synapse: Synapse, options?: ListDataSetsOptio
     const summary: DataSetSummary = {
       ...ds,
       dataSetId: ds.pdpVerifierDataSetId,
-      provider: providerMap.get(ds.providerId),
+      provider: undefined,
       createdWithFilecoinPin,
     }
     return summary

--- a/src/core/data-set/list-data-sets.ts
+++ b/src/core/data-set/list-data-sets.ts
@@ -34,7 +34,6 @@ import type { DataSetSummary, ListDataSetsOptions } from './types.js'
 export async function listDataSets(synapse: Synapse, options?: ListDataSetsOptions): Promise<DataSetSummary[]> {
   const logger = options?.logger
   const address = options?.address ?? getClientAddress(synapse)
-  const withProviderDetails = options?.withProviderDetails ?? false
   const filter = options?.filter
 
   const dataSets = await synapse.storage.findDataSets({ address })
@@ -43,15 +42,13 @@ export async function listDataSets(synapse: Synapse, options?: ListDataSetsOptio
 
   // Fetch provider info for unique provider IDs
   let providerMap: Map<bigint, PDPProvider> = new Map()
-  if (withProviderDetails) {
-    const uniqueProviderIds = new Set(filteredDataSets.map((ds) => ds.providerId))
-    if (uniqueProviderIds.size > 0) {
-      try {
-        const providers = await synapse.providers.getProviders({ providerIds: Array.from(uniqueProviderIds) })
-        providerMap = new Map(providers.map((provider) => [provider.id, provider]))
-      } catch (error) {
-        logger?.warn({ error }, 'Failed to fetch provider info for provider enrichment')
-      }
+  const uniqueProviderIds = new Set(filteredDataSets.map((ds) => ds.providerId))
+  if (uniqueProviderIds.size > 0) {
+    try {
+      const providers = await synapse.providers.getProviders({ providerIds: Array.from(uniqueProviderIds) })
+      providerMap = new Map(providers.map((provider) => [provider.id, provider]))
+    } catch (error) {
+      logger?.warn({ error }, 'Failed to fetch provider info for provider enrichment')
     }
   }
 

--- a/src/core/data-set/resolve-by-metadata.ts
+++ b/src/core/data-set/resolve-by-metadata.ts
@@ -32,7 +32,6 @@ export async function resolveDataSetIdsByMetadata(
   }
 
   const matched = await listDataSets(synapse, {
-    withProviderDetails: false,
     filter: (dataSet) => {
       if (!dataSet.isLive) {
         return false

--- a/src/core/data-set/types.ts
+++ b/src/core/data-set/types.ts
@@ -97,12 +97,6 @@ export interface ListDataSetsOptions {
   address?: Hex
   /** Logger instance for debugging (optional) */
   logger?: Logger | undefined
-  /**
-   * Whether to get the provider details from the SP registry
-   *
-   * @default false
-   */
-  withProviderDetails?: boolean
 
   /**
    * Filter function to apply to the data sets before additional processing

--- a/src/core/piece/remove-all-pieces.ts
+++ b/src/core/piece/remove-all-pieces.ts
@@ -111,7 +111,12 @@ export async function removeAllPieces(
     // Fetch all pieces from the dataset
     onProgress?.({ type: 'removeAll:fetching', data: { dataSetId } })
 
-    const { pieces: allPieces } = await getDataSetPieces(synapse, storageContext, { logger })
+    const { pieces: allPieces } = await getDataSetPieces(
+      synapse,
+      dataSetId,
+      storageContext.provider.pdp?.serviceURL ?? '',
+      { logger }
+    )
 
     // Filter out pieces that are already pending removal - no need to delete them again
     pieces = allPieces.filter((p) => p.status === PieceStatus.ACTIVE)

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -100,7 +100,6 @@ export async function runDataSetListCommand(options: DataSetListCommandOptions):
     spinner.message('Fetching data sets...')
 
     const allDataSets = await listDataSets(synapse, {
-      withProviderDetails: false,
       filter,
     })
     const explicitFilter = filter != null

--- a/src/payments/status.ts
+++ b/src/payments/status.ts
@@ -187,7 +187,6 @@ export async function showPaymentStatus(options: StatusOptions): Promise<void> {
       spinner.start('Fetching data sets...')
       // Get all active data sets for this address
       const dataSets = await listDataSets(synapse, {
-        withProviderDetails: false,
         address,
         filter: (ds) => ds.isLive, // Only count active/live data sets
         logger,

--- a/src/rm/remove-all-pieces.ts
+++ b/src/rm/remove-all-pieces.ts
@@ -72,7 +72,7 @@ export async function runRmAllPieces(options: RmAllPiecesOptions): Promise<RmAll
 
     // Get piece count for confirmation
     const { pieces: allPieces } = await import('../core/data-set/get-data-set-pieces.js').then((m) =>
-      m.getDataSetPieces(synapse, storage, { logger })
+      m.getDataSetPieces(synapse, BigInt(dataSetId), storage.provider.pdp?.serviceURL ?? '', { logger })
     )
     const { PieceStatus } = await import('../core/data-set/types.js')
     const activePieces = allPieces.filter((p) => p.status === PieceStatus.ACTIVE)

--- a/src/test/unit/calculate-actual-storage.test.ts
+++ b/src/test/unit/calculate-actual-storage.test.ts
@@ -13,6 +13,7 @@ const {
   mockSynapse,
   mockCreateStorageContext,
   mockGetDataSetPieces,
+  mockGetProviders,
   defaultCreateStorageContext,
   defaultGetDataSetPieces,
   state,
@@ -21,7 +22,7 @@ const {
     pieces: [] as Array<{ pieceId: number; pieceCid: string; size?: number }>,
   }
 
-  const defaultGetDataSetPieces = async (_synapse: any, _context: any, _options?: any) => {
+  const defaultGetDataSetPieces = async (_synapse: any, dataSetId: bigint, _serviceURL: string, _options?: any) => {
     if (_options?.signal?.aborted) {
       const error = new Error('This operation was aborted')
       error.name = 'AbortError'
@@ -38,7 +39,7 @@ const {
 
     return {
       pieces,
-      dataSetId: _context?.dataSetId ?? 1,
+      dataSetId,
       totalSizeBytes,
       warnings: [],
     }
@@ -53,6 +54,14 @@ const {
 
   const mockCreateStorageContext = vi.fn(defaultCreateStorageContext)
 
+  const mockGetProviders = vi.fn(async ({ providerIds }: { providerIds: bigint[] }) =>
+    providerIds.map((id) => ({
+      id,
+      name: `Provider ${id}`,
+      pdp: { serviceURL: `https://provider-${id}.example.com` },
+    }))
+  )
+
   const mockSynapse = {
     client: {
       account: {
@@ -62,12 +71,16 @@ const {
     storage: {
       createContext: mockCreateStorageContext,
     },
+    providers: {
+      getProviders: mockGetProviders,
+    },
   }
 
   return {
     mockSynapse,
     mockCreateStorageContext,
     mockGetDataSetPieces,
+    mockGetProviders,
     defaultCreateStorageContext,
     defaultGetDataSetPieces,
     state,
@@ -85,6 +98,13 @@ describe('calculateActualStorage', () => {
 
     mockCreateStorageContext.mockImplementation(defaultCreateStorageContext)
     mockGetDataSetPieces.mockImplementation(defaultGetDataSetPieces)
+    mockGetProviders.mockImplementation(async ({ providerIds }) =>
+      providerIds.map((id) => ({
+        id,
+        name: `Provider ${id}`,
+        pdp: { serviceURL: `https://provider-${id}.example.com` },
+      }))
+    )
   })
 
   describe('basic calculation', () => {
@@ -197,12 +217,12 @@ describe('calculateActualStorage', () => {
 
       // Allow first dataset to complete
       let callCount = 0
-      mockGetDataSetPieces.mockImplementation(async (_synapse: any, _context: any, _options?: any) => {
+      mockGetDataSetPieces.mockImplementation(async (_synapse: any, dataSetId: bigint) => {
         callCount++
         if (callCount === 1) {
           return {
             pieces: [{ pieceId: 1, pieceCid: 'bafy1', size: 1024 }],
-            dataSetId: 1,
+            dataSetId,
             totalSizeBytes: 1024n,
             warnings: [],
           }
@@ -226,6 +246,51 @@ describe('calculateActualStorage', () => {
     })
   })
 
+  describe('provider enrichment', () => {
+    it('fetches missing providers in a single multicall', async () => {
+      const dataSets: DataSetSummary[] = [
+        { dataSetId: 1n, providerId: 1n, isLive: true } as unknown as DataSetSummary,
+        { dataSetId: 2n, providerId: 1n, isLive: true } as unknown as DataSetSummary,
+        { dataSetId: 3n, providerId: 2n, isLive: true } as unknown as DataSetSummary,
+      ]
+
+      await calculateActualStorage(mockSynapse as any, dataSets)
+
+      expect(mockGetProviders).toHaveBeenCalledTimes(1)
+      expect(mockGetProviders).toHaveBeenCalledWith({ providerIds: [1n, 2n] })
+      // Each dataset should have received the matching serviceURL
+      const serviceURLs = mockGetDataSetPieces.mock.calls.map((call) => call[2])
+      expect(serviceURLs).toContain('https://provider-1.example.com')
+      expect(serviceURLs).toContain('https://provider-2.example.com')
+    })
+
+    it('skips fetching when every dataset already carries provider info', async () => {
+      const dataSets: DataSetSummary[] = [
+        {
+          dataSetId: 1n,
+          providerId: 1n,
+          isLive: true,
+          provider: { id: 1n, name: 'Pre-filled', pdp: { serviceURL: 'https://pre-filled.example.com' } },
+        } as unknown as DataSetSummary,
+      ]
+
+      await calculateActualStorage(mockSynapse as any, dataSets)
+
+      expect(mockGetProviders).not.toHaveBeenCalled()
+      expect(mockGetDataSetPieces.mock.calls[0]?.[2]).toBe('https://pre-filled.example.com')
+    })
+
+    it('continues with empty serviceURL when provider enrichment fails', async () => {
+      mockGetProviders.mockRejectedValueOnce(new Error('Network error'))
+      const dataSets: DataSetSummary[] = [{ dataSetId: 1n, providerId: 1n, isLive: true } as unknown as DataSetSummary]
+
+      const result = await calculateActualStorage(mockSynapse as any, dataSets)
+
+      expect(result.dataSetsProcessed).toBe(1)
+      expect(mockGetDataSetPieces.mock.calls[0]?.[2]).toBe('')
+    })
+  })
+
   describe('error handling', () => {
     it('should continue processing other datasets when one fails', async () => {
       const dataSets: DataSetSummary[] = [
@@ -244,7 +309,7 @@ describe('calculateActualStorage', () => {
       ]
 
       let callCount = 0
-      mockGetDataSetPieces.mockImplementation(async (_synapse: any, _context: any, _options?: any) => {
+      mockGetDataSetPieces.mockImplementation(async (_synapse: any, dataSetId: bigint) => {
         callCount++
         if (callCount === 1) {
           throw new Error('Dataset query failed')
@@ -252,7 +317,7 @@ describe('calculateActualStorage', () => {
 
         return {
           pieces: [{ pieceId: 1, pieceCid: 'bafy1', size: 1024 }],
-          dataSetId: 2,
+          dataSetId,
           totalSizeBytes: 1024n,
           warnings: [],
         }

--- a/src/test/unit/core-data-set.test.ts
+++ b/src/test/unit/core-data-set.test.ts
@@ -8,13 +8,16 @@ import { METADATA_KEYS } from '@filoz/synapse-sdk'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDataSetPieces, listDataSets } from '../../core/data-set/index.js'
 
+const TEST_DATA_SET_ID = 123n
+const TEST_SERVICE_URL = 'https://provider.example.com'
+
 const {
   mockSynapse,
-  mockStorageContext,
   mockGetAllPieceMetadata,
   mockFindDataSets,
   mockGetProviders,
-  mockGetPieces,
+  mockGetActivePieces,
+  mockGetScheduledRemovals,
   mockGetProviderDataSet,
   state,
 } = vi.hoisted(() => {
@@ -38,11 +41,10 @@ const {
   const mockGetProviders = vi.fn(async ({ providerIds }: { providerIds: any[] }) => {
     return state.providers.filter((p) => providerIds.includes(p.id))
   })
-  const mockGetPieces = vi.fn(async function* () {
-    for (const piece of state.pieces) {
-      yield piece
-    }
-  })
+  const mockGetActivePieces = vi.fn(async () => ({
+    pieces: state.pieces.map((p) => ({ id: p.pieceId, cid: p.pieceCid })),
+    hasMore: false,
+  }))
   const mockGetScheduledRemovals = vi.fn(async () => [] as readonly bigint[])
   const mockGetProviderDataSet = vi.fn(async () => {
     if (state.providerPieces === null) throw new Error('Provider unavailable')
@@ -58,16 +60,6 @@ const {
     return state.pieceMetadata[Number(pieceId)] ?? {}
   })
 
-  const mockStorageContext = {
-    dataSetId: 123n,
-    getPieces: mockGetPieces,
-    getScheduledRemovals: mockGetScheduledRemovals,
-    provider: {
-      serviceProvider: '0xservice-provider',
-      pdp: { serviceURL: 'https://provider.example.com' },
-    },
-  }
-
   const mockSynapse = {
     client: { account: { address: '0xtest-address' as const } },
     chain: { id: 314159, name: 'calibration' },
@@ -77,11 +69,10 @@ const {
 
   return {
     mockSynapse,
-    mockStorageContext,
     mockGetAllPieceMetadata,
     mockFindDataSets,
     mockGetProviders,
-    mockGetPieces,
+    mockGetActivePieces,
     mockGetScheduledRemovals,
     mockGetProviderDataSet,
     state,
@@ -97,6 +88,11 @@ vi.mock('@filoz/synapse-sdk', async () => {
 
 vi.mock('@filoz/synapse-core/warm-storage', () => ({
   getAllPieceMetadata: mockGetAllPieceMetadata,
+}))
+
+vi.mock('@filoz/synapse-core/pdp-verifier', () => ({
+  getActivePieces: mockGetActivePieces,
+  getScheduledRemovals: mockGetScheduledRemovals,
 }))
 
 vi.mock('@filoz/synapse-core/sp', () => ({
@@ -325,7 +321,7 @@ describe('getDataSetPieces', () => {
   })
 
   it('returns empty array when dataset has no pieces', async () => {
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any)
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)
 
     expect(result.pieces).toEqual([])
     expect(result.dataSetId).toBe(123n)
@@ -338,7 +334,7 @@ describe('getDataSetPieces', () => {
       { pieceId: 1n, pieceCid: { toString: () => 'bafkpiece1' } },
     ]
 
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any, {
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL, {
       includeMetadata: false,
     })
 
@@ -370,7 +366,7 @@ describe('getDataSetPieces', () => {
       },
     }
 
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any, {
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL, {
       includeMetadata: true,
     })
 
@@ -406,7 +402,7 @@ describe('getDataSetPieces', () => {
       return metadata
     })
 
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any, {
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL, {
       includeMetadata: true,
     })
 
@@ -426,12 +422,9 @@ describe('getDataSetPieces', () => {
   })
 
   it('throws error when getPieces fails completely', async () => {
-    // biome-ignore lint/correctness/useYield: Generator intentionally throws before yielding to test error handling
-    mockGetPieces.mockImplementationOnce(async function* () {
-      throw new Error('Network error')
-    })
+    mockGetActivePieces.mockRejectedValueOnce(new Error('Network error'))
 
-    await expect(getDataSetPieces(mockSynapse as any, mockStorageContext as any)).rejects.toThrow(
+    await expect(getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)).rejects.toThrow(
       'Failed to retrieve pieces for dataset 123'
     )
   })
@@ -445,7 +438,7 @@ describe('getDataSetPieces', () => {
       },
     }
 
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any, {
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL, {
       includeMetadata: true,
     })
 
@@ -462,7 +455,7 @@ describe('getDataSetPieces', () => {
       { pieceId: 1n, pieceCid: { toString: () => 'bafkpiece1' } },
     ]
 
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any)
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)
 
     expect(result.pieces).toHaveLength(2)
     expect(result.pieces[0]?.size).toBe(1048576) // 1 MiB
@@ -476,7 +469,7 @@ describe('getDataSetPieces', () => {
       { pieceId: 2n, pieceCid: { toString: () => 'bafkpiece2' } }, // 4 MiB
     ]
 
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any)
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)
 
     expect(result.pieces).toHaveLength(3)
     expect(result.totalSizeBytes).toBe(BigInt(1048576 + 2097152 + 4194304)) // 7 MiB total
@@ -485,7 +478,7 @@ describe('getDataSetPieces', () => {
   it('returns undefined totalSizeBytes when no pieces have sizes', async () => {
     state.pieces = []
 
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any)
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)
 
     expect(result.pieces).toHaveLength(0)
     expect(result.totalSizeBytes).toBeUndefined()
@@ -498,7 +491,7 @@ describe('getDataSetPieces', () => {
       { pieceId: 2n, pieceCid: { toString: () => 'bafkpiece2' } }, // Valid
     ]
 
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any)
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)
 
     expect(result.pieces).toHaveLength(3)
     expect(result.pieces[0]?.size).toBe(1048576)
@@ -520,7 +513,7 @@ describe('getDataSetPieces', () => {
       { pieceId: 1n, pieceCid: cid1, subPieceCid: cid1, subPieceOffset: 0 },
     ]
 
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any)
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)
 
     expect(result.pieces).toHaveLength(2)
     expect(result.pieces[0]?.status).toBe('ACTIVE')
@@ -538,7 +531,7 @@ describe('getDataSetPieces', () => {
     // Provider only knows about piece 0
     state.providerPieces = [{ pieceId: 0n, pieceCid: cid0, subPieceCid: cid0, subPieceOffset: 0 }]
 
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any)
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)
 
     expect(result.pieces).toHaveLength(2)
     expect(result.pieces[0]?.status).toBe('ACTIVE')
@@ -557,7 +550,7 @@ describe('getDataSetPieces', () => {
       { pieceId: 1n, pieceCid: cid1, subPieceCid: cid1, subPieceOffset: 0 },
     ]
 
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any)
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)
 
     expect(result.pieces).toHaveLength(2)
     expect(result.pieces[0]?.status).toBe('ACTIVE')
@@ -571,7 +564,7 @@ describe('getDataSetPieces', () => {
     state.pieces = [{ pieceId: 0n, pieceCid: { toString: () => 'bafkpiece0' } }]
     state.providerPieces = null // triggers the mock to throw
 
-    const result = await getDataSetPieces(mockSynapse as any, mockStorageContext as any)
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)
 
     expect(result.pieces).toHaveLength(1)
     expect(result.pieces[0]?.status).toBe('ACTIVE')

--- a/src/test/unit/core-data-set.test.ts
+++ b/src/test/unit/core-data-set.test.ts
@@ -127,126 +127,11 @@ describe('listDataSets', () => {
     expect(mockGetProviders).not.toHaveBeenCalled()
   })
 
-  it('lists datasets without provider enrichment when sp-registry fails', async () => {
-    const expectedDataSet = {
-      pdpVerifierDataSetId: 1,
-      clientDataSetId: 100n,
-      providerId: 2,
-      metadata: { source: 'filecoin-pin' },
-      currentPieceCount: 5,
-      isManaged: true,
-      withCDN: false,
-      isLive: true,
-      serviceProvider: '0xservice',
-      payer: '0xpayer',
-      payee: '0xpayee',
-    }
-    state.datasets = [expectedDataSet]
-    mockGetProviders.mockRejectedValueOnce(new Error('Network error'))
-
-    const result = await listDataSets(mockSynapse as any)
-
-    expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({
-      ...expectedDataSet,
-      createdWithFilecoinPin: false,
-    })
-    expect(result[0]?.provider).toBeUndefined()
-    expect(mockGetProviders).toHaveBeenCalledWith({ providerIds: [2] })
-  })
-
-  it('enriches datasets with provider information when available', async () => {
-    const provider = {
-      id: 2,
-      name: 'Test Provider',
-      serviceProvider: '0xservice',
-      description: 'Test provider',
-      payee: '0xpayee',
-      active: true,
-      products: {},
-    }
-
-    state.datasets = [
-      {
-        pdpVerifierDataSetId: 1,
-        clientDataSetId: 100n,
-        providerId: 2,
-        metadata: {},
-        currentPieceCount: 3,
-        isManaged: true,
-        withCDN: false,
-        isLive: true,
-        serviceProvider: '0xservice',
-        payer: '0xpayer',
-        payee: '0xpayee',
-      },
-    ]
-    state.providers = [provider]
-
-    const result = await listDataSets(mockSynapse as any)
-
-    expect(result).toHaveLength(1)
-    expect(result[0]?.provider).toEqual(provider)
-    expect(result[0]?.createdWithFilecoinPin).toBe(false)
-    expect(mockGetProviders).toHaveBeenCalledWith({ providerIds: [2] })
-  })
-
   it('uses custom address when provided in options', async () => {
     await listDataSets(mockSynapse as any, { address: '0xcustom' })
 
     expect(mockFindDataSets).toHaveBeenCalledWith({ address: '0xcustom' })
     expect(mockGetProviders).not.toHaveBeenCalled()
-  })
-
-  it('handles multiple datasets with mixed provider availability', async () => {
-    const provider1 = {
-      id: 1,
-      name: 'Provider 1',
-      serviceProvider: '0xprovider1',
-      description: 'First provider',
-      payee: '0xpayee1',
-      active: true,
-      products: {},
-    }
-
-    state.datasets = [
-      {
-        pdpVerifierDataSetId: 1,
-        clientDataSetId: 100n,
-        providerId: 1,
-        metadata: {},
-        currentPieceCount: 2,
-        isManaged: true,
-        withCDN: false,
-        isLive: true,
-        serviceProvider: '0xservice1',
-        payer: '0xpayer',
-        payee: '0xpayee',
-      },
-      {
-        pdpVerifierDataSetId: 2,
-        clientDataSetId: 101n,
-        providerId: 999, // Provider not in registry
-        metadata: {},
-        currentPieceCount: 1,
-        isManaged: false,
-        withCDN: true,
-        isLive: true,
-        serviceProvider: '0xservice2',
-        payer: '0xpayer',
-        payee: '0xpayee',
-      },
-    ]
-    state.providers = [provider1]
-
-    const result = await listDataSets(mockSynapse as any)
-
-    expect(result).toHaveLength(2)
-    expect(result[0]?.provider).toEqual(provider1)
-    expect(result[0]?.createdWithFilecoinPin).toBe(false)
-    expect(result[1]?.provider).toBeUndefined()
-    expect(result[1]?.createdWithFilecoinPin).toBe(false)
-    expect(mockGetProviders).toHaveBeenCalledWith({ providerIds: [1, 999] })
   })
 
   it('sets createdWithFilecoinPin to true when both WITH_IPFS_INDEXING and source=filecoin-pin metadata are present', async () => {
@@ -301,7 +186,6 @@ describe('listDataSets', () => {
         payee: '0xpayee',
       },
     ]
-    state.providers = []
 
     const result = await listDataSets(mockSynapse as any)
 

--- a/src/test/unit/core-data-set.test.ts
+++ b/src/test/unit/core-data-set.test.ts
@@ -589,4 +589,20 @@ describe('getDataSetPieces', () => {
     expect((mockGetActivePieces.mock.calls[0] as any)?.[1].limit).toBe(100n)
     expect(result.pieces.map((p) => p.pieceId)).toEqual([0n, 1n, 2n])
   })
+
+  it('stops paginating when the abort signal fires', async () => {
+    const controller = new AbortController()
+    let calls = 0
+    mockGetActivePieces.mockImplementation((async () => {
+      calls++
+      if (calls === 2) controller.abort()
+      return { pieces: [], hasMore: true }
+    }) as any)
+
+    await expect(
+      getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL, { signal: controller.signal })
+    ).rejects.toThrow()
+    // The loop checks the signal before each page, so it stops after the aborting call
+    expect(calls).toBe(2)
+  })
 })

--- a/src/test/unit/core-data-set.test.ts
+++ b/src/test/unit/core-data-set.test.ts
@@ -144,7 +144,7 @@ describe('listDataSets', () => {
     state.datasets = [expectedDataSet]
     mockGetProviders.mockRejectedValueOnce(new Error('Network error'))
 
-    const result = await listDataSets(mockSynapse as any, { withProviderDetails: true })
+    const result = await listDataSets(mockSynapse as any)
 
     expect(result).toHaveLength(1)
     expect(result[0]).toMatchObject({
@@ -183,7 +183,7 @@ describe('listDataSets', () => {
     ]
     state.providers = [provider]
 
-    const result = await listDataSets(mockSynapse as any, { withProviderDetails: true })
+    const result = await listDataSets(mockSynapse as any)
 
     expect(result).toHaveLength(1)
     expect(result[0]?.provider).toEqual(provider)
@@ -239,7 +239,7 @@ describe('listDataSets', () => {
     ]
     state.providers = [provider1]
 
-    const result = await listDataSets(mockSynapse as any, { withProviderDetails: true })
+    const result = await listDataSets(mockSynapse as any)
 
     expect(result).toHaveLength(2)
     expect(result[0]?.provider).toEqual(provider1)

--- a/src/test/unit/core-data-set.test.ts
+++ b/src/test/unit/core-data-set.test.ts
@@ -570,4 +570,23 @@ describe('getDataSetPieces', () => {
     expect(result.pieces[0]?.status).toBe('ACTIVE')
     expect(result.warnings).toContainEqual(expect.objectContaining({ code: 'PROVIDER_PIECES_UNAVAILABLE' }))
   })
+
+  it('paginates getActivePieces across multiple pages', async () => {
+    const pages: Record<string, Array<{ id: bigint; cid: { toString: () => string } }>> = {
+      '0': [{ id: 0n, cid: { toString: () => 'bafkpiece0' } }],
+      '100': [{ id: 1n, cid: { toString: () => 'bafkpiece1' } }],
+      '200': [{ id: 2n, cid: { toString: () => 'bafkpiece2' } }],
+    }
+    mockGetActivePieces.mockImplementation((async (_client: any, { offset }: any) => ({
+      pieces: pages[String(offset)] ?? [],
+      hasMore: offset < 200n,
+    })) as any)
+
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)
+
+    expect(mockGetActivePieces).toHaveBeenCalledTimes(3)
+    expect(mockGetActivePieces.mock.calls.map((c: any) => c[1].offset)).toEqual([0n, 100n, 200n])
+    expect((mockGetActivePieces.mock.calls[0] as any)?.[1].limit).toBe(100n)
+    expect(result.pieces.map((p) => p.pieceId)).toEqual([0n, 1n, 2n])
+  })
 })

--- a/src/test/unit/data-set.test.ts
+++ b/src/test/unit/data-set.test.ts
@@ -152,6 +152,14 @@ vi.mock('@filoz/synapse-core/warm-storage', () => ({
   getPdpDataSet: mockGetPdpDataSet,
 }))
 
+vi.mock('@filoz/synapse-core/pdp-verifier', () => ({
+  getActivePieces: vi.fn(async () => ({
+    pieces: state.pieceList.map((p) => ({ id: p.pieceId, cid: { toString: () => p.pieceCid } })),
+    hasMore: false,
+  })),
+  getScheduledRemovals: vi.fn(async () => [] as readonly bigint[]),
+}))
+
 vi.mock('@filoz/synapse-core/sp', () => ({
   getDataSet: vi.fn(async () => ({
     id: 158n,

--- a/src/test/unit/remove-all-pieces.test.ts
+++ b/src/test/unit/remove-all-pieces.test.ts
@@ -15,6 +15,7 @@ const { mockGetDataSetPieces, mockRemovePiece, mockStorageContext, state } = vi.
 
   const mockStorageContext = {
     dataSetId: state.dataSetId,
+    provider: { pdp: { serviceURL: 'https://provider.example.com' } },
   }
 
   const mockGetDataSetPieces = vi.fn(async () => ({


### PR DESCRIPTION
  ## Summary

  `getDataSetPieces` previously required a fully-built `StorageContext`, which forced every read-only callsite to first run `synapse.storage.createContext(...)` (~4 RPC) even though only `dataSetId` and
  `serviceURL` were ever read off it.

  This PR changes the signature to `(synapse, dataSetId, serviceURL, options)` and switches the internals to synapse-core's `getActivePieces` / `getScheduledRemovals` directly, eliminating the StorageContext
  requirement for read-only piece queries.

  Closes #485.

  **Callsites (4)**

  - `core/data-set/get-detailed-data-set.ts`: drops `createContext` entirely; reads `serviceURL` from the `getPdpDataSet` response that's already being fetched.
  - `core/data-set/calculate-actual-storage.ts`: drops the per-dataset `createContext` loop. To get `serviceURL` without forcing callers to enable `withProviderDetails`, the function now does **on-demand
  provider enrichment** — it trusts whatever `dataSet.provider` entries the caller already supplied and fetches only the missing `providerId`s in a single `synapse.providers.getProviders` multicall.
  - `core/piece/remove-all-pieces.ts`: keeps its existing `StorageContext` (still needed for the piece-removal transactions); just extracts `dataSetId` + `serviceURL` when calling `getDataSetPieces`.
  - `rm/remove-all-pieces.ts`: same as above, at the CLI entry point.