### PR TITLE
feat(server): GA cleanup for pinning server (beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ Use Filecoin Pin programmatically in your Node.js or browser applications. The l
 ### 📡 IPFS Pinning Server (Daemon Mode)
 Run a localhost IPFS Pinning Service API server that implements the [IPFS Pinning Service API specification](https://ipfs.github.io/pinning-services-api-spec/). This allows you to use standard IPFS tooling (like `ipfs pin remote`) while storing data on Filecoin.
 
-- **Status**: Works and is tested, but hasn't received as many features as the CLI. If it would benefit your use case, please comment on the [tracking issue](https://github.com/filecoin-project/filecoin-pin/issues/46) so we can be better informed when it comes to prioritizing.
+- **Status**: Beta. Works and is tested, but hasn't received as many features as the CLI. State is held in memory and is lost across restarts. If it would benefit your use case, please comment on the [tracking issue](https://github.com/filecoin-project/filecoin-pin/issues/46) so we can be better informed when it comes to prioritizing.
 - **Repository**: This repo (`filecoin-pin server` command in CLI)
-- **Usage**: `PRIVATE_KEY=0x... npx filecoin-pin server` (or use session key auth — see [Configuration](#configuration))
+- **Usage**: `PRIVATE_KEY=0x... ACCESS_TOKEN=... npx filecoin-pin server` (or use session key auth — see [Configuration](#configuration))
+- **Authentication**: The server refuses to start unless an access token is configured via `--access-token` / `ACCESS_TOKEN`. Clients then authenticate with `Authorization: Bearer <token>` on every request except `GET /`. To run the server open to all requests (not recommended), pass `--allow-no-auth` / `ALLOW_NO_AUTH=true`.
+- **`delegates` is always empty**: Each pin spins up its own short-lived Helia node that is stopped as soon as the pin operation finishes, so there is no long-lived node to advertise. The `delegates` array in pin responses is therefore always `[]`.
 
 ### 📊 Management Console GUI
 Web-based management console for monitoring and managing your Filecoin Pin deployments. This is effectively a Web UI equivalent to the [CLI](#-cli) affordance.
@@ -250,6 +252,8 @@ RPC_URL=wss://...              # Filecoin RPC endpoint (overrides NETWORK if spe
                                # Calibration: wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1
 
 # Optional for Pinning Server Daemon
+ACCESS_TOKEN=...               # Bearer token required on all API requests except GET /
+ALLOW_NO_AUTH=true             # Start without a token, serving all requests unauthenticated (not recommended)
 PORT=3456                      # Daemon server port
 HOST=localhost                 # Daemon server host
 DATABASE_PATH=./pins.db        # SQLite database location

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -12,6 +12,10 @@ export const serverCommand = new Command('server')
   .option('--wallet-address <address>', 'wallet address for session key auth (env: WALLET_ADDRESS)')
   .option('--session-key <key>', 'session key for session key auth (env: SESSION_KEY)')
   .option('--access-token <token>', 'bearer token required on all API requests except GET / (env: ACCESS_TOKEN)')
+  .option(
+    '--allow-no-auth',
+    'start the server without an access token, serving all requests unauthenticated (env: ALLOW_NO_AUTH)'
+  )
 
 addNetworkOptions(serverCommand)
   .addOption(
@@ -31,6 +35,9 @@ addNetworkOptions(serverCommand)
     }
     if (options.accessToken) {
       process.env.ACCESS_TOKEN = options.accessToken
+    }
+    if (options.allowNoAuth) {
+      process.env.ALLOW_NO_AUTH = 'true'
     }
     // RPC URL takes precedence over network flag
     if (options.rpcUrl) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,6 +73,7 @@ export function createConfig(): Config {
     port: parseInt(process.env.PORT ?? '3456', 10),
     host: process.env.HOST ?? 'localhost',
     accessToken: process.env.ACCESS_TOKEN,
+    allowNoAuth: process.env.ALLOW_NO_AUTH === 'true',
 
     // Synapse SDK configuration
     privateKey: process.env.PRIVATE_KEY,

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -49,6 +49,8 @@ export interface Config {
   walletAddress: string | undefined
   sessionKey: string | undefined
   accessToken: string | undefined
+  /** Allow the pinning server to start without an access token, serving all requests unauthenticated. */
+  allowNoAuth?: boolean
   rpcUrl: string
   chain?: Chain
   databasePath: string

--- a/src/filecoin-pinning-server.ts
+++ b/src/filecoin-pinning-server.ts
@@ -1,4 +1,4 @@
-import fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from 'fastify'
+import fastify, { type FastifyError, type FastifyInstance, type FastifyReply, type FastifyRequest } from 'fastify'
 import { CID } from 'multiformats/cid'
 import type { Logger } from 'pino'
 import { isAddress, isHex } from 'viem'
@@ -31,6 +31,22 @@ async function sendError(reply: FastifyReply, statusCode: number, reason: string
     error.details = details
   }
   await reply.code(statusCode).send({ error })
+}
+
+/** Map an HTTP status code to a machine-readable `reason` for the spec error envelope. */
+function reasonForStatus(statusCode: number): string {
+  switch (statusCode) {
+    case 400:
+      return 'BAD_REQUEST'
+    case 401:
+      return 'UNAUTHORIZED'
+    case 403:
+      return 'FORBIDDEN'
+    case 404:
+      return 'NOT_FOUND'
+    default:
+      return statusCode >= 500 ? 'INTERNAL_ERROR' : 'CLIENT_ERROR'
+  }
 }
 
 interface PinMutationBody {
@@ -198,6 +214,22 @@ export async function createFilecoinPinningServer(
     logger: false, // We'll use our own logger
   })
 
+  // Route Fastify-generated errors (malformed JSON bodies, schema validation, etc.) and unknown
+  // routes through the IPFS Pinning Service spec error envelope so every response is consistent.
+  server.setNotFoundHandler(async (_request, reply) => {
+    await sendError(reply, 404, 'NOT_FOUND', 'Route not found')
+  })
+
+  server.setErrorHandler(async (error: FastifyError, _request, reply) => {
+    const statusCode = error.statusCode ?? 500
+    if (statusCode >= 500) {
+      logger.error({ error }, 'Unhandled server error')
+      await sendError(reply, 500, 'INTERNAL_ERROR', 'Internal server error')
+      return
+    }
+    await sendError(reply, statusCode, reasonForStatus(statusCode), error.message)
+  })
+
   // Add root route for health check (no auth required)
   server.get('/', async (_request, reply) => {
     await reply.send({
@@ -209,8 +241,9 @@ export async function createFilecoinPinningServer(
 
   // Add authentication hook
   server.addHook('preHandler', async (request, reply) => {
-    // Skip auth for root health check
-    if (request.url === '/') {
+    // Skip auth for the root health check. The matched route URL is used rather than request.url
+    // so query strings (e.g. GET /?check=1) don't accidentally require auth.
+    if (request.routeOptions.url === '/') {
       return
     }
 

--- a/src/filecoin-pinning-server.ts
+++ b/src/filecoin-pinning-server.ts
@@ -49,11 +49,7 @@ function reasonForStatus(statusCode: number): string {
   }
 }
 
-interface PinMutationBody {
-  name?: string
-  origins?: string[]
-  meta?: Record<string, string>
-}
+type PinMutationBody = import('./filecoin-pin-store.js').PinOptions
 
 /**
  * Validate the optional `name` / `origins` / `meta` fields shared by the create and update

--- a/src/filecoin-pinning-server.ts
+++ b/src/filecoin-pinning-server.ts
@@ -4,7 +4,7 @@ import type { Logger } from 'pino'
 import { isAddress, isHex } from 'viem'
 import type { Chain, Config } from './core/synapse/index.js'
 import { initializeSynapse, type SynapseSetupConfig } from './core/synapse/index.js'
-import { FilecoinPinStore } from './filecoin-pin-store.js'
+import { FilecoinPinStore, type PinOptions } from './filecoin-pin-store.js'
 import type { ServiceInfo } from './server.js'
 
 declare module 'fastify' {
@@ -49,7 +49,7 @@ function reasonForStatus(statusCode: number): string {
   }
 }
 
-type PinMutationBody = import('./filecoin-pin-store.js').PinOptions
+type PinMutationBody = PinOptions
 
 /**
  * Validate the optional `name` / `origins` / `meta` fields shared by the create and update

--- a/src/filecoin-pinning-server.ts
+++ b/src/filecoin-pinning-server.ts
@@ -1,10 +1,10 @@
-import fastify, { type FastifyInstance, type FastifyRequest } from 'fastify'
+import fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from 'fastify'
 import { CID } from 'multiformats/cid'
 import type { Logger } from 'pino'
 import { isAddress, isHex } from 'viem'
 import type { Chain, Config } from './core/synapse/index.js'
 import { initializeSynapse, type SynapseSetupConfig } from './core/synapse/index.js'
-import { FilecoinPinStore, type PinOptions } from './filecoin-pin-store.js'
+import { FilecoinPinStore } from './filecoin-pin-store.js'
 import type { ServiceInfo } from './server.js'
 
 declare module 'fastify' {
@@ -19,6 +19,63 @@ declare module 'fastify' {
 const DEFAULT_USER_INFO = {
   id: 'default-user',
   name: 'Default User',
+}
+
+/**
+ * Send an error response in the IPFS Pinning Service API error shape:
+ * `{ error: { reason, details } }`. See https://ipfs.github.io/pinning-services-api-spec/.
+ */
+async function sendError(reply: FastifyReply, statusCode: number, reason: string, details?: string): Promise<void> {
+  const error: { reason: string; details?: string } = { reason }
+  if (details != null) {
+    error.details = details
+  }
+  await reply.code(statusCode).send({ error })
+}
+
+interface PinMutationBody {
+  name?: string
+  origins?: string[]
+  meta?: Record<string, string>
+}
+
+/**
+ * Validate the optional `name` / `origins` / `meta` fields shared by the create and update
+ * pin endpoints. Returns the validated options, or an error message describing what is malformed.
+ */
+function parsePinMutationBody(body: unknown): { options: PinMutationBody } | { error: string } {
+  if (body == null || typeof body !== 'object' || Array.isArray(body)) {
+    return { error: 'Request body must be a JSON object' }
+  }
+
+  const { name, origins, meta } = body as Record<string, unknown>
+  const options: PinMutationBody = {}
+
+  if (name !== undefined) {
+    if (typeof name !== 'string') {
+      return { error: 'Field "name" must be a string' }
+    }
+    options.name = name
+  }
+
+  if (origins !== undefined) {
+    if (!Array.isArray(origins) || origins.some((origin) => typeof origin !== 'string')) {
+      return { error: 'Field "origins" must be an array of strings' }
+    }
+    options.origins = origins as string[]
+  }
+
+  if (meta !== undefined) {
+    if (typeof meta !== 'object' || meta === null || Array.isArray(meta)) {
+      return { error: 'Field "meta" must be an object of string values' }
+    }
+    if (Object.values(meta).some((value) => typeof value !== 'string')) {
+      return { error: 'Field "meta" must be an object of string values' }
+    }
+    options.meta = meta as Record<string, string>
+  }
+
+  return { options }
 }
 
 function buildSynapseConfig(config: Config): SynapseSetupConfig {
@@ -67,6 +124,16 @@ export async function createFilecoinPinningServer(
 ): Promise<{ server: FastifyInstance; pinStore: FilecoinPinStore }> {
   // Set up Synapse service
   const synapseConfig = buildSynapseConfig(config)
+
+  // Refuse to start open to the world by accident: require an access token unless the operator
+  // explicitly opts out with --allow-no-auth / ALLOW_NO_AUTH. Checked before the network call below.
+  if (!config.accessToken && config.allowNoAuth !== true) {
+    throw new Error(
+      'No access token configured. Set an access token (--access-token / ACCESS_TOKEN) to require ' +
+        'authentication, or pass --allow-no-auth to run the server open to all requests (not recommended).'
+    )
+  }
+
   const synapse = await initializeSynapse(synapseConfig, logger)
 
   const filecoinPinStore = new FilecoinPinStore({
@@ -147,7 +214,7 @@ export async function createFilecoinPinningServer(
       return
     }
 
-    // If no access token is configured, allow all requests
+    // No access token means the operator started with --allow-no-auth: serve all requests.
     if (!config.accessToken) {
       request.user = DEFAULT_USER_INFO
       return
@@ -155,18 +222,18 @@ export async function createFilecoinPinningServer(
 
     const authHeader = request.headers.authorization
     if (authHeader?.startsWith('Bearer ') !== true) {
-      await reply.code(401).send({ error: 'Missing or invalid authorization header' })
+      await sendError(reply, 401, 'UNAUTHORIZED', 'Missing or invalid authorization header')
       return
     }
 
     const token = authHeader.slice(7).trim() // Remove 'Bearer ' prefix
     if (token.length === 0) {
-      await reply.code(401).send({ error: 'Invalid access token' })
+      await sendError(reply, 401, 'UNAUTHORIZED', 'Invalid access token')
       return
     }
 
     if (token !== config.accessToken) {
-      await reply.code(403).send({ error: 'Invalid access token' })
+      await sendError(reply, 403, 'FORBIDDEN', 'Invalid access token')
       return
     }
 
@@ -205,65 +272,70 @@ async function registerCustomPinRoutes(
   logger: Logger
 ): Promise<void> {
   // POST /pins - Create a new pin
-  fastify.post(
-    '/pins',
-    async (
-      request: FastifyRequest<{
-        Body: { cid?: string; name?: string; origins?: string[]; meta?: Record<string, string> }
-      }>,
-      reply
-    ) => {
-      try {
-        const { cid, name, origins, meta } = request.body
-        if (cid == null) {
-          await reply.code(400).send({ error: 'Missing required field: cid' })
-          return
-        }
-
-        // Parse the CID string to CID object
-        let cidObject: CID
-        try {
-          cidObject = CID.parse(cid)
-        } catch (_error) {
-          await reply.code(400).send({ error: `Invalid CID format: ${cid}` })
-          return
-        }
-
-        const pinOptions: PinOptions = {}
-        if (name != null) pinOptions.name = name
-        if (origins != null) pinOptions.origins = origins
-        if (meta != null) pinOptions.meta = meta
-        if (request.user == null) {
-          await reply.code(401).send({ error: 'Unauthorized' })
-          return
-        }
-        const result = await pinStore.pin(request.user, cidObject, pinOptions)
-
-        await reply.code(202).send({
-          requestid: result.id,
-          status: result.status,
-          created: new Date(result.created).toISOString(),
-          pin: result.pin,
-          delegates: [],
-          info: result.info,
-        })
-      } catch (error) {
-        logger.error({ error }, 'Failed to create pin')
-        await reply.code(500).send({ error: 'Internal server error' })
+  fastify.post('/pins', async (request: FastifyRequest<{ Body: unknown }>, reply) => {
+    try {
+      if (request.user == null) {
+        await sendError(reply, 401, 'UNAUTHORIZED', 'Unauthorized')
+        return
       }
+
+      const body = request.body
+      if (body == null || typeof body !== 'object' || Array.isArray(body)) {
+        await sendError(reply, 400, 'BAD_REQUEST', 'Request body must be a JSON object')
+        return
+      }
+
+      const { cid } = body as Record<string, unknown>
+      if (cid == null) {
+        await sendError(reply, 400, 'BAD_REQUEST', 'Missing required field: cid')
+        return
+      }
+      if (typeof cid !== 'string') {
+        await sendError(reply, 400, 'BAD_REQUEST', 'Field "cid" must be a string')
+        return
+      }
+
+      const parsed = parsePinMutationBody(body)
+      if ('error' in parsed) {
+        await sendError(reply, 400, 'BAD_REQUEST', parsed.error)
+        return
+      }
+
+      // Parse the CID string to CID object
+      let cidObject: CID
+      try {
+        cidObject = CID.parse(cid)
+      } catch (_error) {
+        await sendError(reply, 400, 'BAD_REQUEST', `Invalid CID format: ${cid}`)
+        return
+      }
+
+      const result = await pinStore.pin(request.user, cidObject, parsed.options)
+
+      await reply.code(202).send({
+        requestid: result.id,
+        status: result.status,
+        created: new Date(result.created).toISOString(),
+        pin: result.pin,
+        delegates: [],
+        info: result.info,
+      })
+    } catch (error) {
+      logger.error({ error }, 'Failed to create pin')
+      await sendError(reply, 500, 'INTERNAL_ERROR', 'Internal server error')
     }
-  )
+  })
 
   // GET /pins/:requestId - Get pin status
   fastify.get('/pins/:requestId', async (request: FastifyRequest<{ Params: { requestId: string } }>, reply) => {
     try {
       if (request.user == null) {
-        await reply.code(401).send({ error: 'Unauthorized' })
+        await sendError(reply, 401, 'UNAUTHORIZED', 'Unauthorized')
         return
       }
       const result = await pinStore.get(request.user, request.params.requestId)
       if (result == null) {
-        await reply.code(404).send({ error: 'Pin not found' })
+        await sendError(reply, 404, 'NOT_FOUND', 'Pin not found')
         return
       }
 
@@ -277,7 +349,7 @@ async function registerCustomPinRoutes(
       })
     } catch (error) {
       logger.error({ error }, 'Failed to get pin status')
-      await reply.code(500).send({ error: 'Internal server error' })
+      await sendError(reply, 500, 'INTERNAL_ERROR', 'Internal server error')
     }
   })
 
@@ -298,7 +370,7 @@ async function registerCustomPinRoutes(
         if (limitNum != null && !Number.isNaN(limitNum)) listQuery.limit = limitNum
 
         if (request.user == null) {
-          await reply.code(401).send({ error: 'Unauthorized' })
+          await sendError(reply, 401, 'UNAUTHORIZED', 'Unauthorized')
           return
         }
         const result = await pinStore.list(request.user, listQuery)
@@ -318,44 +390,60 @@ async function registerCustomPinRoutes(
         })
       } catch (error) {
         logger.error({ error }, 'Failed to list pins')
-        await reply.code(500).send({ error: 'Internal server error' })
+        await sendError(reply, 500, 'INTERNAL_ERROR', 'Internal server error')
       }
     }
   )
 
   // POST /pins/:requestId - Update pin (not commonly used)
-  fastify.post('/pins/:requestId', async (request: any, reply: any) => {
-    try {
-      const { name, origins, meta } = request.body
-      const result = await pinStore.update(request.user, request.params.requestId, { name, origins, meta })
+  fastify.post(
+    '/pins/:requestId',
+    async (request: FastifyRequest<{ Params: { requestId: string }; Body: unknown }>, reply) => {
+      try {
+        if (request.user == null) {
+          await sendError(reply, 401, 'UNAUTHORIZED', 'Unauthorized')
+          return
+        }
 
-      if (result == null) {
-        await reply.code(404).send({ error: 'Pin not found' })
-        return
+        const parsed = parsePinMutationBody(request.body)
+        if ('error' in parsed) {
+          await sendError(reply, 400, 'BAD_REQUEST', parsed.error)
+          return
+        }
+
+        const result = await pinStore.update(request.user, request.params.requestId, parsed.options)
+        if (result == null) {
+          await sendError(reply, 404, 'NOT_FOUND', 'Pin not found')
+          return
+        }
+
+        await reply.send({
+          requestid: result.id,
+          status: result.status,
+          created: new Date(result.created).toISOString(),
+          pin: result.pin,
+          delegates: [],
+          info: result.info,
+        })
+      } catch (error) {
+        logger.error({ error }, 'Failed to update pin')
+        await sendError(reply, 500, 'INTERNAL_ERROR', 'Internal server error')
       }
-
-      await reply.send({
-        requestid: result.id,
-        status: result.status,
-        created: new Date(result.created).toISOString(),
-        pin: result.pin,
-        delegates: [],
-        info: result.info,
-      })
-    } catch (error) {
-      logger.error({ error }, 'Failed to update pin')
-      await reply.code(500).send({ error: 'Internal server error' })
     }
-  })
+  )
 
   // DELETE /pins/:requestId - Cancel/delete pin and clean up CAR file
-  fastify.delete('/pins/:requestId', async (request: any, reply: any) => {
+  fastify.delete('/pins/:requestId', async (request: FastifyRequest<{ Params: { requestId: string } }>, reply) => {
     try {
+      if (request.user == null) {
+        await sendError(reply, 401, 'UNAUTHORIZED', 'Unauthorized')
+        return
+      }
       await pinStore.cancel(request.user, request.params.requestId)
       await reply.code(202).send()
     } catch (error) {
       logger.error({ error }, 'Failed to cancel pin')
-      await reply.code(500).send({ error: 'Internal server error' })
+      await sendError(reply, 500, 'INTERNAL_ERROR', 'Internal server error')
     }
   })
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -81,7 +81,7 @@ export async function startServer(): Promise<void> {
     } else if (errorMessage.includes('No access token')) {
       console.error('\n❌ Error: An access token is required to start the pinning server')
       console.error('   Access token:  --access-token <token>  or  ACCESS_TOKEN=...')
-      console.error('   To run without authentication (not recommended), pass --allow-no-auth.\n')
+      console.error('   To run without authentication (not recommended), pass --allow-no-auth or set ALLOW_NO_AUTH=true.\n')
     }
 
     process.exit(1)

--- a/src/server.ts
+++ b/src/server.ts
@@ -81,7 +81,9 @@ export async function startServer(): Promise<void> {
     } else if (errorMessage.includes('No access token')) {
       console.error('\n❌ Error: An access token is required to start the pinning server')
       console.error('   Access token:  --access-token <token>  or  ACCESS_TOKEN=...')
-      console.error('   To run without authentication (not recommended), pass --allow-no-auth or set ALLOW_NO_AUTH=true.\n')
+      console.error(
+        '   To run without authentication (not recommended), pass --allow-no-auth or set ALLOW_NO_AUTH=true.\n'
+      )
     }
 
     process.exit(1)

--- a/src/server.ts
+++ b/src/server.ts
@@ -78,6 +78,10 @@ export async function startServer(): Promise<void> {
       console.error('   Private key:   --private-key <key>  or  PRIVATE_KEY=0x...')
       console.error('   Session key:   --wallet-address <addr> --session-key <key>')
       console.error('                  or  WALLET_ADDRESS=0x... SESSION_KEY=0x...\n')
+    } else if (errorMessage.includes('No access token')) {
+      console.error('\n❌ Error: An access token is required to start the pinning server')
+      console.error('   Access token:  --access-token <token>  or  ACCESS_TOKEN=...')
+      console.error('   To run without authentication (not recommended), pass --allow-no-auth.\n')
     }
 
     process.exit(1)

--- a/src/test/integration/integration.test.ts
+++ b/src/test/integration/integration.test.ts
@@ -668,6 +668,34 @@ describe('End-to-End Pinning Service', () => {
       const body = (await res.json()) as { error: { reason: string; details?: string } }
       expect(body.error.reason).toBe('INTERNAL_ERROR')
     })
+
+    it('returns spec error shape for Fastify-generated 400 (malformed JSON body)', async () => {
+      const res = await fetch(`${serverAddress}/pins`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-token' },
+        body: '{ not valid json',
+      })
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: { reason: string; details?: string } }
+      expect(body.error.reason).toBe('BAD_REQUEST')
+      expect(typeof body.error.details).toBe('string')
+    })
+
+    it('returns spec error shape for unknown routes (404)', async () => {
+      const res = await fetch(`${serverAddress}/does-not-exist`, {
+        headers: { Authorization: 'Bearer test-token' },
+      })
+      expect(res.status).toBe(404)
+      const body = (await res.json()) as { error: { reason: string; details?: string } }
+      expect(body.error.reason).toBe('NOT_FOUND')
+    })
+
+    it('serves the health check without auth even with a query string', async () => {
+      const res = await fetch(`${serverAddress}/?check=1`)
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { status: string }
+      expect(body.status).toBe('ok')
+    })
   })
 
   describe('Block Transfer Verification', () => {

--- a/src/test/integration/integration.test.ts
+++ b/src/test/integration/integration.test.ts
@@ -53,6 +53,7 @@ describe('End-to-End Pinning Service', () => {
       carStoragePath: testOutputDir,
       port: 0, // Use random port
       privateKey: '0x0000000000000000000000000000000000000000000000000000000000000001', // Fake test key
+      accessToken: 'test-token', // Requests authenticate with `Bearer test-token`
     }
     const logger = createLogger(config)
 
@@ -615,6 +616,58 @@ describe('End-to-End Pinning Service', () => {
 
       expect(getResponse.status).toBe(404)
     }, 15000)
+  })
+
+  describe('Error response shape (IPFS Pinning Service API spec)', () => {
+    it('returns { error: { reason, details } } for 401 (missing auth)', async () => {
+      const res = await fetch(`${serverAddress}/pins`, { method: 'GET' })
+      expect(res.status).toBe(401)
+      const body = (await res.json()) as { error: { reason: string; details?: string } }
+      expect(typeof body.error.reason).toBe('string')
+      expect(typeof body.error.details).toBe('string')
+    })
+
+    it('returns spec error shape for 400 (malformed body, missing cid)', async () => {
+      const res = await fetch(`${serverAddress}/pins`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-token' },
+        body: JSON.stringify({ name: 'no cid here' }),
+      })
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: { reason: string; details?: string } }
+      expect(body.error.reason).toBe('BAD_REQUEST')
+      expect(typeof body.error.details).toBe('string')
+    })
+
+    it('returns spec error shape for 400 (malformed update body)', async () => {
+      const res = await fetch(`${serverAddress}/pins/anything`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-token' },
+        body: JSON.stringify({ name: 123 }),
+      })
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: { reason: string; details?: string } }
+      expect(body.error.reason).toBe('BAD_REQUEST')
+    })
+
+    it('returns spec error shape for 404 (unknown pin)', async () => {
+      const res = await fetch(`${serverAddress}/pins/does-not-exist`, {
+        headers: { Authorization: 'Bearer test-token' },
+      })
+      expect(res.status).toBe(404)
+      const body = (await res.json()) as { error: { reason: string; details?: string } }
+      expect(body.error.reason).toBe('NOT_FOUND')
+    })
+
+    it('returns spec error shape for 500 (internal error)', async () => {
+      vi.spyOn(pinStore, 'get').mockRejectedValueOnce(new Error('boom'))
+      const res = await fetch(`${serverAddress}/pins/anything`, {
+        headers: { Authorization: 'Bearer test-token' },
+      })
+      expect(res.status).toBe(500)
+      const body = (await res.json()) as { error: { reason: string; details?: string } }
+      expect(body.error.reason).toBe('INTERNAL_ERROR')
+    })
   })
 
   describe('Block Transfer Verification', () => {

--- a/src/test/unit/filecoin-pinning-server.unit.test.ts
+++ b/src/test/unit/filecoin-pinning-server.unit.test.ts
@@ -41,6 +41,7 @@ describe('createFilecoinPinningServer auth selection', () => {
       privateKey: undefined,
       walletAddress: '0x0000000000000000000000000000000000000002',
       sessionKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+      accessToken: 'test-token',
     }
     const logger = createLogger(config)
 
@@ -178,5 +179,81 @@ describe('createFilecoinPinningServer auth selection', () => {
     await expect(createFilecoinPinningServer(config, logger, SERVICE_INFO)).rejects.toThrow(
       'Private key must be 32 bytes'
     )
+  })
+})
+
+describe('createFilecoinPinningServer access token guard', () => {
+  let server: any
+  let pinStore: any
+
+  const VALID_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(async () => {
+    if (server != null) {
+      await server.close()
+      server = undefined
+    }
+    if (pinStore != null) {
+      await pinStore.stop()
+      pinStore = undefined
+    }
+  })
+
+  it('should refuse to start when no access token and no allowNoAuth', async () => {
+    const config = {
+      ...createConfig(),
+      carStoragePath: TEST_OUTPUT_DIR,
+      port: 0,
+      privateKey: VALID_PRIVATE_KEY,
+      accessToken: undefined,
+      allowNoAuth: false,
+    }
+    const logger = createLogger(config)
+
+    await expect(createFilecoinPinningServer(config, logger, SERVICE_INFO)).rejects.toThrow(
+      'No access token configured'
+    )
+  })
+
+  it('should start without an access token when allowNoAuth is set', async () => {
+    const config = {
+      ...createConfig(),
+      carStoragePath: TEST_OUTPUT_DIR,
+      port: 0,
+      privateKey: VALID_PRIVATE_KEY,
+      accessToken: undefined,
+      allowNoAuth: true,
+    }
+    const logger = createLogger(config)
+
+    const result = await createFilecoinPinningServer(config, logger, SERVICE_INFO)
+    server = result.server
+    pinStore = result.pinStore
+
+    expect(server).toBeDefined()
+    expect(pinStore).toBeDefined()
+  })
+
+  it('should start when an access token is configured', async () => {
+    const config = {
+      ...createConfig(),
+      carStoragePath: TEST_OUTPUT_DIR,
+      port: 0,
+      privateKey: VALID_PRIVATE_KEY,
+      accessToken: 'secret-token',
+      allowNoAuth: false,
+    }
+    const logger = createLogger(config)
+
+    const result = await createFilecoinPinningServer(config, logger, SERVICE_INFO)
+    server = result.server
+    pinStore = result.pinStore
+
+    expect(server).toBeDefined()
+    expect(pinStore).toBeDefined()
   })
 })


### PR DESCRIPTION
Resolves #523 (part of #279). GA v1 pinning server cleanup. The server ships as beta; state loss across restarts is accepted, so this is cleanup only (no persistence work).

## What changed

### Refuse startup without an access token (breaking)
The server previously ran open to all requests when no token was configured. It now refuses to start unless an access token is set via `--access-token` / `ACCESS_TOKEN`, or the operator explicitly opts out with `--allow-no-auth` / `ALLOW_NO_AUTH`. The check runs after synapse-config validation but before the network call, with a friendly stderr hint on failure.

### IPFS Pinning Service spec error shape
All error responses now use `{ error: { reason, details } }` (per the [spec](https://ipfs.github.io/pinning-services-api-spec/)) instead of `{ error: string }`, via a shared `sendError` helper. Covers 400 / 401 / 403 / 404 / 500.

### Typed + validated `POST` and `DELETE /pins/:requestId`
Removed the `any`-typed handlers and added `FastifyRequest` generics. A shared `parsePinMutationBody` validates `name` / `origins` / `meta` (also applied to `POST /pins`); malformed bodies return `400`. Added auth-context (`401`) guards.

### Docs
README pinning-server section now notes the beta status (in-memory, state lost across restarts), the access-token requirement + `--allow-no-auth`, and that `delegates` is always `[]` (each pin uses a short-lived Helia node, so there's no long-lived node to advertise). Added `ACCESS_TOKEN` / `ALLOW_NO_AUTH` to the env-var list.

## Tests
- New unit tests for the startup guard (no token → throws; `--allow-no-auth` → starts; token → starts).
- New integration tests asserting the spec error shape for 400 / 401 / 404 / 500 (500 via a `pinStore.get` spy) and malformed update bodies.
- Updated existing fixtures: integration config sets `accessToken: 'test-token'`; unit session-key success case sets a token.
- Full suite green: 524 unit + 13 integration, lint + typecheck pass.

## Reviewer notes
- **Breaking**: existing deployments relying on token-less startup must now pass `--allow-no-auth` or configure a token.
- `--allow-no-auth` flag name is open to change (per the issue).