### PR TITLE
fix: keep node-only devnet config out of browser bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "packageManager": "pnpm@10.32.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "browser": {
+    "./dist/common/devnet-config.js": "./dist/common/devnet-config.browser.js"
+  },
   "exports": {
     ".": {
       "browser": {

--- a/src/common/devnet-config.browser.ts
+++ b/src/common/devnet-config.browser.ts
@@ -1,0 +1,20 @@
+/**
+ * Browser stub for ./devnet-config.js.
+ *
+ * Devnet support reads devnet-info.json from disk via node:fs/os/path, which has
+ * no meaning in the browser. Bundlers resolve to this file via the "browser" field
+ * in package.json, keeping node built-ins out of browser bundles. The only browser
+ * path that reaches devnet config is a guarded probe in resolveChainFromRpc, which
+ * catches this throw and falls through to the unsupported-chain error.
+ */
+
+import type { Chain } from '@filoz/synapse-sdk'
+
+export interface DevnetConfig {
+  chain: Chain
+  privateKey: string | undefined
+}
+
+export function resolveDevnetConfig(): DevnetConfig {
+  throw new Error('Devnet configuration is not available in the browser.')
+}

--- a/src/common/devnet-config.ts
+++ b/src/common/devnet-config.ts
@@ -1,0 +1,71 @@
+/**
+ * Devnet configuration loading.
+ *
+ * This module statically imports node:fs/os/path to read devnet-info.json, so it
+ * is Node-only. Browser bundlers resolve it to ./devnet-config.browser.js via the
+ * "browser" field in package.json — keeping node built-ins out of browser bundles.
+ */
+
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { toChain, validateDevnetInfo } from '@filoz/synapse-core/devnet'
+import type { Chain } from '@filoz/synapse-sdk'
+
+function getDefaultDevnetInfoPath(): string {
+  const baseDir = process.env.FOC_DEVNET_BASEDIR?.trim() || join(homedir(), '.foc-devnet')
+  return join(baseDir, 'state', 'latest', 'devnet-info.json')
+}
+
+export interface DevnetConfig {
+  chain: Chain
+  privateKey: string | undefined
+}
+
+let cachedDevnetConfig: DevnetConfig | undefined
+
+/**
+ * Load and cache devnet configuration from devnet-info.json.
+ *
+ * Reads the devnet info file, validates it, and builds a Chain via synapse-core's
+ * toChain(). The result is cached for the lifetime of the process so that
+ * getRpcUrl() and parseCLIAuth() share the same chain object.
+ */
+export function resolveDevnetConfig(): DevnetConfig {
+  if (cachedDevnetConfig) {
+    return cachedDevnetConfig
+  }
+
+  const devnetInfoPath = process.env.DEVNET_INFO_PATH || getDefaultDevnetInfoPath()
+  const userIndex = Number(process.env.DEVNET_USER_INDEX || '0')
+
+  let rawData: unknown
+  try {
+    rawData = JSON.parse(readFileSync(devnetInfoPath, 'utf8'))
+  } catch (error) {
+    throw new Error(
+      `Failed to read devnet info from ${devnetInfoPath}: ${error instanceof Error ? error.message : String(error)}. ` +
+        'Set DEVNET_INFO_PATH to the correct path, or ensure foc-devnet is running.'
+    )
+  }
+
+  const devnetInfo = validateDevnetInfo(rawData)
+  const { info } = devnetInfo
+
+  if (userIndex >= info.users.length) {
+    throw new Error(
+      `DEVNET_USER_INDEX=${userIndex} out of range (${info.users.length} user(s) available in devnet-info.json)`
+    )
+  }
+
+  const user = info.users[userIndex]
+  if (user == null) {
+    throw new Error(`DEVNET_USER_INDEX=${userIndex} did not resolve to a user in devnet-info.json`)
+  }
+
+  cachedDevnetConfig = {
+    chain: toChain(devnetInfo),
+    privateKey: user.private_key_hex,
+  }
+  return cachedDevnetConfig
+}

--- a/src/common/get-rpc-url.ts
+++ b/src/common/get-rpc-url.ts
@@ -1,11 +1,7 @@
-import { readFileSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
-import { toChain, validateDevnetInfo } from '@filoz/synapse-core/devnet'
-import type { Chain } from '@filoz/synapse-sdk'
 import { calibration, mainnet } from '@filoz/synapse-sdk'
 import type { CLIAuthOptions } from '../utils/cli-auth.js'
 import { DEVNET_CHAIN_ID } from './constants.js'
+import { resolveDevnetConfig } from './devnet-config.js'
 
 const NETWORK_CHAINS = {
   mainnet,
@@ -23,63 +19,6 @@ export function normalizeNetworkName(input: string | undefined): string | undefi
   const trimmed = input?.toLowerCase().trim()
   if (!trimmed) return undefined
   return NETWORK_ALIASES[trimmed] ?? trimmed
-}
-function getDefaultDevnetInfoPath(): string {
-  const baseDir = process.env.FOC_DEVNET_BASEDIR?.trim() || join(homedir(), '.foc-devnet')
-  return join(baseDir, 'state', 'latest', 'devnet-info.json')
-}
-
-interface DevnetConfig {
-  chain: Chain
-  privateKey: string | undefined
-}
-
-let cachedDevnetConfig: DevnetConfig | undefined
-
-/**
- * Load and cache devnet configuration from devnet-info.json.
- *
- * Reads the devnet info file, validates it, and builds a Chain via synapse-core's
- * toChain(). The result is cached for the lifetime of the process so that
- * getRpcUrl() and parseCLIAuth() share the same chain object.
- */
-export function resolveDevnetConfig(): DevnetConfig {
-  if (cachedDevnetConfig) {
-    return cachedDevnetConfig
-  }
-
-  const devnetInfoPath = process.env.DEVNET_INFO_PATH || getDefaultDevnetInfoPath()
-  const userIndex = Number(process.env.DEVNET_USER_INDEX || '0')
-
-  let rawData: unknown
-  try {
-    rawData = JSON.parse(readFileSync(devnetInfoPath, 'utf8'))
-  } catch (error) {
-    throw new Error(
-      `Failed to read devnet info from ${devnetInfoPath}: ${error instanceof Error ? error.message : String(error)}. ` +
-        'Set DEVNET_INFO_PATH to the correct path, or ensure foc-devnet is running.'
-    )
-  }
-
-  const devnetInfo = validateDevnetInfo(rawData)
-  const { info } = devnetInfo
-
-  if (userIndex >= info.users.length) {
-    throw new Error(
-      `DEVNET_USER_INDEX=${userIndex} out of range (${info.users.length} user(s) available in devnet-info.json)`
-    )
-  }
-
-  const user = info.users[userIndex]
-  if (user == null) {
-    throw new Error(`DEVNET_USER_INDEX=${userIndex} did not resolve to a user in devnet-info.json`)
-  }
-
-  cachedDevnetConfig = {
-    chain: toChain(devnetInfo),
-    privateKey: user.private_key_hex,
-  }
-  return cachedDevnetConfig
 }
 
 /**
@@ -127,4 +66,4 @@ export function getRpcUrl(options: CLIAuthOptions): string {
   return defaultUrl
 }
 
-export { DEVNET_CHAIN_ID, NETWORK_CHAINS }
+export { DEVNET_CHAIN_ID, NETWORK_CHAINS, resolveDevnetConfig }

--- a/src/core/synapse/resolve-chain-from-rpc.ts
+++ b/src/core/synapse/resolve-chain-from-rpc.ts
@@ -24,9 +24,10 @@ export async function resolveChainFromRpc(transport: Transport, logger?: Logger)
   if (id === calibration.id) return calibration
 
   // Devnet support pulls in node:fs via resolveDevnetConfig, so import it lazily to keep this
-  // module browser-safe. Mainnet/calibration probes never reach this branch.
+  // module browser-safe. Browser bundlers resolve devnet-config to a stub (see the "browser"
+  // field in package.json). Mainnet/calibration probes never reach this branch.
   try {
-    const { resolveDevnetConfig } = await import('../../common/get-rpc-url.js')
+    const { resolveDevnetConfig } = await import('../../common/devnet-config.js')
     const devnet = resolveDevnetConfig().chain
     if (id === devnet.id) return devnet
   } catch (err) {

--- a/src/test/unit/devnet-config-browser-stub.test.ts
+++ b/src/test/unit/devnet-config-browser-stub.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { resolveDevnetConfig } from '../../common/devnet-config.browser.js'
+
+/**
+ * Devnet config reads devnet-info.json via node:fs/os/path, so it must be kept out
+ * of browser bundles. Bundlers swap ./common/devnet-config.js for its browser stub
+ * via the "browser" field in package.json; resolveChainFromRpc's guarded lazy import
+ * catches the stub's throw. These tests lock that wiring in place so it can't silently
+ * regress and force consumers back to shipping their own stub.
+ */
+describe('devnet-config browser stub', () => {
+  it('is wired up in the package.json "browser" field', () => {
+    const pkgUrl = new URL('../../../package.json', import.meta.url)
+    const pkg = JSON.parse(readFileSync(fileURLToPath(pkgUrl), 'utf8'))
+    expect(pkg.browser['./dist/common/devnet-config.js']).toBe('./dist/common/devnet-config.browser.js')
+  })
+
+  it('throws so the resolveChainFromRpc devnet probe falls through', () => {
+    expect(() => resolveDevnetConfig()).toThrow(/not available in the browser/)
+  })
+})

--- a/src/test/unit/resolve-chain-from-rpc.test.ts
+++ b/src/test/unit/resolve-chain-from-rpc.test.ts
@@ -11,7 +11,7 @@ vi.mock('viem', async (importOriginal) => {
   }
 })
 
-vi.mock('../../common/get-rpc-url.js', () => ({
+vi.mock('../../common/devnet-config.js', () => ({
   resolveDevnetConfig: vi.fn(() => {
     throw new Error('devnet-info.json not available')
   }),
@@ -54,7 +54,7 @@ describe('resolveChainFromRpc', () => {
 
   it('returns devnet chain when chainId matches devnet config', async () => {
     const devnetChain = { id: 31415926, name: 'devnet' } as const
-    const { resolveDevnetConfig } = await import('../../common/get-rpc-url.js')
+    const { resolveDevnetConfig } = await import('../../common/devnet-config.js')
     vi.mocked(resolveDevnetConfig).mockReturnValueOnce({ chain: devnetChain as never, privateKey: undefined })
 
     mockChainId(devnetChain.id)


### PR DESCRIPTION
## Summary

`src/common/get-rpc-url.ts` statically imports `node:fs`/`node:os`/`node:path` (added with devnet support). The browser only reaches it via the guarded lazy `import()` in `resolveChainFromRpc`, but Rollup/Vite still bundle lazy-import targets and choke on the node built-ins — breaking browser builds for downstream consumers.

This restores browser/Rollup support by isolating the node-only devnet code and letting bundlers swap it for a browser stub via the package `browser` field — the same mechanism the repo already uses for its other browser variants.

- New `src/common/devnet-config.ts` holds the `node:fs/os/path` imports, `resolveDevnetConfig`, cache, and `DevnetConfig`.
- New `src/common/devnet-config.browser.ts` stub throws; it's caught by the existing guard in `resolveChainFromRpc`.
- `package.json` `browser` field maps `./dist/common/devnet-config.js` → the stub.
- `get-rpc-url.ts` drops the node imports and re-exports `resolveDevnetConfig`, so node callers (`config.ts`, `cli-auth.ts`, `resolve-network.ts`) are unchanged.

Found via filecoin-project/filecoin-pin-website#188, which had to work around this with a Vite `resolveId` stub plugin. That workaround can be dropped once the site bumps to a release containing this change.

## Verification

- Bundled the browser-reachable path (`resolveChainFromRpc`) with esbuild targeting the browser: builds clean, pulls in no `node:fs/os/path`/`readFileSync`, resolves to the stub. The node target still uses the real devnet module.
- Added `devnet-config-browser-stub.test.ts` locking in the `browser` mapping + stub throw.
- `pnpm run lint`, `pnpm run typecheck`, and the unit project all pass.

## Test plan

- [x] CI green (lint, typecheck, unit, integration, browser)
- [x] Confirm a browser bundle of filecoin-pin no longer requires a devnet stub