### PR TITLE
fix(ci): add manual npm publish dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Run npm publish with --dry-run (manual dispatch only)
+        type: boolean
+        default: false
 
 permissions:
   id-token: write  # Required for OIDC
@@ -17,6 +23,7 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
+        if: github.event_name == 'push'
         with:
           # PAT so release PRs trigger other workflows (auto-label, add-issues-and-prs-to-fs-project-board).
           # This PAT has the permissions outlined in https://github.com/googleapis/release-please-action?tab=readme-ov-file#workflow-permissions.
@@ -24,19 +31,56 @@ jobs:
           token: ${{ secrets.FILOZZY_RELEASE_PLEASE_PAT }}
           config-file: release-please-config.json
 
-      # The following steps only run if a release is created
+      # Publish steps run when release-please created a release on push,
+      # or when a maintainer manually dispatched the workflow from a release tag.
       - name: Checkout
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v6
 
+      - name: Validate dispatch ref and release state
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+
+          case "$REF" in
+            refs/tags/v[0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "::error::Dispatch ref must be a vX.Y.Z tag, got: $REF"
+              exit 1
+              ;;
+          esac
+          TAG="${REF#refs/tags/}"
+          VERSION="${TAG#v}"
+
+          PKG_NAME="$(node -p "require('./package.json').name")"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $TAG does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::GitHub release $TAG not found"
+            exit 1
+          fi
+
+          PUBLISHED="$(npm view "$PKG_NAME@$VERSION" version 2>/dev/null || true)"
+          if [ -n "$PUBLISHED" ]; then
+            echo "::error::npm already has $PKG_NAME@$PUBLISHED"
+            exit 1
+          fi
+
       - name: Set up pnpm
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
         uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         with:
           run_install: false
 
       - name: Setup Node.js
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
         uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
@@ -46,17 +90,19 @@ jobs:
 
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
         run: npm install -g npm@latest
 
       - name: Install dependencies
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
         run: pnpm run build
 
       - name: Publish to npm
-        if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --access public
+        if: ${{ steps.release.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
+        run: npm publish --access public ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && '--dry-run' || '' }}


### PR DESCRIPTION
## What changed

Adds a `workflow_dispatch` trigger to `release-please.yml` so a maintainer can re-run the npm publish path against an existing release tag when the automatic publish on push did not execute. Recovers cases like v0.22.0, where release-please created the GitHub release and tag (commit 7b6936e) but the `npm publish` step skipped and npm still serves 0.21.0.

The release-please action step is now gated to `push` events so a manual dispatch does not re-trigger release PR machinery. On dispatch, the workflow validates that `github.ref` is a `vX.Y.Z` tag, that the tag matches `package.json` version, that the corresponding GitHub release exists, and that npm does not already serve that version. A `dry_run` boolean input gates `npm publish --dry-run` for rehearsal.

Keeping the change inside `release-please.yml` reuses the existing npm trusted publisher binding, which is keyed on workflow filename.

## How to verify

1. Merge.
2. Actions → release-please → Run workflow → select tag `v0.22.0`, set `dry_run=true`. Confirm validation and dry run succeed.
3. Re-dispatch from the same tag with `dry_run=false`.
4. `npm view filecoin-pin version` reports `0.22.0` with SLSA provenance attestations.

## Notes

- `workflow_dispatch` requires repository write access; validation rejects branch refs, mismatched versions, missing GitHub releases, and already-published npm versions.
- No change to push-triggered behavior.
