### PR TITLE
feat(cli): wire -v/--verbose to debug log level

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { checkForUpdate, type UpdateCheckStatus } from './common/version-check.j
 import { configureTelemetry, flushTelemetry } from './core/telemetry/index.js'
 import { version as packageVersion } from './core/utils/version.js'
 import { readTelemetryConfigFromEnv } from './read-telemetry-config-from-env.js'
+import { applyVerboseLogLevel } from './utils/cli-logger.js'
 
 // Apply CLI env vars to the telemetry library before any subcommand runs.
 configureTelemetry({ ...readTelemetryConfigFromEnv(), affordance: 'CLI' })
@@ -17,7 +18,7 @@ const program = new Command()
   .name('filecoin-pin')
   .description('IPFS Pinning Service with Filecoin storage via Synapse SDK')
   .version(packageVersion)
-  .option('-v, --verbose', 'verbose output')
+  .option('-v, --verbose', 'enable debug-level logging (sets LOG_LEVEL=debug)')
   .option('--no-update-check', 'skip check for updates')
 
 // Add subcommands
@@ -28,6 +29,11 @@ for (const command of ALL_CLI_COMMANDS) {
 // Default action - show help if no command specified
 program.action(() => {
   program.help()
+})
+
+// Wire the global `-v/--verbose` flag to the log level before each action runs.
+program.hook('preAction', () => {
+  applyVerboseLogLevel(program.optsWithGlobals<{ verbose?: boolean }>().verbose)
 })
 
 let updateCheckResult: UpdateCheckStatus | null = null

--- a/src/test/unit/cli-logger.test.ts
+++ b/src/test/unit/cli-logger.test.ts
@@ -20,6 +20,12 @@ describe('applyVerboseLogLevel', () => {
     expect(env.LOG_LEVEL).toBeUndefined()
   })
 
+  it('treats empty LOG_LEVEL as unset', () => {
+    const env: NodeJS.ProcessEnv = { LOG_LEVEL: '' }
+    applyVerboseLogLevel(true, env)
+    expect(env.LOG_LEVEL).toBe('debug')
+  })
+
   it('does not override an explicit LOG_LEVEL', () => {
     const env: NodeJS.ProcessEnv = { LOG_LEVEL: 'trace' }
     applyVerboseLogLevel(true, env)

--- a/src/test/unit/cli-logger.test.ts
+++ b/src/test/unit/cli-logger.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { applyVerboseLogLevel } from '../../utils/cli-logger.js'
+
+describe('applyVerboseLogLevel', () => {
+  it('sets LOG_LEVEL=debug when verbose is true and LOG_LEVEL is unset', () => {
+    const env: NodeJS.ProcessEnv = {}
+    applyVerboseLogLevel(true, env)
+    expect(env.LOG_LEVEL).toBe('debug')
+  })
+
+  it('does not change LOG_LEVEL when verbose is false', () => {
+    const env: NodeJS.ProcessEnv = {}
+    applyVerboseLogLevel(false, env)
+    expect(env.LOG_LEVEL).toBeUndefined()
+  })
+
+  it('does not change LOG_LEVEL when verbose is undefined', () => {
+    const env: NodeJS.ProcessEnv = {}
+    applyVerboseLogLevel(undefined, env)
+    expect(env.LOG_LEVEL).toBeUndefined()
+  })
+
+  it('does not override an explicit LOG_LEVEL', () => {
+    const env: NodeJS.ProcessEnv = { LOG_LEVEL: 'trace' }
+    applyVerboseLogLevel(true, env)
+    expect(env.LOG_LEVEL).toBe('trace')
+  })
+})

--- a/src/utils/cli-logger.ts
+++ b/src/utils/cli-logger.ts
@@ -30,7 +30,6 @@ export function applyVerboseLogLevel(verbose: boolean | undefined, env: NodeJS.P
     env.LOG_LEVEL = 'debug'
   }
 }
-}
 
 /**
  * Buffer for collecting log lines to output together

--- a/src/utils/cli-logger.ts
+++ b/src/utils/cli-logger.ts
@@ -18,6 +18,20 @@ function isTTY(): boolean {
 }
 
 /**
+ * Apply the global `-v/--verbose` flag to the log level.
+ *
+ * Runners read `LOG_LEVEL` when they construct their pino logger, so setting it
+ * before the action runs makes `-v` emit debug logs for any command. An
+ * explicit `LOG_LEVEL` already in the environment wins, so users can still pick
+ * a different level (e.g. `trace`) without `-v` clobbering it.
+ */
+export function applyVerboseLogLevel(verbose: boolean | undefined, env: NodeJS.ProcessEnv = process.env): void {
+  if (verbose === true && env.LOG_LEVEL == null) {
+    env.LOG_LEVEL = 'debug'
+  }
+}
+
+/**
  * Buffer for collecting log lines to output together
  */
 let lineBuffer: string[] = []

--- a/src/utils/cli-logger.ts
+++ b/src/utils/cli-logger.ts
@@ -26,9 +26,10 @@ function isTTY(): boolean {
  * a different level (e.g. `trace`) without `-v` clobbering it.
  */
 export function applyVerboseLogLevel(verbose: boolean | undefined, env: NodeJS.ProcessEnv = process.env): void {
-  if (verbose === true && env.LOG_LEVEL == null) {
+  if (verbose === true && (env.LOG_LEVEL == null || env.LOG_LEVEL === '')) {
     env.LOG_LEVEL = 'debug'
   }
+}
 }
 
 /**


### PR DESCRIPTION
## Summary

Part of #522 (GA CLI cleanup).

The global `-v/--verbose` flag was declared on the root command but never read — a dead flag. It now sets `LOG_LEVEL=debug` via a `preAction` hook. Every runner reads `LOG_LEVEL` when it constructs its pino logger, so `-v` enables debug logging for any command.

An explicit `LOG_LEVEL` already in the environment still wins, so users can pick a different level (e.g. `trace`) without `-v` clobbering it.

## Changes

- Add `applyVerboseLogLevel()` helper in `src/utils/cli-logger.ts`.
- Call it from a `preAction` hook in `src/cli.ts`.
- Update the flag's help text to describe the behavior.

## Test plan

- [x] Unit tests for `applyVerboseLogLevel` (sets debug when verbose + unset; no-op when false/undefined; does not override an explicit level).
- [x] `node dist/cli.js --help` shows the updated `-v, --verbose` description.
- [x] `tsc --noEmit` and Biome pass.