### PR TITLE
feat(upload-action): default network to mainnet

### DIFF
--- a/upload-action/FLOW.md
+++ b/upload-action/FLOW.md
@@ -32,7 +32,7 @@ This document explains how the action works internally and why each step exists.
 `parseInputs()` uses a single schema for both phases:
 - `path`: required for both phases.
 - `walletPrivateKey`: required when `phase !== 'compute'`.
-- `network`: required; must be `mainnet` or `calibration`.
+- `network`: optional; must be `mainnet` or `calibration`. Defaults to `mainnet`.
 - `minStorageDays`: optional number (defaults to `0` when unset).
 - `filecoinPayBalanceLimit`: bigint parsed from USDFC string; required when `minStorageDays > 0`.
 - `withCDN`, `dryRun`: optional advanced settings with defaults (providerAddress should rarely be used).

--- a/upload-action/README.md
+++ b/upload-action/README.md
@@ -31,7 +31,6 @@ If `path` points to a regular file whose name ends in `.car`, the action skips i
   with:
     path: build.car
     walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
-    network: calibration
 ```
 
 The CAR must declare exactly one root; multi-root and rootless CARs are rejected so the upload always has an unambiguous IPFS root CID. Directories (even named `foo.car/`) fall through to the UnixFS packer.
@@ -50,7 +49,6 @@ For most users, automatic provider selection is recommended. However, for advanc
   with:
     path: dist
     walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
-    network: calibration
 ```
 
 **Priority order**:

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -18,8 +18,9 @@ inputs:
     description: Wallet private key used to fund uploads (USDFC on Calibration/Mainnet). Required unless dryRun is true.
     required: false
   network:
-    description: What Filecoin network to use. Should either be "mainnet" or "calibration".
-    required: true
+    description: What Filecoin network to use. Should either be "mainnet" or "calibration". Defaults to "mainnet".
+    required: false
+    default: mainnet
 
   # Financial controls
   minStorageDays:

--- a/upload-action/examples/two-workflow-pattern/upload-to-filecoin.yml
+++ b/upload-action/examples/two-workflow-pattern/upload-to-filecoin.yml
@@ -41,6 +41,6 @@ jobs:
         with:
           path: dist  # Path to the downloaded build artifacts
           walletPrivateKey: ${{ secrets.WALLET_PRIVATE_KEY }}
-          network: calibration
+          network: mainnet
           minStorageDays: "30"  # Hardcoded - The value committed in the main branch will be used, not the value in a modifying PR
           filecoinPayBalanceLimit: "0.25" # Hardcoded - The value committed in the main branch will be used, not the value in a modifying PR

--- a/upload-action/src/inputs.js
+++ b/upload-action/src/inputs.js
@@ -86,7 +86,7 @@ export function parseBoolean(v) {
 export function parseInputs(phase = 'single') {
   const walletPrivateKey = getInput('walletPrivateKey')
   const contentPath = getInput('path')
-  const networkRaw = getInput('network')
+  const networkRaw = getInput('network', 'mainnet')
   const minStorageDaysRaw = getInput('minStorageDays', '')
   const filecoinPayBalanceLimitRaw = getInput('filecoinPayBalanceLimit', '')
   const withCDN = parseBoolean(getInput('withCDN', 'false'))


### PR DESCRIPTION
Closes #443. 

* CLI/library already default to mainnet (#445);
* upload-action now matches: `network` input optional, defaults to mainnet.
* Update examples and FLOW.md/README accordingly.