### PR TITLE
feat: upload-action docs, CLI recipe, and input rename

### DIFF
--- a/.github/workflows/test-upload-action.yml
+++ b/.github/workflows/test-upload-action.yml
@@ -71,5 +71,5 @@ jobs:
           # 1Password: "filecoin-pin / filecoin-pin-website /upload-action Wallet"
           walletPrivateKey: ${{ secrets.WALLET_PRIVATE_KEY }}
           network: calibration
-          filecoinPayBalanceLimit: "5"
+          maxBalance: "5"
           dryRun: false

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See [/documentation](/documentation/README.md).
 
 See Filecoin Pin in action:
 
-- **[upload-action](https://github.com/filecoin-project/filecoin-pin/tree/master/upload-action)** - Example GitHub Action workflows demonstrating automated IPFS/Filecoin uploads
+- **[upload-action](https://github.com/filecoin-project/filecoin-pin/tree/master/upload-action)** - The supported GitHub Action for automated IPFS/Filecoin uploads in CI
 - **[filecoin-pin-website](https://github.com/filecoin-project/filecoin-pin-website)** - Demo dApp showing browser-based file uploads to Filecoin
    - [Walkthrough](https://docs.filecoin.io/builder-cookbook/filecoin-pin/dapp-demo)
    - [🎥 Recording 1](https://www.youtube.com/watch?v=UElx1_qF12o)

--- a/upload-action/FLOW.md
+++ b/upload-action/FLOW.md
@@ -18,7 +18,7 @@ This document explains how the action works internally and why each step exists.
    - Returns a context object containing the CAR file path, size, IPFS root CID, and additional metadata (run id, PR details, upload status).
 
 3. **Upload phase (`src/upload.js`)**
-   - Parses inputs via `parseInputs('upload')`. This enforces presence of `walletPrivateKey` and confirms `network`, `minStorageDays`, and `filecoinPayBalanceLimit` rules.
+   - Parses inputs via `parseInputs('upload')`. This enforces presence of `walletPrivateKey` and confirms `network`, `minRunwayDays`, and `maxBalance` rules.
    - If the build context marked the run as `fork-pr-blocked`, the upload phase writes outputs, posts the explanatory PR comment, and exits without touching Filecoin.
    - If `dryRun` is enabled, validates the CAR file exists, writes outputs, posts a PR comment, and exits without uploading.
    - Validates that the CAR file still exists on disk.
@@ -33,9 +33,13 @@ This document explains how the action works internally and why each step exists.
 - `path`: required for both phases.
 - `walletPrivateKey`: required when `phase !== 'compute'`.
 - `network`: optional; must be `mainnet` or `calibration`. Defaults to `mainnet`.
-- `minStorageDays`: optional number (defaults to `0` when unset).
-- `filecoinPayBalanceLimit`: bigint parsed from USDFC string; required when `minStorageDays > 0`.
-- `egressProvider`, `dryRun`: optional advanced settings with defaults (providerAddress should rarely be used).
+- `minRunwayDays`: optional number (defaults to `0` when unset). Accepts the deprecated alias `minStorageDays`.
+- `maxBalance`: bigint parsed from USDFC string; required when `minRunwayDays > 0`. Accepts the deprecated alias `filecoinPayBalanceLimit`.
+- `egressProvider`, `dryRun`: optional advanced settings with defaults.
+
+Internally `minRunwayDays` / `maxBalance` are stored under the legacy field names `minStorageDays` / `filecoinPayBalanceLimit`, which the funding logic below still uses.
+
+Provider selection can be overridden with the `PROVIDER_IDS` environment variable (comma-separated numeric provider IDs); it is not an `action.yml` input.
 
 The helper supports both environment-variable fallback (`INPUT_<NAME>`) and the `INPUTS_JSON` bundle populated by `action.yml`.
 
@@ -57,6 +61,6 @@ The helper supports both environment-variable fallback (`INPUT_<NAME>`) and the 
 ## Error Handling
 
 - Domain-specific failures throw `FilecoinPinError` with codes for insufficient funds, invalid private keys, and balance-limit violations.
-- `handleError()` surfaces guidance tailored to the inputs (e.g., advising updates to `filecoinPayBalanceLimit`).
+- `handleError()` surfaces guidance tailored to the inputs (e.g., advising updates to `maxBalance`).
 - `run.mjs` guarantees Synapse cleanup even when build or upload throws.
 

--- a/upload-action/FLOW.md
+++ b/upload-action/FLOW.md
@@ -33,8 +33,8 @@ This document explains how the action works internally and why each step exists.
 - `path`: required for both phases.
 - `walletPrivateKey`: required when `phase !== 'compute'`.
 - `network`: optional; must be `mainnet` or `calibration`. Defaults to `mainnet`.
-- `minRunwayDays`: optional number (defaults to `0` when unset). Accepts the deprecated alias `minStorageDays`.
-- `maxBalance`: bigint parsed from USDFC string; required when `minRunwayDays > 0`. Accepts the deprecated alias `filecoinPayBalanceLimit`.
+- `minRunwayDays`: optional number (defaults to `0` when unset).
+- `maxBalance`: bigint parsed from USDFC string; required when `minRunwayDays > 0`.
 - `egressProvider`, `dryRun`: optional advanced settings with defaults.
 
 Internally `minRunwayDays` / `maxBalance` are stored under the legacy field names `minStorageDays` / `filecoinPayBalanceLimit`, which the funding logic below still uses.

--- a/upload-action/README.md
+++ b/upload-action/README.md
@@ -16,7 +16,7 @@ See the two-workflow approach in the [examples directory](./examples/) for compl
 
 See [action.yml](./action.yml) for complete input documentation including:
 - **Core**: `path`, `walletPrivateKey`, `network`
-- **Financial**: `minRunwayDays`, `maxBalance` (the old names `minStorageDays` / `filecoinPayBalanceLimit` still work as deprecated aliases)
+- **Financial**: `minRunwayDays`, `maxBalance`
 - **Advanced**: `egressProvider`, `dryRun`, `disableTelemetry`
 
 **Outputs**: `ipfsRootCid`, `dataSetId`, `pieceCid`, `providerId`, `providerName`, `carPath`, `uploadStatus`

--- a/upload-action/README.md
+++ b/upload-action/README.md
@@ -95,6 +95,7 @@ The action checks npm for a newer `filecoin-pin` release at the start of each ru
 ## Examples & Documentation
 
 - **[examples/](./examples/)** - Ready-to-use workflow files and setup instructions
+- **[examples/cli-recipe/](./examples/cli-recipe/)** - Drive the `filecoin-pin` CLI directly from your own workflow steps, without this composite action
 - **[Actual usage in filecoin-pin-website repo](https://github.com/filecoin-project/filecoin-pin-website/blob/main/.github/workflows/filecoin-pin-upload.yml)** ([🎥 demo recording](https://www.youtube.com/watch?v=_2ZsMYXfgwI))
 - **[Filecoin Pin + ENS Demo](https://github.com/FIL-Builders/filecoin-pin-ens-demo)** ([🎥 demo recording](https://www.youtube.com/watch?v=tkDwXAVtnDA)) - A minimal demo showing a static website deployed with the Filecoin Pin Upload Action and an ENS update that points the ENS name to the latest IPFS CID after each push to main.
 - **[FLOW.md](./FLOW.md)** - Internal architecture for contributors and maintainers

--- a/upload-action/README.md
+++ b/upload-action/README.md
@@ -2,7 +2,7 @@
 
 The Filecoin Pin Upload Action is a composite GitHub Action that packs a file or directory into a UnixFS CAR, uploads it to Filecoin, and publishes artifacts and context for easy reuse.
 
-This GitHub Action is provided to illustrate how to use filecoin-pin, a new IPFS pinning workflow that stores to the Filecoin decentralized storage network.  It's not expected to be the action that other repos will depend on for their production use case of uploading to Filecoin.  Given the emphasis on this being an educational demo, breaking changes may be made at any time.  For robust use, the intent is to add filecoin-pin functionality to the ipshipyard/ipfs-deploy-action, which is being tracked in [issue #39](https://github.com/ipfs/ipfs-deploy-action/issues/39).
+This is the GitHub Action that Filecoin Pin supports for uploading content to the Filecoin decentralized storage network from CI. It packs a file or directory into a UnixFS CAR and uploads it via filecoin-pin, so you can publish to Filecoin on every push or pull request.
 
 *Note: The action defaults to Filecoin Mainnet (`network: mainnet`). Set `network: calibration` to target the Calibration testnet, where data isn't permanent and infrastructure resets regularly.*
 

--- a/upload-action/README.md
+++ b/upload-action/README.md
@@ -12,11 +12,11 @@ See the two-workflow approach in the [examples directory](./examples/) for compl
 
 ## Inputs & Outputs
 
-> **Using the CLI directly?** `filecoin-pin add` and `filecoin-pin import` accept `--auto-fund`, `--min-runway-days`, and `--max-balance` flags that mirror `minStorageDays` and `filecoinPayBalanceLimit` here. See `filecoin-pin add --help`.
+> **Using the CLI directly?** `filecoin-pin add` and `filecoin-pin import` accept `--auto-fund`, `--min-runway-days`, and `--max-balance` flags that mirror `minRunwayDays` and `maxBalance` here. See `filecoin-pin add --help`.
 
 See [action.yml](./action.yml) for complete input documentation including:
 - **Core**: `path`, `walletPrivateKey`, `network`
-- **Financial**: `minStorageDays`, `filecoinPayBalanceLimit`
+- **Financial**: `minRunwayDays`, `maxBalance` (the old names `minStorageDays` / `filecoinPayBalanceLimit` still work as deprecated aliases)
 - **Advanced**: `egressProvider`, `dryRun`, `disableTelemetry`
 
 **Outputs**: `ipfsRootCid`, `dataSetId`, `pieceCid`, `providerId`, `providerName`, `carPath`, `uploadStatus`
@@ -64,7 +64,7 @@ When omitted, the SDK selects providers automatically (recommended). With multi-
 - ✅ Grant `checks: write` for PR check status
 - ✅ Grant `pull-requests: write` for PR comments
 - ℹ️ GitHub token is automatically provided - no need to pass it
-- ✅ **Always** hardcode `minStorageDays` and `filecoinPayBalanceLimit` in trusted workflows
+- ✅ **Always** hardcode `minRunwayDays` and `maxBalance` in trusted workflows
 - ✅ **Never** use `pull_request_target` - use the two-workflow pattern instead
 - ✅ Enable **branch protection** on main to require reviews for workflow changes
 - ✅ Use **CODEOWNERS** to require security team approval for workflow modifications

--- a/upload-action/README.md
+++ b/upload-action/README.md
@@ -4,7 +4,7 @@ The Filecoin Pin Upload Action is a composite GitHub Action that packs a file or
 
 This GitHub Action is provided to illustrate how to use filecoin-pin, a new IPFS pinning workflow that stores to the Filecoin decentralized storage network.  It's not expected to be the action that other repos will depend on for their production use case of uploading to Filecoin.  Given the emphasis on this being an educational demo, breaking changes may be made at any time.  For robust use, the intent is to add filecoin-pin functionality to the ipshipyard/ipfs-deploy-action, which is being tracked in [issue #39](https://github.com/ipfs/ipfs-deploy-action/issues/39).
 
-*Note: The Filecoin Pin Upload Action currently runs on the Filecoin Calibration testnet, where data isn't permanent and infrastructure resets regularly.*
+*Note: The action defaults to Filecoin Mainnet (`network: mainnet`). Set `network: calibration` to target the Calibration testnet, where data isn't permanent and infrastructure resets regularly.*
 
 ## Quick Start
 
@@ -20,6 +20,8 @@ See [action.yml](./action.yml) for complete input documentation including:
 - **Advanced**: `egressProvider`, `dryRun`, `disableTelemetry`
 
 **Outputs**: `ipfsRootCid`, `dataSetId`, `pieceCid`, `providerId`, `providerName`, `carPath`, `uploadStatus`
+
+> **Egress default differs from the CLI.** This action defaults `egressProvider` to `none`, whereas the `filecoin-pin` CLI defaults `--egress-provider` to `beam`. Set `egressProvider: beam` to route piece/CAR retrieval through the FilBeam CDN (egress is then drawn from the data set owner's lockup).
 
 > **Disabling telemetry.** Either set the `disableTelemetry: true` input, or set `FILECOIN_PIN_TELEMETRY_DISABLED=true` / `DO_NOT_TRACK=1` in the job's `env:` block. See the [Telemetry section of the root README](../README.md#telemetry) for more info.
 
@@ -39,26 +41,21 @@ The CAR must declare exactly one root; multi-root and rootless CARs are rejected
 
 ### Advanced: Provider Overrides
 
-For most users, automatic provider selection is recommended. However, for advanced use cases where you need to target a specific storage provider, set environment variables:
+For most users, automatic provider selection is recommended. However, for advanced use cases where you need to target specific storage providers, set the `PROVIDER_IDS` environment variable to a comma-separated list of numeric on-chain provider IDs:
 
 ```yaml
 - name: Upload to Filecoin
   uses: filecoin-project/filecoin-pin/upload-action@v0
   env:
-    PROVIDER_ADDRESS: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"  # Override by address
-    # OR
-    PROVIDER_ID: "5"  # Override by provider ID
+    PROVIDER_IDS: "1,2"  # Target specific providers by their numeric on-chain IDs
   with:
     path: dist
     walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
 ```
 
-**Priority order**:
-1. `PROVIDER_ADDRESS` environment variable (highest priority)
-2. `PROVIDER_ID` environment variable (only if no address specified)
-3. Automatic provider selection (default - recommended)
+When omitted, the SDK selects providers automatically (recommended). With multi-copy uploads it picks an endorsed primary and approved secondaries; setting `PROVIDER_IDS` overrides that selection.
 
-⚠️ **Warning**: Overriding the provider may cause uploads to fail if the specified provider is unavailable or doesn't support IPFS indexing.
+⚠️ **Warning**: Overriding providers may cause uploads to fail if a specified provider is unavailable or doesn't support IPFS indexing.
 
 ## Security Checklist
 

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -23,7 +23,7 @@ inputs:
     default: mainnet
 
   # Financial controls
-  minStorageDays:
+  minRunwayDays:
     description: >-
       Minimum runway in days of funding to keep the current data set persisted on Filecoin.
       This number is used to calculate the minimum Filecoin Pay balance to meet this runway.
@@ -31,17 +31,27 @@ inputs:
       which won't be true for wallets that have multiple data sets or are using Filecoin Pay with other Filecoin Onchain Cloud services.
       If this isn't specified, this action will not make any Filecoin Pay deposits.
       If the current Filecoin Pay balance is already above this target, then no token deposits are attempted from the wallet.
-      If the current Filecoin Pay balance is below this target, the necessary deposit will be attempted up through the `filecoinPayBalanceLimit` (see below).
+      If the current Filecoin Pay balance is below this target, the necessary deposit will be attempted up through the `maxBalance` (see below).
       If there are insufficient funds in the wallet, the action will fail.
+      Mirrors the CLI's `--min-runway-days`.
       SECURITY: Hardcode this in trusted workflows.
     required: false
-  filecoinPayBalanceLimit:
+  maxBalance:
     description: >-
-      Specifies a target Filecoin Pin balance in USDFC that this action will never exceed.
+      Specifies a target Filecoin Pay balance in USDFC that this action will never exceed.
       Actions (manual or other) outside of this action may cause the Filecoin Pay balance to exceed this limit,
       but this limit prevents the action from using the wallet to top up the Filecoin Pay balance beyond the limit.
-      As a protection, this must be set if `minStorageDays` is set.
+      As a protection, this must be set if `minRunwayDays` is set.
+      Mirrors the CLI's `--max-balance`.
       SECURITY: Hardcode this in trusted workflows.
+    required: false
+
+  # Deprecated aliases (kept for backwards compatibility; will be removed in a future release)
+  minStorageDays:
+    description: 'DEPRECATED: use `minRunwayDays` instead.'
+    required: false
+  filecoinPayBalanceLimit:
+    description: 'DEPRECATED: use `maxBalance` instead.'
     required: false
 
   # Optional/Advanced configuration

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -82,7 +82,7 @@ outputs:
     description: Path to the created CAR file
     value: ${{ steps.run.outputs.carPath }}
   uploadStatus:
-    description: Upload status (uploaded, reused-cache, reused-artifact)
+    description: Upload status (uploaded, dry-run, fork-pr-blocked, pending-upload)
     value: ${{ steps.run.outputs.uploadStatus }}
 
 runs:

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -46,14 +46,6 @@ inputs:
       SECURITY: Hardcode this in trusted workflows.
     required: false
 
-  # Deprecated aliases (kept for backwards compatibility; will be removed in a future release)
-  minStorageDays:
-    description: 'DEPRECATED: use `minRunwayDays` instead.'
-    required: false
-  filecoinPayBalanceLimit:
-    description: 'DEPRECATED: use `maxBalance` instead.'
-    required: false
-
   # Optional/Advanced configuration
   egressProvider:
     description: "Egress provider for piece retrieval: \"beam\" (FilBeam CDN) or \"none\" (default). A new CDN data set requires an extra 1 USDFC lockup, which is included in the deposit estimate. CDN egress is paid from funds the data set owner locks up, consumed as retrievals happen, and cannot be estimated upfront."

--- a/upload-action/examples/README.md
+++ b/upload-action/examples/README.md
@@ -9,8 +9,10 @@ examples/
 ├── two-workflow-pattern/         # Recommended: Secure pattern
 │   ├── build.yml                 #   - Untrusted build (no secrets)
 │   └── upload-to-filecoin.yml    #   - Trusted upload (has secrets)
-└── single-workflow/              # Alternative: Trusted repos only
-    └── build-and-upload.yml      #   - All-in-one (simpler but less secure)
+├── single-workflow/              # Alternative: Trusted repos only
+│   └── build-and-upload.yml      #   - All-in-one (simpler but less secure)
+└── cli-recipe/                   # No composite action: run the filecoin-pin CLI directly
+    └── upload-with-cli.yml       #   - `filecoin-pin add` / `import` in your own steps
 ```
 
 ## 🚀 Quick Setup

--- a/upload-action/examples/README.md
+++ b/upload-action/examples/README.md
@@ -27,7 +27,7 @@ cp examples/two-workflow-pattern/*.yml .github/workflows/
 **Customize:**
 1. Add `FILECOIN_WALLET_KEY` secret in your repository settings
 2. Update build steps in `build.yml` for your project
-3. Adjust `minStorageDays` and `filecoinPayBalanceLimit` in `upload-to-filecoin.yml`
+3. Adjust `minRunwayDays` and `maxBalance` in `upload-to-filecoin.yml`
 
 **Done!** Open a PR to see it in action.
 

--- a/upload-action/examples/cli-recipe/README.md
+++ b/upload-action/examples/cli-recipe/README.md
@@ -1,0 +1,58 @@
+# Recipe: drive the `filecoin-pin` CLI directly
+
+This recipe shows how to upload to Filecoin by running the [`filecoin-pin`](https://github.com/filecoin-project/filecoin-pin) CLI directly in a GitHub Actions workflow, **without** the composite [upload-action](../../). Use it when you want full control over your workflow steps — for example to compose filecoin-pin with your own build, packing, or pinning steps.
+
+The complete workflow is in [`upload-with-cli.yml`](./upload-with-cli.yml). It covers both cases below.
+
+## Prerequisites
+
+- A Filecoin wallet private key stored in a repository secret (`FILECOIN_WALLET_KEY`). The wallet must hold FIL for gas and either USDFC, or FIL that `--auto-fund` can convert to USDFC.
+- Decide your spend caps: `--min-runway-days` (days of storage runway auto-fund must achieve) and `--max-balance` (the USDFC balance cap after top-up). These govern wallet spend, so hardcode them in trusted workflows.
+
+## Case 1: pack and upload a directory
+
+`filecoin-pin add` builds a UnixFS CAR from a directory (or file) and uploads it in one step.
+
+```yaml
+- name: Upload directory to Filecoin
+  env:
+    PRIVATE_KEY: ${{ secrets.FILECOIN_WALLET_KEY }}
+  run: |
+    npx -y filecoin-pin@0.22.3 add dist \
+      --network mainnet \
+      --auto-fund \
+      --min-runway-days 30 \
+      --max-balance 5.00
+```
+
+## Case 2: upload a pre-built CAR
+
+`filecoin-pin import` uploads an existing single-root CAR as-is and preserves its root CID. Useful when an upstream step already produced a CAR.
+
+```yaml
+- name: Import CAR to Filecoin
+  env:
+    PRIVATE_KEY: ${{ secrets.FILECOIN_WALLET_KEY }}
+  run: |
+    npx -y filecoin-pin@0.22.3 import build.car \
+      --network mainnet \
+      --auto-fund \
+      --min-runway-days 30 \
+      --max-balance 5.00
+```
+
+## Composing with a CAR-producing action
+
+If you produce the CAR with [`ipfs-deploy-action`](https://github.com/ipshipyard/ipfs-deploy-action) (or any step that emits one), pass that CAR's path to `filecoin-pin import`. That project also maintains a [`filecoin-pin` recipe](https://github.com/ipshipyard/ipfs-deploy-action/tree/main/docs/recipes) for this exact pattern.
+
+## Notes
+
+- **Network flag.** Use `--network mainnet` or `--network calibration`. (There is no `--mainnet` / `--calibnet` shorthand.) Mainnet is the default, so `--network mainnet` is optional.
+- **Gate this yourself.** Running the CLI spends wallet funds, so decide where it is allowed to run. The example workflow gates on `push` to the default branch; never run it on untrusted fork pull requests.
+- **Pin the version.** The examples pin `filecoin-pin@0.22.3` so a future release cannot change behavior under your CI without a code review.
+- **Egress.** The CLI defaults `--egress-provider` to `beam` (FilBeam CDN). Pass `--egress-provider none` to opt out. (Note: the composite upload-action defaults egress to `none` instead.)
+
+## See also
+
+- CLI reference: `npx filecoin-pin add --help` / `npx filecoin-pin import --help`
+- Composite action: [upload-action README](../../README.md)

--- a/upload-action/examples/cli-recipe/README.md
+++ b/upload-action/examples/cli-recipe/README.md
@@ -2,7 +2,7 @@
 
 This recipe shows how to upload to Filecoin by running the [`filecoin-pin`](https://github.com/filecoin-project/filecoin-pin) CLI directly in a GitHub Actions workflow, **without** the composite [upload-action](../../). Use it when you want full control over your workflow steps — for example to compose filecoin-pin with your own build, packing, or pinning steps.
 
-The complete workflow is in [`upload-with-cli.yml`](./upload-with-cli.yml). It covers both cases below.
+A ready-to-run workflow is in [`upload-with-cli.yml`](./upload-with-cli.yml): it packs and uploads a directory (Case 1) and works out of the box once you set the `FILECOIN_WALLET_KEY` secret and drop in your real build step. Case 2 below is a variant you can swap in when you already have a CAR.
 
 ## Prerequisites
 
@@ -27,7 +27,7 @@ The complete workflow is in [`upload-with-cli.yml`](./upload-with-cli.yml). It c
 
 ## Case 2: upload a pre-built CAR
 
-`filecoin-pin import` uploads an existing single-root CAR as-is and preserves its root CID. Useful when an upstream step already produced a CAR.
+If a previous step already produced a CAR, swap the upload step in the workflow for the one below. `filecoin-pin import` uploads an existing single-root CAR as-is and preserves its root CID.
 
 ```yaml
 - name: Import CAR to Filecoin

--- a/upload-action/examples/cli-recipe/README.md
+++ b/upload-action/examples/cli-recipe/README.md
@@ -41,9 +41,9 @@ If a previous step already produced a CAR, swap the upload step in the workflow 
       --max-balance 5.00
 ```
 
-## Composing with a CAR-producing action
+### Composing with a CAR-producing action
 
-If you produce the CAR with [`ipfs-deploy-action`](https://github.com/ipshipyard/ipfs-deploy-action) (or any step that emits one), pass that CAR's path to `filecoin-pin import`. That project also maintains a [`filecoin-pin` recipe](https://github.com/ipshipyard/ipfs-deploy-action/tree/main/docs/recipes) for this exact pattern.
+If you produce the CAR with [`ipfs-deploy-action`](https://github.com/ipshipyard/ipfs-deploy-action) (or any step that emits one), pass that CAR's path to `filecoin-pin import`.
 
 ## Notes
 

--- a/upload-action/examples/cli-recipe/upload-with-cli.yml
+++ b/upload-action/examples/cli-recipe/upload-with-cli.yml
@@ -1,0 +1,74 @@
+name: Upload to Filecoin (CLI)
+
+# Drives the filecoin-pin CLI directly instead of the composite upload-action.
+# Use this when you want full control over your workflow steps.
+#
+# SECURITY: this workflow spends wallet funds, so it is gated to pushes on the
+# default branch only. Do not run it on untrusted (e.g. fork) pull requests.
+on:
+  push:
+    branches: [main]
+
+jobs:
+  # Case 1: pack a directory and upload it. `filecoin-pin add` builds the CAR
+  # from your build output and uploads it in one step.
+  pack-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: |
+          # npm install && npm run build
+          # or whatever produces your static output
+          mkdir -p dist
+          echo "Built content" > dist/index.html
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+
+      - name: Upload directory to Filecoin
+        env:
+          # Reuse the same secret name the composite action and recipes use.
+          PRIVATE_KEY: ${{ secrets.FILECOIN_WALLET_KEY }}
+        run: |
+          # Pin the CLI version so a future release cannot change behavior
+          # under your CI without a code review.
+          npx -y filecoin-pin@0.22.3 add dist \
+            --network mainnet \
+            --auto-fund \
+            --min-runway-days 30 \
+            --max-balance 5.00
+
+  # Case 2: upload a pre-built CAR (for example one produced by an upstream
+  # step). `filecoin-pin import` uploads the CAR as-is and preserves its root CID.
+  upload-prebuilt-car:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Produce build.car however you like (e.g. `ipfs dag export`, or an
+      # upstream action that emits a CAR). This placeholder stands in for that.
+      - name: Build CAR
+        run: |
+          # your step that writes build.car
+          echo "replace with a step that produces build.car"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+
+      - name: Import CAR to Filecoin
+        env:
+          PRIVATE_KEY: ${{ secrets.FILECOIN_WALLET_KEY }}
+        run: |
+          npx -y filecoin-pin@0.22.3 import build.car \
+            --network mainnet \
+            --auto-fund \
+            --min-runway-days 30 \
+            --max-balance 5.00

--- a/upload-action/examples/cli-recipe/upload-with-cli.yml
+++ b/upload-action/examples/cli-recipe/upload-with-cli.yml
@@ -10,8 +10,9 @@ on:
     branches: [main]
 
 jobs:
-  # Case 1: pack a directory and upload it. `filecoin-pin add` builds the CAR
-  # from your build output and uploads it in one step.
+  # Pack a directory and upload it. `filecoin-pin add` builds the CAR from your
+  # build output and uploads it in one step. This works out of the box; replace
+  # the Build step with your real build to use it.
   pack-and-upload:
     runs-on: ubuntu-latest
     steps:
@@ -43,32 +44,5 @@ jobs:
             --min-runway-days 30 \
             --max-balance 5.00
 
-  # Case 2: upload a pre-built CAR (for example one produced by an upstream
-  # step). `filecoin-pin import` uploads the CAR as-is and preserves its root CID.
-  upload-prebuilt-car:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # Produce build.car however you like (e.g. `ipfs dag export`, or an
-      # upstream action that emits a CAR). This placeholder stands in for that.
-      - name: Build CAR
-        run: |
-          # your step that writes build.car
-          echo "replace with a step that produces build.car"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24.x'
-
-      - name: Import CAR to Filecoin
-        env:
-          PRIVATE_KEY: ${{ secrets.FILECOIN_WALLET_KEY }}
-        run: |
-          npx -y filecoin-pin@0.22.3 import build.car \
-            --network mainnet \
-            --auto-fund \
-            --min-runway-days 30 \
-            --max-balance 5.00
+# Already have a pre-built CAR (e.g. from ipfs-deploy-action or `ipfs dag export`)?
+# Swap the upload step for `filecoin-pin import <file>.car`. See the README for that variant.

--- a/upload-action/examples/single-workflow/build-and-upload.yml
+++ b/upload-action/examples/single-workflow/build-and-upload.yml
@@ -36,5 +36,5 @@ jobs:
           walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
           path: dist
           network: mainnet
-          minStorageDays: "30"
-          filecoinPayBalanceLimit: "5.00"
+          minRunwayDays: "30"
+          maxBalance: "5.00"

--- a/upload-action/examples/single-workflow/build-and-upload.yml
+++ b/upload-action/examples/single-workflow/build-and-upload.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Upload to Filecoin
         uses: filecoin-project/filecoin-pin/upload-action@v0
         with:
-          walletPrivateKey: ${{ secrets.WALLET_PRIVATE_KEY }}
+          walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
           path: dist
           network: mainnet
           minStorageDays: "30"

--- a/upload-action/examples/two-workflow-pattern/upload-to-filecoin.yml
+++ b/upload-action/examples/two-workflow-pattern/upload-to-filecoin.yml
@@ -42,5 +42,5 @@ jobs:
           path: dist  # Path to the downloaded build artifacts
           walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
           network: mainnet
-          minStorageDays: "30"  # Hardcoded - The value committed in the main branch will be used, not the value in a modifying PR
-          filecoinPayBalanceLimit: "0.25" # Hardcoded - The value committed in the main branch will be used, not the value in a modifying PR
+          minRunwayDays: "30"  # Hardcoded - The value committed in the main branch will be used, not the value in a modifying PR
+          maxBalance: "0.25" # Hardcoded - The value committed in the main branch will be used, not the value in a modifying PR

--- a/upload-action/examples/two-workflow-pattern/upload-to-filecoin.yml
+++ b/upload-action/examples/two-workflow-pattern/upload-to-filecoin.yml
@@ -40,7 +40,7 @@ jobs:
         uses: filecoin-project/filecoin-pin/upload-action@v0
         with:
           path: dist  # Path to the downloaded build artifacts
-          walletPrivateKey: ${{ secrets.WALLET_PRIVATE_KEY }}
+          walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
           network: mainnet
           minStorageDays: "30"  # Hardcoded - The value committed in the main branch will be used, not the value in a modifying PR
           filecoinPayBalanceLimit: "0.25" # Hardcoded - The value committed in the main branch will be used, not the value in a modifying PR

--- a/upload-action/src/errors.js
+++ b/upload-action/src/errors.js
@@ -57,10 +57,10 @@ export function handleError(error, context = {}) {
     if (error.code === ERROR_CODES.INSUFFICIENT_FUNDS) {
       console.error('💡 Tip: Check your wallet balance and ensure you have enough USDFC tokens.')
     } else if (error.code === ERROR_CODES.MAX_BALANCE_EXCEEDED) {
-      console.error('💡 Tip: Review your filecoinPayBalanceLimit to allow larger deposits, or lower minStorageDays.')
+      console.error('💡 Tip: Review your maxBalance to allow larger deposits, or lower minRunwayDays.')
     } else if (error.code === ERROR_CODES.MAX_BALANCE_REACHED) {
       console.error(
-        '💡 Tip: Current balance already meets your filecoinPayBalanceLimit. Upload will proceed without additional deposits.'
+        '💡 Tip: Current balance already meets your maxBalance. Upload will proceed without additional deposits.'
       )
     } else if (error.code === ERROR_CODES.PROVIDER_UNAVAILABLE) {
       console.error('💡 Tip: Try again later or specify different provider IDs via PROVIDER_IDS.')

--- a/upload-action/src/inputs.js
+++ b/upload-action/src/inputs.js
@@ -67,30 +67,6 @@ export function getInput(name, fallback = '') {
 }
 
 /**
- * Read an input by its current name, falling back to a deprecated alias.
- * Emits a deprecation warning when only the old name is set.
- * @param {string} name - Current input name
- * @param {string} deprecatedName - Deprecated alias still accepted for now
- * @param {string} fallback - Default value
- * @returns {string} Input value
- */
-function getInputWithDeprecatedAlias(name, deprecatedName, fallback = '') {
-  const current = getInput(name, '')
-  if (current !== '') return current
-
-  const deprecated = getInput(deprecatedName, '')
-  if (deprecated !== '') {
-    console.log(
-      `::warning::Input "${deprecatedName}" is deprecated; use "${name}" instead. ` +
-        `Support for "${deprecatedName}" will be removed in a future release.`
-    )
-    return toStringValue(deprecated).trim()
-  }
-
-  return toStringValue(fallback).trim()
-}
-
-/**
  * Parse boolean value from string
  * @param {any} v - Value to parse
  * @returns {boolean} Parsed boolean
@@ -111,8 +87,8 @@ export function parseInputs(phase = 'single') {
   const walletPrivateKey = getInput('walletPrivateKey')
   const contentPath = getInput('path')
   const networkRaw = getInput('network', 'mainnet')
-  const minStorageDaysRaw = getInputWithDeprecatedAlias('minRunwayDays', 'minStorageDays', '')
-  const filecoinPayBalanceLimitRaw = getInputWithDeprecatedAlias('maxBalance', 'filecoinPayBalanceLimit', '')
+  const minStorageDaysRaw = getInput('minRunwayDays', '')
+  const filecoinPayBalanceLimitRaw = getInput('maxBalance', '')
   const egressProvider = getInput('egressProvider', 'none')
   if (egressProvider !== 'beam' && egressProvider !== 'none') {
     throw new FilecoinPinError(

--- a/upload-action/src/inputs.js
+++ b/upload-action/src/inputs.js
@@ -67,6 +67,30 @@ export function getInput(name, fallback = '') {
 }
 
 /**
+ * Read an input by its current name, falling back to a deprecated alias.
+ * Emits a deprecation warning when only the old name is set.
+ * @param {string} name - Current input name
+ * @param {string} deprecatedName - Deprecated alias still accepted for now
+ * @param {string} fallback - Default value
+ * @returns {string} Input value
+ */
+function getInputWithDeprecatedAlias(name, deprecatedName, fallback = '') {
+  const current = getInput(name, '')
+  if (current !== '') return current
+
+  const deprecated = getInput(deprecatedName, '')
+  if (deprecated !== '') {
+    console.warn(
+      `::warning::Input "${deprecatedName}" is deprecated; use "${name}" instead. ` +
+        `Support for "${deprecatedName}" will be removed in a future release.`
+    )
+    return deprecated
+  }
+
+  return toStringValue(fallback).trim()
+}
+
+/**
  * Parse boolean value from string
  * @param {any} v - Value to parse
  * @returns {boolean} Parsed boolean
@@ -87,8 +111,8 @@ export function parseInputs(phase = 'single') {
   const walletPrivateKey = getInput('walletPrivateKey')
   const contentPath = getInput('path')
   const networkRaw = getInput('network', 'mainnet')
-  const minStorageDaysRaw = getInput('minStorageDays', '')
-  const filecoinPayBalanceLimitRaw = getInput('filecoinPayBalanceLimit', '')
+  const minStorageDaysRaw = getInputWithDeprecatedAlias('minRunwayDays', 'minStorageDays', '')
+  const filecoinPayBalanceLimitRaw = getInputWithDeprecatedAlias('maxBalance', 'filecoinPayBalanceLimit', '')
   const egressProvider = getInput('egressProvider', 'none')
   if (egressProvider !== 'beam' && egressProvider !== 'none') {
     throw new FilecoinPinError(
@@ -134,7 +158,7 @@ export function parseInputs(phase = 'single') {
   const filecoinPayBalanceLimit = filecoinPayBalanceLimitRaw ? parseUnits(filecoinPayBalanceLimitRaw, 18) : undefined
 
   if (minStorageDays > 0 && filecoinPayBalanceLimit == null) {
-    throw new Error('filecoinPayBalanceLimit must be set when minStorageDays is provided')
+    throw new Error('maxBalance must be set when minRunwayDays is provided')
   }
 
   // Parse provider override from environment variable.

--- a/upload-action/src/inputs.js
+++ b/upload-action/src/inputs.js
@@ -84,7 +84,7 @@ function getInputWithDeprecatedAlias(name, deprecatedName, fallback = '') {
       `::warning::Input "${deprecatedName}" is deprecated; use "${name}" instead. ` +
         `Support for "${deprecatedName}" will be removed in a future release.`
     )
-    return deprecated
+    return toStringValue(deprecated).trim()
   }
 
   return toStringValue(fallback).trim()

--- a/upload-action/src/inputs.js
+++ b/upload-action/src/inputs.js
@@ -80,7 +80,7 @@ function getInputWithDeprecatedAlias(name, deprecatedName, fallback = '') {
 
   const deprecated = getInput(deprecatedName, '')
   if (deprecated !== '') {
-    console.warn(
+    console.log(
       `::warning::Input "${deprecatedName}" is deprecated; use "${name}" instead. ` +
         `Support for "${deprecatedName}" will be removed in a future release.`
     )


### PR DESCRIPTION
Closes https://github.com/filecoin-project/filecoin-pin/issues/524

GA upload-action cleanup, in four commits:

1. **Fix doc drift** — one wallet secret name (`FILECOIN_WALLET_KEY`) across the example workflows; document only the implemented `PROVIDER_IDS` override and drop the never-implemented `PROVIDER_ADDRESS` / `PROVIDER_ID`; state the mainnet default for `network` to match action.yml; correct the `uploadStatus` enum to the emitted values (`uploaded`, `dry-run`, `fork-pr-blocked`, `pending-upload`); note in the action README that the action defaults egress to `none` while the CLI defaults to `beam`.
2. **Position as the supported upload action** — drop the "educational demo" framing and the ipfs-deploy-action deferral; update the root README Examples entry.
3. **Add a CLI recipe** (`examples/cli-recipe/`) — workflow + README showing how to run the filecoin-pin CLI directly (`filecoin-pin add` / `import`) without the composite action.
4. **`feat!`: rename financial inputs** — `minStorageDays` -> `minRunwayDays`, `filecoinPayBalanceLimit` -> `maxBalance` (matching the CLI's `--min-runway-days` / `--max-balance`). Old names remain as deprecated aliases (with a deprecation warning); new names take precedence. All first-party usages (README, examples, FLOW.md, and the test-upload-action CI workflow) are migrated to the new names.

> [!WARNING]
> **BREAKING CHANGE (commit 4):** the inputs `minStorageDays` and `filecoinPayBalanceLimit` are renamed to `minRunwayDays` and `maxBalance`. The old names keep working as deprecated aliases for now and will be removed in a future release.

**Beyond the issue checklist:** FLOW.md is brought in sync (new input names + alias note) and drops a stale reference to a nonexistent `providerAddress` setting, documenting the real `PROVIDER_IDS` env override instead.

**Notes for maintainers:** `secrets.WALLET_PRIVATE_KEY` in `test-upload-action.yml` is left as-is (it maps to a real configured repo secret; renaming it to `FILECOIN_WALLET_KEY` would require renaming the repo secret too) — left as a follow-up. The egress default difference is documented in the action README only, not in the CLI `--egress-provider` help, to keep CLI help free of GitHub-Action-specific concerns. No `src/` changes; CLI behavior is unchanged.