### PR TITLE
ci: cap workflow job runtime and skip unused Playwright download

### DIFF
--- a/.github/workflows/test-upload-action.yml
+++ b/.github/workflows/test-upload-action.yml
@@ -12,6 +12,9 @@ concurrency:
 jobs:
   dry-run:
     runs-on: ubuntu-latest
+    # Successful dry-run jobs finish in under a minute. Cap well above that so
+    # a stalled setup/install step fails fast instead of riding the default 6h limit.
+    timeout-minutes: 10
     # TODO: drop this gate once the action no longer exits early with
     # `fork-pr-blocked` when `dryRun: true`. Until then, running on forks
     # produces a misleading "skipped" check rather than real coverage.
@@ -39,6 +42,10 @@ jobs:
 
   upload:
     runs-on: ubuntu-latest
+    # Successful upload jobs finish in roughly 2-3 minutes, including the real
+    # Calibration on-chain work. Cap with headroom for a slow provider/chain so
+    # a stalled setup/install step fails fast instead of riding the default 6h limit.
+    timeout-minutes: 15
     if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
         node: [lts/*, current]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # Lint, typecheck, build, and unit/integration tests finish within a few
+    # minutes. Cap well above that so a stalled step fails fast instead of
+    # riding the default 6h limit.
+    timeout-minutes: 15
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -57,6 +61,10 @@ jobs:
 
   browser-test:
     runs-on: ubuntu-latest
+    # Browser tests finish in under a minute once the cached Chromium is in
+    # place. Cap with headroom for a cold browser download so a stalled step
+    # fails fast instead of riding the default 6h limit.
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -197,10 +197,10 @@ runs:
     - name: Install workspace dependencies
       shell: bash
       working-directory: ${{ steps.repo-root.outputs.path }}
-      # playwright-chromium is a root browser-test devDependency the action
-      # never uses, but pnpm runs its install script (see onlyBuiltDependencies
-      # in pnpm-workspace.yaml), which downloads a ~167MB browser. Skip that
-      # download so a stalled fetch can't hang the install for hours.
+      # playwright-chromium is a root browser-test devDependency this action
+      # never uses. Its install script (listed in onlyBuiltDependencies in
+      # pnpm-workspace.yaml) downloads a ~167MB browser; skipping that keeps
+      # the install lean. The Test workflow sets the same flag.
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
       run: pnpm install --frozen-lockfile

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -197,6 +197,12 @@ runs:
     - name: Install workspace dependencies
       shell: bash
       working-directory: ${{ steps.repo-root.outputs.path }}
+      # playwright-chromium is a root browser-test devDependency the action
+      # never uses, but pnpm runs its install script (see onlyBuiltDependencies
+      # in pnpm-workspace.yaml), which downloads a ~167MB browser. Skip that
+      # download so a stalled fetch can't hang the install for hours.
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
       run: pnpm install --frozen-lockfile
 
     - name: Build filecoin-pin package


### PR DESCRIPTION
## What changed

Add `timeout-minutes` to every CI job that lacked one, and stop the upload-action install from downloading a browser it never uses.

- `test-upload-action.yml`: `dry-run` 10 min, `upload` 15 min.
- `test.yml`: `test` 15 min, `browser-test` 10 min.
- `upload-action/action.yml`: set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` on the install step, matching the flag `test.yml` already sets.

On [run 26511503333](https://github.com/filecoin-project/filecoin-pin/actions/runs/26511503333) (PR #505), both upload-action jobs stalled for ~3h inside `pnpm install` while `playwright-chromium` fetched a ~167MB browser, holding the PR's checks open until cancelled. With no job timeout, the stall would have run to GitHub's default 6h cap.

The skip removes the unused download; the timeouts cap any future stall well above observed run times (dry-run ~40s, upload ~3m, test ~2m, browser-test ~40s).

## How to verify

This PR's own checks exercise the new caps. Install logs no longer show the `playwright-chromium` browser download.
