### PR TITLE
fix(cli): distinct exit code 2 for cancelled or unconfirmed operations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ One-shot CLI commands should keep Commander.js wiring separate from command beha
 
 - `src/commands/<command>.ts` parses Commander arguments/options, calls the runner, catches errors, and owns CLI exit codes.
 - `src/<command>/` contains business logic and user-facing terminal UI such as spinners, status output, cancellation messages, and cleanup.
-- Runner functions signal failures by throwing (never call `process.exit()`). The one exception is the "incomplete" outcome (see [Exit codes](#exit-codes)): a runner may set `process.exitCode = EXIT_CODE_INCOMPLETE` and return normally rather than throw.
+- Runner functions signal failures by throwing (never call `process.exit()`). The one exception is the "incomplete" outcome (see [Exit codes](#exit-codes)): a runner may call `setIncompleteExitCode()` and return normally rather than throw. Deep helpers that abort by throwing use `CliIncomplete`, which the runner's outer catch maps to the same call.
 - Command wiring should not print errors that the runner already displayed.
 - Use `finally` blocks for cleanup that must happen on both success and failure.
 
@@ -55,12 +55,12 @@ One-shot commands use three exit codes so scripts can distinguish outcomes (`EXI
 | --- | --- | --- |
 | `0` | Success | Runner returns normally; wrapper exits `process.exitCode ?? 0`. |
 | `1` | Failure — the operation errored | Runner throws; the Commander wrapper catches and exits `1`. |
-| `2` | Incomplete — neither succeeded nor failed | Runner sets `process.exitCode = EXIT_CODE_INCOMPLETE` and returns normally (does **not** throw). |
+| `2` | Incomplete — neither succeeded nor failed | Runner calls `setIncompleteExitCode()` and returns normally (does **not** throw). |
 
 Use `2` (incomplete) when the user deliberately stops an operation or a requested confirmation never arrives — for example declining a destructive `confirm()` prompt, or a `--wait` confirmation that times out after the transaction was already submitted. These are not errors (so `1` would be misleading) but they are not successes either (so `0` would hide them from scripts).
 
 Guidelines:
 
-- Set the code defensively so a prior failure is never downgraded: `if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE`.
+- Mark the outcome with `setIncompleteExitCode()` from `src/common/cli-errors.ts`; the helper never downgrades a prior failure code.
 - When a command fans out over multiple targets (e.g. `remove` over several data sets), a hard failure (`process.exit(1)`) still takes precedence over an incomplete (`2`).
 - `2` overlaps with the "usage error" convention some CLIs use, but Commander already exits `1` on argument-parse errors here, so `2` is reserved exclusively for the incomplete outcome.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,26 @@ One-shot CLI commands should keep Commander.js wiring separate from command beha
 
 - `src/commands/<command>.ts` parses Commander arguments/options, calls the runner, catches errors, and owns CLI exit codes.
 - `src/<command>/` contains business logic and user-facing terminal UI such as spinners, status output, cancellation messages, and cleanup.
-- Runner functions must throw errors instead of calling `process.exit()` or setting `process.exitCode`.
+- Runner functions signal failures by throwing (never call `process.exit()`). The one exception is the "incomplete" outcome (see [Exit codes](#exit-codes)): a runner may set `process.exitCode = EXIT_CODE_INCOMPLETE` and return normally rather than throw.
 - Command wiring should not print errors that the runner already displayed.
 - Use `finally` blocks for cleanup that must happen on both success and failure.
 
 The `server` command is long-running and manages its own process lifecycle, so this one-shot command pattern does not apply there.
+
+### Exit codes
+
+One-shot commands use three exit codes so scripts can distinguish outcomes (`EXIT_CODE_INCOMPLETE` lives in `src/common/cli-errors.ts`):
+
+| Code | Meaning | How it is produced |
+| --- | --- | --- |
+| `0` | Success | Runner returns normally; wrapper exits `process.exitCode ?? 0`. |
+| `1` | Failure — the operation errored | Runner throws; the Commander wrapper catches and exits `1`. |
+| `2` | Incomplete — neither succeeded nor failed | Runner sets `process.exitCode = EXIT_CODE_INCOMPLETE` and returns normally (does **not** throw). |
+
+Use `2` (incomplete) when the user deliberately stops an operation or a requested confirmation never arrives — for example declining a destructive `confirm()` prompt, or a `--wait` confirmation that times out after the transaction was already submitted. These are not errors (so `1` would be misleading) but they are not successes either (so `0` would hide them from scripts).
+
+Guidelines:
+
+- Set the code defensively so a prior failure is never downgraded: `if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE`.
+- When a command fans out over multiple targets (e.g. `remove` over several data sets), a hard failure (`process.exit(1)`) still takes precedence over an incomplete (`2`).
+- `2` overlaps with the "usage error" convention some CLIs use, but Commander already exits `1` on argument-parse errors here, so `2` is reserved exclusively for the incomplete outcome.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,15 @@ const program = new Command()
   .version(packageVersion)
   .option('-v, --verbose', 'enable debug-level logging (sets LOG_LEVEL=debug)')
   .option('--no-update-check', 'skip check for updates')
+  .addHelpText(
+    'after',
+    `
+Exit codes:
+  0  success
+  1  error (the operation failed)
+  2  incomplete (the operation neither succeeded nor failed: a confirmation
+     was declined, or a --wait confirmation timed out after submission)`
+  )
 
 // Add subcommands
 for (const command of ALL_CLI_COMMANDS) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ Exit codes:
   0  success
   1  error (the operation failed)
   2  incomplete (the operation neither succeeded nor failed: a confirmation
-     was declined, or a --wait confirmation timed out after submission)`
+     was declined, or a requested confirmation wait timed out after submission)`
   )
 
 // Add subcommands

--- a/src/common/cli-errors.ts
+++ b/src/common/cli-errors.ts
@@ -1,7 +1,7 @@
 /**
  * Exit code for operations that neither succeeded nor errored: the user
  * cancelled (e.g. declining the `terminate` confirmation) or a requested
- * confirmation wait timed out (`rm --wait`). Distinct from `1`, which the
+ * confirmation wait timed out. Distinct from `1`, which the
  * Commander wrappers use for caught errors, so scripts can tell "incomplete"
  * apart from "failed".
  */

--- a/src/common/cli-errors.ts
+++ b/src/common/cli-errors.ts
@@ -8,6 +8,39 @@
 export const EXIT_CODE_INCOMPLETE = 2
 
 /**
+ * Marks the process outcome as incomplete (exit code 2) unless a failure
+ * code is already set. All incomplete-outcome sites go through this helper
+ * so a real failure (exit 1) is never downgraded to incomplete.
+ */
+export function setIncompleteExitCode(): void {
+  if ((process.exitCode ?? 0) === 0) {
+    process.exitCode = EXIT_CODE_INCOMPLETE
+  }
+}
+
+/**
+ * Sentinel error for user-cancelled operations in code that aborts by
+ * throwing (deep helpers where setting the exit code and returning would
+ * let the caller continue). The runner's outer catch detects it via
+ * {@link isCliIncomplete}, reports the cancellation, and calls
+ * {@link setIncompleteExitCode} instead of failing with exit 1.
+ */
+export class CliIncomplete extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'CliIncomplete'
+  }
+}
+
+/**
+ * Type guard for `CliIncomplete`. Used by runner outer catches to map a
+ * user cancellation to the incomplete exit code rather than a failure.
+ */
+export function isCliIncomplete(error: unknown): error is CliIncomplete {
+  return error instanceof CliIncomplete
+}
+
+/**
  * Sentinel error type for CLI runners that have already displayed the
  * user-facing failure message via clack/log/console.
  *

--- a/src/common/cli-errors.ts
+++ b/src/common/cli-errors.ts
@@ -1,4 +1,13 @@
 /**
+ * Exit code for operations that neither succeeded nor errored: the user
+ * cancelled (e.g. declining the `terminate` confirmation) or a requested
+ * confirmation wait timed out (`rm --wait`). Distinct from `1`, which the
+ * Commander wrappers use for caught errors, so scripts can tell "incomplete"
+ * apart from "failed".
+ */
+export const EXIT_CODE_INCOMPLETE = 2
+
+/**
  * Sentinel error type for CLI runners that have already displayed the
  * user-facing failure message via clack/log/console.
  *

--- a/src/core/piece/remove-all-pieces.ts
+++ b/src/core/piece/remove-all-pieces.ts
@@ -43,6 +43,13 @@ export interface RemoveAllPiecesResult {
   dataSetId: bigint
   totalPieces: number
   removedCount: number
+  /**
+   * Of the `removedCount` removals, how many were confirmed on-chain. Only
+   * meaningful when `waitForConfirmation` is true; otherwise stays 0 since no
+   * confirmation is awaited. `removedCount - confirmedCount` is the number of
+   * removals whose confirmation wait timed out (submitted but unconfirmed).
+   */
+  confirmedCount: number
   failedCount: number
   transactions: PieceRemovalResult[]
 }
@@ -137,6 +144,7 @@ export async function removeAllPieces(
       dataSetId,
       totalPieces: 0,
       removedCount: 0,
+      confirmedCount: 0,
       failedCount: 0,
       transactions: [],
     }
@@ -145,6 +153,7 @@ export async function removeAllPieces(
   // Remove each piece
   const transactions: PieceRemovalResult[] = []
   let removedCount = 0
+  let confirmedCount = 0
   let failedCount = 0
 
   for (let i = 0; i < pieces.length; i++) {
@@ -163,14 +172,21 @@ export async function removeAllPieces(
     onProgress?.({ type: 'removeAll:removing', data: { current, total: totalPieces, pieceCid } })
 
     try {
+      let pieceConfirmed = false
       const txHash = await removePiece(pieceCid, storageContext, {
         synapse,
         waitForConfirmation,
         logger,
+        onProgress: (event) => {
+          if (event.type === 'removePiece:complete') {
+            pieceConfirmed = event.data.confirmed
+          }
+        },
       })
 
       transactions.push({ pieceCid, txHash, success: true })
       removedCount++
+      if (pieceConfirmed) confirmedCount++
 
       onProgress?.({ type: 'removeAll:removed', data: { current, total: totalPieces, pieceCid, txHash } })
 
@@ -192,6 +208,7 @@ export async function removeAllPieces(
     dataSetId,
     totalPieces,
     removedCount,
+    confirmedCount,
     failedCount,
     transactions,
   }

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -293,7 +293,6 @@ export async function runTerminateDataSetCommand(dataSetId: number, options: Dat
         if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
         return
       }
-      }
 
       if (shouldWait === undefined) {
         const waitConfirm = await confirm({

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -1,7 +1,7 @@
 import { confirm, isCancel } from '@clack/prompts'
 import type { EnhancedDataSetInfo, Synapse } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
-import { CliFatal, isCliFatal } from '../common/cli-errors.js'
+import { CliFatal, EXIT_CODE_INCOMPLETE, isCliFatal } from '../common/cli-errors.js'
 import { type DataSetSummary, getDetailedDataSet, listDataSets } from '../core/data-set/index.js'
 import type { PieceInfo } from '../core/data-set/types.js'
 import { getClientAddress } from '../core/synapse/index.js'
@@ -290,6 +290,7 @@ export async function runTerminateDataSetCommand(dataSetId: number, options: Dat
       })
       if (isCancel(proceed) || !proceed) {
         cancel('Termination cancelled')
+        process.exitCode = EXIT_CODE_INCOMPLETE
         return
       }
 

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -290,8 +290,9 @@ export async function runTerminateDataSetCommand(dataSetId: number, options: Dat
       })
       if (isCancel(proceed) || !proceed) {
         cancel('Termination cancelled')
-        process.exitCode = EXIT_CODE_INCOMPLETE
+        if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
         return
+      }
       }
 
       if (shouldWait === undefined) {

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -1,7 +1,8 @@
 import { confirm, isCancel } from '@clack/prompts'
 import type { EnhancedDataSetInfo, Synapse } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
-import { CliFatal, EXIT_CODE_INCOMPLETE, isCliFatal } from '../common/cli-errors.js'
+import { WaitForTransactionReceiptTimeoutError } from 'viem'
+import { CliFatal, isCliFatal, setIncompleteExitCode } from '../common/cli-errors.js'
 import { type DataSetSummary, getDetailedDataSet, listDataSets } from '../core/data-set/index.js'
 import type { PieceInfo } from '../core/data-set/types.js'
 import { getClientAddress } from '../core/synapse/index.js'
@@ -290,7 +291,7 @@ export async function runTerminateDataSetCommand(dataSetId: number, options: Dat
       })
       if (isCancel(proceed) || !proceed) {
         cancel('Termination cancelled')
-        if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
+        setIncompleteExitCode()
         return
       }
 
@@ -311,7 +312,19 @@ export async function runTerminateDataSetCommand(dataSetId: number, options: Dat
 
     if (shouldWait) {
       spinner.message(`Waiting for confirmation: ${txHash}...`)
-      const receipt = await synapse.client.waitForTransactionReceipt({ hash: txHash })
+      let receipt: Awaited<ReturnType<typeof synapse.client.waitForTransactionReceipt>>
+      try {
+        receipt = await synapse.client.waitForTransactionReceipt({ hash: txHash })
+      } catch (error) {
+        // The transaction was submitted but the confirmation wait timed out,
+        // matching the incomplete outcome `remove --wait` reports.
+        if (error instanceof WaitForTransactionReceiptTimeoutError) {
+          spinner.stop(`Transaction submitted, confirmation still pending: ${txHash}`)
+          setIncompleteExitCode()
+          return
+        }
+        throw error
+      }
       if (receipt.status !== 'success') {
         throw new Error(`Termination transaction reverted: ${txHash}`)
       }

--- a/src/payments/fund.ts
+++ b/src/payments/fund.ts
@@ -4,11 +4,11 @@
  * Adjusts funds to exactly match a target runway (days) or a target deposited amount.
  */
 
-import { confirm } from '@clack/prompts'
+import { confirm, isCancel } from '@clack/prompts'
 import type { Synapse } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
 import { parseUnits } from 'viem'
-import { CliFatal, isCliFatal } from '../common/cli-errors.js'
+import { CliFatal, CliIncomplete, isCliFatal, isCliIncomplete, setIncompleteExitCode } from '../common/cli-errors.js'
 import { MIN_RUNWAY_DAYS } from '../common/constants.js'
 import {
   checkUSDFCBalance,
@@ -54,8 +54,8 @@ async function ensureBelowThirtyDaysAllowed(opts: {
     message: 'Proceed with reducing runway below 30 days?',
     initialValue: false,
   })
-  if (!proceed) {
-    throw new Error('Fund adjustment cancelled by user')
+  if (isCancel(proceed) || !proceed) {
+    throw new CliIncomplete('Fund adjustment cancelled by user')
   }
 }
 
@@ -82,8 +82,8 @@ async function performAdjustment(params: {
         message: `Deposit ${formatUSDFC(needed)} USDFC?`,
         initialValue: false,
       })
-      if (!proceed) {
-        throw new Error('Deposit cancelled by user')
+      if (isCancel(proceed) || !proceed) {
+        throw new CliIncomplete('Deposit cancelled by user')
       }
     }
     spinner.start(depositMsg)
@@ -100,8 +100,8 @@ async function performAdjustment(params: {
         message: `Withdraw ${formatUSDFC(withdrawAmount)} USDFC?`,
         initialValue: false,
       })
-      if (!proceed) {
-        throw new Error('Withdraw cancelled by user')
+      if (isCancel(proceed) || !proceed) {
+        throw new CliIncomplete('Withdraw cancelled by user')
       }
     }
     spinner.start(withdrawMsg)
@@ -353,6 +353,12 @@ export async function runFund(options: FundOptions): Promise<void> {
     await printSummary(synapse)
     outro('Fund adjustment completed')
   } catch (error) {
+    if (isCliIncomplete(error)) {
+      spinner.stop()
+      cancel(error.message)
+      setIncompleteExitCode()
+      return
+    }
     if (isCliFatal(error)) {
       spinner.stop()
       throw error

--- a/src/payments/interactive.ts
+++ b/src/payments/interactive.ts
@@ -9,7 +9,7 @@
 import { cancel, confirm, isCancel, password, text } from '@clack/prompts'
 import pc from 'picocolors'
 import { parseUnits } from 'viem'
-import { CliFatal, EXIT_CODE_INCOMPLETE, isCliFatal } from '../common/cli-errors.js'
+import { CliFatal, isCliFatal, setIncompleteExitCode } from '../common/cli-errors.js'
 import {
   calculateDepositCapacity,
   checkAndSetAllowances,
@@ -71,7 +71,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
         cancel('Setup cancelled')
         // User cancelled: not a failure. Signal "incomplete" (2) distinctly
         // from success (0) and a caught error (1).
-        if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
+        setIncompleteExitCode()
         return
       }
 
@@ -167,7 +167,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
     if (isCancel(shouldDeposit)) {
       cancel('Setup cancelled')
-      if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
+      setIncompleteExitCode()
       return
     }
 
@@ -200,7 +200,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
       if (isCancel(amountStr)) {
         cancel('Setup cancelled')
-        if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
+        setIncompleteExitCode()
         return
       }
 

--- a/src/payments/interactive.ts
+++ b/src/payments/interactive.ts
@@ -9,7 +9,7 @@
 import { cancel, confirm, isCancel, password, text } from '@clack/prompts'
 import pc from 'picocolors'
 import { parseUnits } from 'viem'
-import { CliFatal, isCliFatal } from '../common/cli-errors.js'
+import { CliFatal, EXIT_CODE_INCOMPLETE, isCliFatal } from '../common/cli-errors.js'
 import {
   calculateDepositCapacity,
   checkAndSetAllowances,
@@ -69,7 +69,10 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
       if (isCancel(input)) {
         cancel('Setup cancelled')
-        throw new CliFatal('Setup cancelled')
+        // User cancelled: not a failure. Signal "incomplete" (2) distinctly
+        // from success (0) and a caught error (1).
+        if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
+        return
       }
 
       // Add 0x prefix if it was missing
@@ -164,7 +167,8 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
     if (isCancel(shouldDeposit)) {
       cancel('Setup cancelled')
-      throw new CliFatal('Setup cancelled')
+      if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
+      return
     }
 
     if (shouldDeposit) {
@@ -196,7 +200,8 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
       if (isCancel(amountStr)) {
         cancel('Setup cancelled')
-        throw new CliFatal('Setup cancelled')
+        if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
+        return
       }
 
       depositAmount = parseUnits(amountStr, 18)

--- a/src/rm/remove-all-pieces.ts
+++ b/src/rm/remove-all-pieces.ts
@@ -183,8 +183,13 @@ export async function runRmAllPieces(options: RmAllPiecesOptions): Promise<RmAll
 
     // Time-out waiting for requested confirmation on one or more removals,
     // leaving them unconfirmed. Signal that distinctly so scripts can tell it
-    // apart from both success (0) and a caught error (1).
-    if (options.waitForConfirmation === true && result.confirmedCount < result.removedCount) {
+    // apart from both success (0) and a caught error (1). Set it defensively so
+    // a prior non-zero exit code is never downgraded.
+    if (
+      options.waitForConfirmation === true &&
+      result.confirmedCount < result.removedCount &&
+      (process.exitCode ?? 0) === 0
+    ) {
       process.exitCode = EXIT_CODE_INCOMPLETE
     }
 

--- a/src/rm/remove-all-pieces.ts
+++ b/src/rm/remove-all-pieces.ts
@@ -11,6 +11,7 @@
 import { confirm, isCancel } from '@clack/prompts'
 import pc from 'picocolors'
 import pino from 'pino'
+import { EXIT_CODE_INCOMPLETE } from '../common/cli-errors.js'
 import { type RemoveAllPiecesProgressEvents, removeAllPieces } from '../core/piece/index.js'
 import { initializeSynapse } from '../core/synapse/index.js'
 import { parseCLIAuth } from '../utils/cli-auth.js'
@@ -123,7 +124,17 @@ export async function runRmAllPieces(options: RmAllPiecesOptions): Promise<RmAll
 
       if (isCancel(shouldProceed) || !shouldProceed) {
         cancel('Remove cancelled by user')
-        throw new Error('Remove cancelled by user')
+        // User declined the destructive confirmation: not a failure, but the
+        // removal did not happen. Signal "incomplete" (2) distinctly from both
+        // success (0) and a caught error (1), matching `data-set terminate`.
+        if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
+        return {
+          dataSetId,
+          totalPieces: pieceCount,
+          removedCount: 0,
+          failedCount: 0,
+          transactions: [],
+        }
       }
     }
 
@@ -169,6 +180,13 @@ export async function runRmAllPieces(options: RmAllPiecesOptions): Promise<RmAll
       waitForConfirmation: options.waitForConfirmation ?? false,
       pieces: activePieces,
     })
+
+    // Time-out waiting for requested confirmation on one or more removals,
+    // leaving them unconfirmed. Signal that distinctly so scripts can tell it
+    // apart from both success (0) and a caught error (1).
+    if (options.waitForConfirmation === true && result.confirmedCount < result.removedCount) {
+      process.exitCode = EXIT_CODE_INCOMPLETE
+    }
 
     // Ensure spinner is stopped before displaying results
     spinner.stop(

--- a/src/rm/remove-all-pieces.ts
+++ b/src/rm/remove-all-pieces.ts
@@ -11,7 +11,7 @@
 import { confirm, isCancel } from '@clack/prompts'
 import pc from 'picocolors'
 import pino from 'pino'
-import { EXIT_CODE_INCOMPLETE } from '../common/cli-errors.js'
+import { setIncompleteExitCode } from '../common/cli-errors.js'
 import { type RemoveAllPiecesProgressEvents, removeAllPieces } from '../core/piece/index.js'
 import { initializeSynapse } from '../core/synapse/index.js'
 import { parseCLIAuth } from '../utils/cli-auth.js'
@@ -127,7 +127,7 @@ export async function runRmAllPieces(options: RmAllPiecesOptions): Promise<RmAll
         // User declined the destructive confirmation: not a failure, but the
         // removal did not happen. Signal "incomplete" (2) distinctly from both
         // success (0) and a caught error (1), matching `data-set terminate`.
-        if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
+        setIncompleteExitCode()
         return {
           dataSetId,
           totalPieces: pieceCount,
@@ -181,21 +181,25 @@ export async function runRmAllPieces(options: RmAllPiecesOptions): Promise<RmAll
       pieces: activePieces,
     })
 
+    // Per-piece failures are collected by the core function rather than
+    // thrown, so surface them through the exit code here: any failed piece
+    // means the command failed (1), which takes precedence over incomplete.
+    if (result.failedCount > 0) {
+      process.exitCode = 1
+    }
+
     // Time-out waiting for requested confirmation on one or more removals,
     // leaving them unconfirmed. Signal that distinctly so scripts can tell it
-    // apart from both success (0) and a caught error (1). Set it defensively so
-    // a prior non-zero exit code is never downgraded.
-    if (
-      options.waitForConfirmation === true &&
-      result.confirmedCount < result.removedCount &&
-      (process.exitCode ?? 0) === 0
-    ) {
-      process.exitCode = EXIT_CODE_INCOMPLETE
+    // apart from both success (0) and a caught error (1).
+    const confirmationPending = options.waitForConfirmation === true && result.confirmedCount < result.removedCount
+    if (confirmationPending) {
+      setIncompleteExitCode()
     }
 
     // Ensure spinner is stopped before displaying results
+    const spinnerIcon = result.failedCount > 0 ? pc.red('✗') : pc.green('✓')
     spinner.stop(
-      `${pc.green('✓')} Removal complete: ${result.removedCount}/${result.totalPieces} succeeded, ${result.failedCount} failed`
+      `${spinnerIcon} Removal complete: ${result.removedCount}/${result.totalPieces} succeeded, ${result.failedCount} failed`
     )
 
     // Display results
@@ -213,6 +217,8 @@ export async function runRmAllPieces(options: RmAllPiecesOptions): Promise<RmAll
 
     if (result.failedCount > 0) {
       outro(`Remove completed with ${result.failedCount} failure(s)`)
+    } else if (confirmationPending) {
+      outro('Remove submitted; confirmation still pending')
     } else {
       outro('Remove completed successfully')
     }

--- a/src/rm/remove-piece.ts
+++ b/src/rm/remove-piece.ts
@@ -114,7 +114,7 @@ export async function runRmPiece(options: RmPieceOptions): Promise<RmPieceResult
       waitForConfirmation: options.waitForConfirmation ?? false,
     })
 
-    // A requested confirmation wait that timed out leaves the removal
+    // Time-out waiting for requested confirmation, leaving the removal
     // unconfirmed. Signal that distinctly so scripts can tell it apart from
     // both success (0) and a caught error (1).
     if (options.waitForConfirmation === true && !isConfirmed) {

--- a/src/rm/remove-piece.ts
+++ b/src/rm/remove-piece.ts
@@ -9,6 +9,7 @@
  */
 import pc from 'picocolors'
 import pino from 'pino'
+import { EXIT_CODE_INCOMPLETE } from '../common/cli-errors.js'
 import { type RemovePieceProgressEvents, removePiece } from '../core/piece/index.js'
 import { initializeSynapse } from '../core/synapse/index.js'
 import { parseCLIAuth } from '../utils/cli-auth.js'
@@ -112,6 +113,13 @@ export async function runRmPiece(options: RmPieceOptions): Promise<RmPieceResult
       onProgress,
       waitForConfirmation: options.waitForConfirmation ?? false,
     })
+
+    // A requested confirmation wait that timed out leaves the removal
+    // unconfirmed. Signal that distinctly so scripts can tell it apart from
+    // both success (0) and a caught error (1).
+    if (options.waitForConfirmation === true && !isConfirmed) {
+      process.exitCode = EXIT_CODE_INCOMPLETE
+    }
 
     // Ensure spinner is stopped before displaying results
     spinner.stop(`${pc.green('✓')} Piece removed${isConfirmed ? ' and confirmed' : ' (confirmation pending)'}`)

--- a/src/rm/remove-piece.ts
+++ b/src/rm/remove-piece.ts
@@ -116,8 +116,9 @@ export async function runRmPiece(options: RmPieceOptions): Promise<RmPieceResult
 
     // Time-out waiting for requested confirmation, leaving the removal
     // unconfirmed. Signal that distinctly so scripts can tell it apart from
-    // both success (0) and a caught error (1).
-    if (options.waitForConfirmation === true && !isConfirmed) {
+    // both success (0) and a caught error (1). Set it defensively so a prior
+    // non-zero exit code is never downgraded.
+    if (options.waitForConfirmation === true && !isConfirmed && (process.exitCode ?? 0) === 0) {
       process.exitCode = EXIT_CODE_INCOMPLETE
     }
 

--- a/src/rm/remove-piece.ts
+++ b/src/rm/remove-piece.ts
@@ -9,7 +9,7 @@
  */
 import pc from 'picocolors'
 import pino from 'pino'
-import { EXIT_CODE_INCOMPLETE } from '../common/cli-errors.js'
+import { setIncompleteExitCode } from '../common/cli-errors.js'
 import { type RemovePieceProgressEvents, removePiece } from '../core/piece/index.js'
 import { initializeSynapse } from '../core/synapse/index.js'
 import { parseCLIAuth } from '../utils/cli-auth.js'
@@ -116,10 +116,10 @@ export async function runRmPiece(options: RmPieceOptions): Promise<RmPieceResult
 
     // Time-out waiting for requested confirmation, leaving the removal
     // unconfirmed. Signal that distinctly so scripts can tell it apart from
-    // both success (0) and a caught error (1). Set it defensively so a prior
-    // non-zero exit code is never downgraded.
-    if (options.waitForConfirmation === true && !isConfirmed && (process.exitCode ?? 0) === 0) {
-      process.exitCode = EXIT_CODE_INCOMPLETE
+    // both success (0) and a caught error (1).
+    const confirmationPending = options.waitForConfirmation === true && !isConfirmed
+    if (confirmationPending) {
+      setIncompleteExitCode()
     }
 
     // Ensure spinner is stopped before displaying results
@@ -142,7 +142,11 @@ export async function runRmPiece(options: RmPieceOptions): Promise<RmPieceResult
     // Clean up WebSocket providers to allow process termination
     // Synapse instances don't require explicit cleanup
 
-    outro('Remove completed successfully')
+    if (confirmationPending) {
+      outro('Remove submitted; confirmation still pending')
+    } else {
+      outro('Remove completed successfully')
+    }
 
     return result
   } catch (error) {

--- a/src/session/run-authorize.ts
+++ b/src/session/run-authorize.ts
@@ -11,6 +11,7 @@ import { confirm, isCancel } from '@clack/prompts'
 import pc from 'picocolors'
 import { type Account, createWalletClient, getAddress, type Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
+import { EXIT_CODE_INCOMPLETE } from '../common/cli-errors.js'
 import {
   type AuthorizeSessionProgressEvents,
   type AuthorizeSessionResult,
@@ -23,7 +24,14 @@ import { parseValidityDays } from './parse-validity-days.js'
 import { resolveNetwork } from './resolve-network.js'
 import type { SessionAuthorizeOptions } from './types.js'
 
-export async function runSessionAuthorize(options: SessionAuthorizeOptions): Promise<AuthorizeSessionResult> {
+/**
+ * Authorize a session address on-chain. Returns the authorization result, or
+ * `undefined` when the user declines the interactive confirmation (in which
+ * case the process exit code is set to {@link EXIT_CODE_INCOMPLETE}).
+ */
+export async function runSessionAuthorize(
+  options: SessionAuthorizeOptions
+): Promise<AuthorizeSessionResult | undefined> {
   intro(pc.bold('Filecoin Pin Session Authorize'))
 
   const privateKey = options.privateKey || process.env.PRIVATE_KEY
@@ -69,7 +77,10 @@ export async function runSessionAuthorize(options: SessionAuthorizeOptions): Pro
     })
     if (isCancel(proceed) || proceed !== true) {
       cancel('Authorization cancelled')
-      throw new Error('Authorization cancelled')
+      // User declined: not a failure, but nothing was authorized. Signal
+      // "incomplete" (2) distinctly from success (0) and a caught error (1).
+      if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
+      return undefined
     }
   }
 

--- a/src/session/run-authorize.ts
+++ b/src/session/run-authorize.ts
@@ -11,7 +11,7 @@ import { confirm, isCancel } from '@clack/prompts'
 import pc from 'picocolors'
 import { type Account, createWalletClient, getAddress, type Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { EXIT_CODE_INCOMPLETE } from '../common/cli-errors.js'
+import { setIncompleteExitCode } from '../common/cli-errors.js'
 import {
   type AuthorizeSessionProgressEvents,
   type AuthorizeSessionResult,
@@ -79,7 +79,7 @@ export async function runSessionAuthorize(
       cancel('Authorization cancelled')
       // User declined: not a failure, but nothing was authorized. Signal
       // "incomplete" (2) distinctly from success (0) and a caught error (1).
-      if ((process.exitCode ?? 0) === 0) process.exitCode = EXIT_CODE_INCOMPLETE
+      setIncompleteExitCode()
       return undefined
     }
   }

--- a/src/test/unit/data-set.test.ts
+++ b/src/test/unit/data-set.test.ts
@@ -1,4 +1,5 @@
 import { METADATA_KEYS } from '@filoz/synapse-sdk'
+import { WaitForTransactionReceiptTimeoutError } from 'viem'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DataSetSummary, PieceInfo } from '../../core/data-set/types.js'
 import {
@@ -518,7 +519,7 @@ describe('runTerminateDataSetCommand', () => {
   })
 
   it('exits with code 2 when the user cancels the confirmation prompt', async () => {
-    mockIsInteractive.mockReturnValue(true)
+    mockIsInteractive.mockReturnValueOnce(true)
     mockConfirm.mockResolvedValueOnce(false)
 
     await runTerminateDataSetCommand(158, {
@@ -546,6 +547,21 @@ describe('runTerminateDataSetCommand', () => {
     expect(mockTerminateDataSet).toHaveBeenCalledWith({ dataSetId: 158n })
     expect(mockWaitForTransactionReceipt).toHaveBeenCalledWith({ hash: '0xtxhash123' })
     expect(displayDataSetListMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('exits with code 2 when the confirmation wait times out', async () => {
+    mockWaitForTransactionReceipt.mockRejectedValueOnce(
+      new WaitForTransactionReceiptTimeoutError({ hash: '0xtxhash123' })
+    )
+
+    await runTerminateDataSetCommand(158, {
+      privateKey: 'test-key',
+      rpcUrl: 'wss://sample',
+      wait: true,
+    })
+
+    expect(mockTerminateDataSet).toHaveBeenCalledWith({ dataSetId: 158n })
+    expect(process.exitCode).toBe(2)
   })
 
   it('rejects termination for read-only accounts', async () => {

--- a/src/test/unit/data-set.test.ts
+++ b/src/test/unit/data-set.test.ts
@@ -20,6 +20,9 @@ const {
   mockTerminateDataSet,
   mockWaitForTransactionReceipt,
   mockSynapseCreate,
+  mockIsInteractive,
+  mockConfirm,
+  mockIsCancel,
   state,
 } = vi.hoisted(() => {
   const displayDataSetListMock = vi.fn()
@@ -37,6 +40,9 @@ const {
   const mockGetPdpDataSet = vi.fn()
   const mockTerminateDataSet = vi.fn()
   const mockWaitForTransactionReceipt = vi.fn()
+  const mockIsInteractive = vi.fn(() => false)
+  const mockConfirm = vi.fn(async () => true)
+  const mockIsCancel = vi.fn(() => false)
   const state = {
     pieceMetadata: {} as Record<string, string>,
     pieceList: [] as Array<{ pieceId: bigint; pieceCid: string }>,
@@ -112,6 +118,9 @@ const {
     mockWaitForTransactionReceipt,
     mockSynapseCreate,
     mockCreateContext,
+    mockIsInteractive,
+    mockConfirm,
+    mockIsCancel,
     state,
   }
 })
@@ -131,7 +140,7 @@ vi.mock('../../utils/cli-helpers.js', () => ({
   outro: vi.fn(),
   cancel: cancelMock,
   createSpinner: () => spinnerMock,
-  isInteractive: () => false,
+  isInteractive: mockIsInteractive,
 }))
 
 vi.mock('../../utils/cli-logger.js', () => ({
@@ -144,8 +153,8 @@ vi.mock('../../utils/cli-logger.js', () => ({
 }))
 
 vi.mock('@clack/prompts', () => ({
-  confirm: vi.fn(async () => true),
-  isCancel: vi.fn(() => false),
+  confirm: mockConfirm,
+  isCancel: mockIsCancel,
 }))
 
 // Use shared SDK mock with custom extensions for dataset command testing
@@ -506,6 +515,20 @@ describe('runTerminateDataSetCommand', () => {
     expect(mockTerminateDataSet).toHaveBeenCalledWith({ dataSetId: 158n })
     expect(mockWaitForTransactionReceipt).not.toHaveBeenCalled()
     expect(displayDataSetListMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('exits with code 2 when the user cancels the confirmation prompt', async () => {
+    mockIsInteractive.mockReturnValue(true)
+    mockConfirm.mockResolvedValueOnce(false)
+
+    await runTerminateDataSetCommand(158, {
+      privateKey: 'test-key',
+      rpcUrl: 'wss://sample',
+    })
+
+    expect(mockTerminateDataSet).not.toHaveBeenCalled()
+    expect(cancelMock).toHaveBeenCalledWith('Termination cancelled')
+    expect(process.exitCode).toBe(2)
   })
 
   it('terminates a dataset and waits for confirmation', async () => {

--- a/src/test/unit/remove-all-cmd.test.ts
+++ b/src/test/unit/remove-all-cmd.test.ts
@@ -123,4 +123,20 @@ describe('runRmAllPieces exit codes', () => {
 
     expect(process.exitCode).toBe(0)
   })
+
+  it('does not downgrade a prior non-zero exit code on wait timeout', async () => {
+    process.exitCode = 1
+    mockRemoveAllPieces.mockResolvedValueOnce({
+      dataSetId: 123,
+      totalPieces: 2,
+      removedCount: 2,
+      confirmedCount: 1,
+      failedCount: 0,
+      transactions: [],
+    })
+
+    await runRmAllPieces({ ...baseOptions, force: true, waitForConfirmation: true })
+
+    expect(process.exitCode).toBe(1)
+  })
 })

--- a/src/test/unit/remove-all-cmd.test.ts
+++ b/src/test/unit/remove-all-cmd.test.ts
@@ -124,6 +124,56 @@ describe('runRmAllPieces exit codes', () => {
     expect(process.exitCode).toBe(0)
   })
 
+  it('exits with code 1 when some pieces fail to remove', async () => {
+    mockRemoveAllPieces.mockResolvedValueOnce({
+      dataSetId: 123,
+      totalPieces: 2,
+      removedCount: 1,
+      confirmedCount: 0,
+      failedCount: 1,
+      transactions: [{ pieceCid: 'bafkpiece2', success: false, error: 'revert' }],
+    })
+
+    await runRmAllPieces({ ...baseOptions, force: true })
+
+    expect(process.exitCode).toBe(1)
+    expect(mockOutro).toHaveBeenCalledWith('Remove completed with 1 failure(s)')
+  })
+
+  it('exits with code 1 when every piece fails during a confirmation wait', async () => {
+    mockRemoveAllPieces.mockResolvedValueOnce({
+      dataSetId: 123,
+      totalPieces: 2,
+      removedCount: 0,
+      confirmedCount: 0,
+      failedCount: 2,
+      transactions: [
+        { pieceCid: 'bafkpiece1', success: false, error: 'revert' },
+        { pieceCid: 'bafkpiece2', success: false, error: 'revert' },
+      ],
+    })
+
+    await runRmAllPieces({ ...baseOptions, force: true, waitForConfirmation: true })
+
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('reports a pending outro instead of success on wait timeout', async () => {
+    mockRemoveAllPieces.mockResolvedValueOnce({
+      dataSetId: 123,
+      totalPieces: 2,
+      removedCount: 2,
+      confirmedCount: 1,
+      failedCount: 0,
+      transactions: [],
+    })
+
+    await runRmAllPieces({ ...baseOptions, force: true, waitForConfirmation: true })
+
+    expect(mockOutro).toHaveBeenCalledWith('Remove submitted; confirmation still pending')
+    expect(mockOutro).not.toHaveBeenCalledWith('Remove completed successfully')
+  })
+
   it('does not downgrade a prior non-zero exit code on wait timeout', async () => {
     process.exitCode = 1
     mockRemoveAllPieces.mockResolvedValueOnce({

--- a/src/test/unit/remove-all-cmd.test.ts
+++ b/src/test/unit/remove-all-cmd.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runRmAllPieces } from '../../rm/remove-all-pieces.js'
+import type { RmAllPiecesOptions } from '../../rm/types.js'
+
+const {
+  mockIntro,
+  mockOutro,
+  mockCancel,
+  mockCreateSpinner,
+  mockIsInteractive,
+  mockParseCLIAuth,
+  mockInitializeSynapse,
+  mockGetDataSetPieces,
+  mockRemoveAllPieces,
+  mockConfirm,
+  mockIsCancel,
+  state,
+} = vi.hoisted(() => {
+  const spinner = { start: vi.fn(), stop: vi.fn(), message: vi.fn(), clear: vi.fn() }
+  const state = {
+    pieces: [
+      { pieceCid: 'bafkpiece1', status: 'ACTIVE' },
+      { pieceCid: 'bafkpiece2', status: 'ACTIVE' },
+    ],
+  }
+  const mockStorageContext = {
+    dataSetId: 123n,
+    provider: { pdp: { serviceURL: 'https://provider.example.com' } },
+  }
+  return {
+    mockIntro: vi.fn(),
+    mockOutro: vi.fn(),
+    mockCancel: vi.fn(),
+    mockCreateSpinner: vi.fn(() => spinner),
+    mockIsInteractive: vi.fn(() => true),
+    mockParseCLIAuth: vi.fn(() => ({ privateKey: '0xabc', rpcUrl: 'wss://rpc' })),
+    mockInitializeSynapse: vi.fn(() => ({
+      chain: { name: 'calibration' },
+      storage: { createContext: vi.fn(async () => mockStorageContext) },
+    })),
+    mockGetDataSetPieces: vi.fn(async () => ({ pieces: state.pieces })),
+    mockRemoveAllPieces: vi.fn(),
+    mockConfirm: vi.fn(),
+    mockIsCancel: vi.fn(() => false),
+    state,
+  }
+})
+
+vi.mock('@clack/prompts', () => ({ confirm: mockConfirm, isCancel: mockIsCancel }))
+vi.mock('../../utils/cli-helpers.js', () => ({
+  intro: mockIntro,
+  outro: mockOutro,
+  cancel: mockCancel,
+  createSpinner: mockCreateSpinner,
+  isInteractive: mockIsInteractive,
+}))
+vi.mock('../../utils/cli-auth.js', () => ({ parseCLIAuth: mockParseCLIAuth }))
+vi.mock('../../utils/cli-logger.js', () => ({
+  log: { line: vi.fn(), flush: vi.fn(), spinnerSection: vi.fn() },
+}))
+vi.mock('../../core/synapse/index.js', () => ({ initializeSynapse: mockInitializeSynapse }))
+vi.mock('../../core/piece/index.js', () => ({ removeAllPieces: mockRemoveAllPieces }))
+vi.mock('../../core/data-set/get-data-set-pieces.js', () => ({ getDataSetPieces: mockGetDataSetPieces }))
+vi.mock('../../core/data-set/types.js', () => ({
+  PieceStatus: { ACTIVE: 'ACTIVE', PENDING_REMOVAL: 'PENDING_REMOVAL' },
+}))
+
+describe('runRmAllPieces exit codes', () => {
+  const baseOptions: RmAllPiecesOptions = { dataSet: '123', all: true }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsInteractive.mockReturnValue(true)
+    mockIsCancel.mockReturnValue(false)
+    state.pieces = [
+      { pieceCid: 'bafkpiece1', status: 'ACTIVE' },
+      { pieceCid: 'bafkpiece2', status: 'ACTIVE' },
+    ]
+    process.exitCode = 0
+  })
+
+  afterEach(() => {
+    process.exitCode = 0
+  })
+
+  it('exits with code 2 when the user declines the confirmation', async () => {
+    mockConfirm.mockResolvedValueOnce(false)
+
+    const result = await runRmAllPieces(baseOptions)
+
+    expect(result.removedCount).toBe(0)
+    expect(mockRemoveAllPieces).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(2)
+  })
+
+  it('exits with code 2 when a requested confirmation wait times out', async () => {
+    mockRemoveAllPieces.mockResolvedValueOnce({
+      dataSetId: 123,
+      totalPieces: 2,
+      removedCount: 2,
+      confirmedCount: 1,
+      failedCount: 0,
+      transactions: [],
+    })
+
+    await runRmAllPieces({ ...baseOptions, force: true, waitForConfirmation: true })
+
+    expect(mockRemoveAllPieces).toHaveBeenCalled()
+    expect(process.exitCode).toBe(2)
+  })
+
+  it('does not set a failure exit code when all confirmations succeed', async () => {
+    mockRemoveAllPieces.mockResolvedValueOnce({
+      dataSetId: 123,
+      totalPieces: 2,
+      removedCount: 2,
+      confirmedCount: 2,
+      failedCount: 0,
+      transactions: [],
+    })
+
+    await runRmAllPieces({ ...baseOptions, force: true, waitForConfirmation: true })
+
+    expect(process.exitCode).toBe(0)
+  })
+})

--- a/src/test/unit/remove-all-pieces.test.ts
+++ b/src/test/unit/remove-all-pieces.test.ts
@@ -22,7 +22,7 @@ const { mockGetDataSetPieces, mockRemovePiece, mockStorageContext, state } = vi.
     pieces: state.pieces,
   }))
 
-  const mockRemovePiece = vi.fn(async (_pieceCid: string) => {
+  const mockRemovePiece = vi.fn(async (_pieceCid: string, _ctx?: any, _opts?: { onProgress?: any }) => {
     state.txCounter++
     return `0xhash${state.txCounter}`
   })
@@ -118,6 +118,43 @@ describe('removeAllPieces', () => {
     const failedEvent = onProgress.mock.calls.find((call) => call[0].type === 'removeAll:failed')
     expect(failedEvent).toBeDefined()
     expect(failedEvent?.[0].data.error).toBe('Transaction failed')
+  })
+
+  it('counts confirmations reported by removePiece when waiting', async () => {
+    mockRemovePiece.mockImplementation(async (_pieceCid: string, _ctx: any, opts?: { onProgress?: any }) => {
+      state.txCounter++
+      const txHash = `0xhash${state.txCounter}`
+      opts?.onProgress?.({ type: 'removePiece:complete', data: { txHash, confirmed: true } })
+      return txHash
+    })
+
+    const result = await removeAllPieces(mockStorageContext as any, {
+      synapse: mockSynapse as any,
+      waitForConfirmation: true,
+    })
+
+    expect(result.removedCount).toBe(2)
+    expect(result.confirmedCount).toBe(2)
+  })
+
+  it('leaves confirmedCount below removedCount when a confirmation times out', async () => {
+    let call = 0
+    mockRemovePiece.mockImplementation(async (_pieceCid: string, _ctx: any, opts?: { onProgress?: any }) => {
+      call++
+      state.txCounter++
+      const txHash = `0xhash${state.txCounter}`
+      // Only the first piece confirms; the second times out (confirmed: false).
+      opts?.onProgress?.({ type: 'removePiece:complete', data: { txHash, confirmed: call === 1 } })
+      return txHash
+    })
+
+    const result = await removeAllPieces(mockStorageContext as any, {
+      synapse: mockSynapse as any,
+      waitForConfirmation: true,
+    })
+
+    expect(result.removedCount).toBe(2)
+    expect(result.confirmedCount).toBe(1)
   })
 
   it('returns empty result when no pieces to remove', async () => {

--- a/src/test/unit/rm-cmd.test.ts
+++ b/src/test/unit/rm-cmd.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runRmPiece } from '../../rm/remove-piece.js'
 import type { RmPieceOptions } from '../../rm/types.js'
 
@@ -94,6 +94,11 @@ describe('runRmPiece', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    process.exitCode = 0
+  })
+
+  afterEach(() => {
+    process.exitCode = 0
   })
 
   it('removes a piece and returns result with confirmation status', async () => {
@@ -105,6 +110,7 @@ describe('runRmPiece', () => {
       transactionHash: '0xtx',
       confirmed: true,
     })
+    expect(process.exitCode).toBe(0)
 
     expect(mockInitializeSynapse).toHaveBeenCalledWith(
       expect.objectContaining({ privateKey: '0xabc', rpcUrl: 'wss://rpc' }),
@@ -122,6 +128,47 @@ describe('runRmPiece', () => {
     expect(spinner.stop).toHaveBeenCalledWith(expect.stringContaining('Piece removed'))
     expect(mockIntro).toHaveBeenCalled()
     expect(mockOutro).toHaveBeenCalledWith('Remove completed successfully')
+  })
+
+  it('exits with code 2 when a requested confirmation wait times out', async () => {
+    mockRemovePiece.mockImplementationOnce(async (_pieceCid: string, _storage: any, opts: { onProgress?: any }) => {
+      opts.onProgress?.({
+        type: 'removePiece:submitted',
+        data: { pieceCid: _pieceCid, dataSetId: Number(_storage.dataSetId), txHash: '0xtx' },
+      })
+      opts.onProgress?.({
+        type: 'removePiece:confirmationFailed',
+        data: { pieceCid: _pieceCid, dataSetId: Number(_storage.dataSetId), txHash: '0xtx', message: 'timed out' },
+      })
+      opts.onProgress?.({
+        type: 'removePiece:complete',
+        data: { txHash: '0xtx', confirmed: false },
+      })
+      return '0xtx'
+    })
+
+    const result = await runRmPiece({ ...baseOptions, waitForConfirmation: true })
+
+    expect(result.confirmed).toBe(false)
+    expect(process.exitCode).toBe(2)
+  })
+
+  it('does not set a failure exit code when confirmation was not requested', async () => {
+    mockRemovePiece.mockImplementationOnce(async (_pieceCid: string, _storage: any, opts: { onProgress?: any }) => {
+      opts.onProgress?.({
+        type: 'removePiece:submitted',
+        data: { pieceCid: _pieceCid, dataSetId: Number(_storage.dataSetId), txHash: '0xtx' },
+      })
+      opts.onProgress?.({
+        type: 'removePiece:complete',
+        data: { txHash: '0xtx', confirmed: false },
+      })
+      return '0xtx'
+    })
+
+    await runRmPiece({ ...baseOptions, waitForConfirmation: false })
+
+    expect(process.exitCode).toBe(0)
   })
 
   it('throws when piece CID or data set is missing', async () => {

--- a/src/test/unit/rm-cmd.test.ts
+++ b/src/test/unit/rm-cmd.test.ts
@@ -153,6 +153,18 @@ describe('runRmPiece', () => {
     expect(process.exitCode).toBe(2)
   })
 
+  it('does not downgrade a prior non-zero exit code on wait timeout', async () => {
+    process.exitCode = 1
+    mockRemovePiece.mockImplementationOnce(async (_pieceCid: string, _storage: any, opts: { onProgress?: any }) => {
+      opts.onProgress?.({ type: 'removePiece:complete', data: { txHash: '0xtx', confirmed: false } })
+      return '0xtx'
+    })
+
+    await runRmPiece({ ...baseOptions, waitForConfirmation: true })
+
+    expect(process.exitCode).toBe(1)
+  })
+
   it('does not set a failure exit code when confirmation was not requested', async () => {
     mockRemovePiece.mockImplementationOnce(async (_pieceCid: string, _storage: any, opts: { onProgress?: any }) => {
       opts.onProgress?.({

--- a/src/test/unit/rm-cmd.test.ts
+++ b/src/test/unit/rm-cmd.test.ts
@@ -151,6 +151,8 @@ describe('runRmPiece', () => {
 
     expect(result.confirmed).toBe(false)
     expect(process.exitCode).toBe(2)
+    expect(mockOutro).toHaveBeenCalledWith('Remove submitted; confirmation still pending')
+    expect(mockOutro).not.toHaveBeenCalledWith('Remove completed successfully')
   })
 
   it('does not downgrade a prior non-zero exit code on wait timeout', async () => {

--- a/src/test/unit/run-fund.test.ts
+++ b/src/test/unit/run-fund.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runFund } from '../../payments/fund.js'
+
+const { mockConfirm, mockIsCancel, mockCancel, mockPlan, mockDeposit, mockWithdraw } = vi.hoisted(() => ({
+  mockConfirm: vi.fn(),
+  mockIsCancel: vi.fn(() => false),
+  mockCancel: vi.fn(),
+  mockPlan: vi.fn(),
+  mockDeposit: vi.fn(),
+  mockWithdraw: vi.fn(),
+}))
+
+vi.mock('@clack/prompts', () => ({
+  confirm: mockConfirm,
+  isCancel: mockIsCancel,
+}))
+vi.mock('../../core/synapse/index.js', () => ({
+  initializeSynapse: vi.fn(async () => ({})),
+}))
+vi.mock('../../utils/cli-auth.js', () => ({
+  parseCLIAuth: vi.fn(() => ({})),
+  getCLILogger: vi.fn(() => ({})),
+}))
+vi.mock('../../utils/cli-helpers.js', () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  cancel: mockCancel,
+  isInteractive: vi.fn(() => true),
+  createSpinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() })),
+}))
+vi.mock('../../utils/cli-logger.js', () => ({
+  isTTY: vi.fn(() => true),
+  log: { line: vi.fn(), indent: vi.fn(), flush: vi.fn() },
+}))
+vi.mock('../../core/payments/index.js', () => ({
+  DEFAULT_LOCKUP_DAYS: 30,
+  planFilecoinPayFunding: mockPlan,
+  checkUSDFCBalance: vi.fn(async () => 1_000_000_000_000_000_000_000n),
+  depositUSDFC: mockDeposit,
+  withdrawUSDFC: mockWithdraw,
+  clampDepositToLimit: vi.fn((v: bigint) => v),
+  executeFilecoinPayFunding: vi.fn(),
+  toStorageRunwaySummary: vi.fn(() => ({})),
+}))
+vi.mock('../../core/utils/format.js', () => ({
+  formatUSDFC: vi.fn((v: bigint) => String(v)),
+}))
+vi.mock('../../core/utils/index.js', () => ({
+  formatRunwaySummary: vi.fn(() => []),
+}))
+
+function planResult(delta: bigint) {
+  return {
+    plan: {
+      targetType: 'deposit',
+      mode: 'exact',
+      delta,
+      targetDeposit: delta > 0n ? delta : -delta,
+      walletShortfall: null,
+      projected: { runway: { state: 'active', runwayDays: 60 } },
+      current: { runway: { rateUsed: 1n } },
+    },
+    status: { walletUsdfcBalance: 1_000_000_000_000_000_000_000n },
+  }
+}
+
+describe('runFund confirmation exit codes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsCancel.mockReturnValue(false)
+    process.exitCode = 0
+  })
+
+  it('exits with code 2 when the deposit confirmation is declined', async () => {
+    mockPlan.mockResolvedValueOnce(planResult(5_000_000_000_000_000_000n))
+    mockConfirm.mockResolvedValueOnce(false)
+
+    await runFund({ amount: '5' })
+
+    expect(mockDeposit).not.toHaveBeenCalled()
+    expect(mockCancel).toHaveBeenCalledWith('Deposit cancelled by user')
+    expect(process.exitCode).toBe(2)
+  })
+
+  it('aborts the deposit when the confirmation prompt is cancelled', async () => {
+    const cancelSymbol = Symbol('clack:cancel')
+    mockPlan.mockResolvedValueOnce(planResult(5_000_000_000_000_000_000n))
+    mockConfirm.mockResolvedValueOnce(cancelSymbol)
+    mockIsCancel.mockReturnValueOnce(true)
+
+    await runFund({ amount: '5' })
+
+    expect(mockDeposit).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(2)
+  })
+
+  it('exits with code 2 when the withdraw confirmation is declined', async () => {
+    mockPlan.mockResolvedValueOnce(planResult(-5_000_000_000_000_000_000n))
+    mockConfirm.mockResolvedValueOnce(false)
+
+    await runFund({ amount: '5' })
+
+    expect(mockWithdraw).not.toHaveBeenCalled()
+    expect(mockCancel).toHaveBeenCalledWith('Withdraw cancelled by user')
+    expect(process.exitCode).toBe(2)
+  })
+
+  it('keeps a declined confirmation from downgrading a prior failure code', async () => {
+    process.exitCode = 1
+    mockPlan.mockResolvedValueOnce(planResult(5_000_000_000_000_000_000n))
+    mockConfirm.mockResolvedValueOnce(false)
+
+    await runFund({ amount: '5' })
+
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/src/test/unit/run-interactive-setup.test.ts
+++ b/src/test/unit/run-interactive-setup.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runInteractiveSetup } from '../../payments/interactive.js'
+
+const { mockPassword, mockIsCancel, mockIsTTY } = vi.hoisted(() => ({
+  mockPassword: vi.fn(),
+  mockIsCancel: vi.fn(() => false),
+  mockIsTTY: vi.fn(() => true),
+}))
+
+vi.mock('@clack/prompts', () => ({
+  cancel: vi.fn(),
+  confirm: vi.fn(),
+  isCancel: mockIsCancel,
+  password: mockPassword,
+  text: vi.fn(),
+}))
+vi.mock('../../utils/cli-helpers.js', () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  createSpinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() })),
+}))
+vi.mock('../../utils/cli-logger.js', () => ({
+  isTTY: mockIsTTY,
+  log: { line: vi.fn(), flush: vi.fn(), indent: vi.fn() },
+}))
+
+describe('runInteractiveSetup exit codes', () => {
+  const originalPrivateKey = process.env.PRIVATE_KEY
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsTTY.mockReturnValue(true)
+    delete process.env.PRIVATE_KEY
+    process.exitCode = 0
+  })
+
+  afterEach(() => {
+    process.exitCode = 0
+    if (originalPrivateKey === undefined) delete process.env.PRIVATE_KEY
+    else process.env.PRIVATE_KEY = originalPrivateKey
+  })
+
+  it('exits with code 2 when the private-key prompt is cancelled', async () => {
+    const cancelSymbol = Symbol('clack:cancel')
+    mockPassword.mockResolvedValueOnce(cancelSymbol)
+    mockIsCancel.mockReturnValueOnce(true)
+
+    await runInteractiveSetup({} as any)
+
+    expect(process.exitCode).toBe(2)
+  })
+})

--- a/src/test/unit/run-session-authorize.test.ts
+++ b/src/test/unit/run-session-authorize.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runSessionAuthorize } from '../../session/run-authorize.js'
+
+const { mockConfirm, mockIsCancel, mockIsInteractive, mockResolveNetwork } = vi.hoisted(() => ({
+  mockConfirm: vi.fn(),
+  mockIsCancel: vi.fn(() => false),
+  mockIsInteractive: vi.fn(() => true),
+  mockResolveNetwork: vi.fn(async () => ({ chain: { name: 'calibration', id: 314159 }, transport: {} })),
+}))
+
+vi.mock('@clack/prompts', () => ({ confirm: mockConfirm, isCancel: mockIsCancel }))
+vi.mock('../../utils/cli-helpers.js', () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  cancel: vi.fn(),
+  createSpinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() })),
+  isInteractive: mockIsInteractive,
+}))
+vi.mock('../../utils/cli-logger.js', () => ({
+  log: { section: vi.fn(), flush: vi.fn() },
+}))
+vi.mock('../../session/resolve-network.js', () => ({ resolveNetwork: mockResolveNetwork }))
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: vi.fn(() => ({ address: '0x1111111111111111111111111111111111111111' })),
+}))
+
+describe('runSessionAuthorize exit codes', () => {
+  const baseOptions = {
+    privateKey: `0x${'a'.repeat(64)}`,
+    sessionAddress: '0x2222222222222222222222222222222222222222',
+    validityDays: '10',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsInteractive.mockReturnValue(true)
+    mockIsCancel.mockReturnValue(false)
+    process.exitCode = 0
+  })
+
+  afterEach(() => {
+    process.exitCode = 0
+  })
+
+  it('exits with code 2 and returns undefined when the user declines', async () => {
+    mockConfirm.mockResolvedValueOnce(false)
+
+    const result = await runSessionAuthorize(baseOptions as any)
+
+    expect(result).toBeUndefined()
+    expect(process.exitCode).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary

Part of #522 (GA CLI cleanup).

`rm --wait-for-confirmation` on a confirmation timeout and `data-set terminate` on a declined confirmation both returned normally, so the `postAction` hook exited `0`. Scripts had no way to distinguish "the operation didn't complete" from success.

Both paths now set exit code `2` (`EXIT_CODE_INCOMPLETE`), distinct from the `1` the Commander wrappers use for caught errors.

## Changes

- Add `EXIT_CODE_INCOMPLETE = 2` in `src/common/cli-errors.ts`.
- `data-set terminate`: set exit code `2` when the user declines/cancels the confirmation prompt.
- `rm`: set exit code `2` when `--wait-for-confirmation` was requested but the wait timed out (removal unconfirmed).

## Test plan

- [x] Unit test: `rm` exits `2` when a requested confirmation wait times out, and stays `0` when confirmation wasn't requested.
- [x] Unit test: `data-set terminate` exits `2` when the user cancels the confirmation prompt.
- [x] `tsc --noEmit` and Biome pass on changed files.