### PR TITLE
fix(cli): suppress update banner when stdout is not a TTY

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 import './instrument.js'
 import { Command } from 'commander'
-import pc from 'picocolors'
 
 import { ALL_CLI_COMMANDS } from './commands/index.js'
-import { checkForUpdate, type UpdateCheckStatus } from './common/version-check.js'
+import { checkForUpdate, printUpdateBanner, type UpdateCheckStatus } from './common/version-check.js'
 import { configureTelemetry, flushTelemetry } from './core/telemetry/index.js'
 import { version as packageVersion } from './core/utils/version.js'
 import { readTelemetryConfigFromEnv } from './read-telemetry-config-from-env.js'
@@ -56,15 +55,10 @@ program.hook('preAction', () => {
 })
 
 program.hook('postAction', async (_thisCommand, actionCommand) => {
-  if (updateCheckResult?.status === 'update-available') {
+  if (updateCheckResult != null) {
     const result = updateCheckResult
     updateCheckResult = null
-
-    const header = `${pc.yellow(`Update available: filecoin-pin ${result.currentVersion} → ${result.latestVersion}`)}. Upgrade with ${pc.cyan('npm i -g filecoin-pin@latest')}`
-    const releasesLink = 'https://github.com/filecoin-project/filecoin-pin/releases'
-    const instruction = `Visit ${releasesLink} to view release notes or download the latest version.`
-    console.log(header)
-    console.log(instruction)
+    printUpdateBanner(result)
   }
 
   // Viem's WebSocket transport holds persistent connections (with keepAlive

--- a/src/common/version-check.ts
+++ b/src/common/version-check.ts
@@ -1,5 +1,7 @@
+import pc from 'picocolors'
 import { compare } from 'semver'
 import { name as packageName, version as packageVersion } from '../core/utils/version.js'
+import { isTTY } from '../utils/cli-logger.js'
 
 type UpdateCheckStatus =
   | {
@@ -106,6 +108,28 @@ export async function checkForUpdate(options: CheckForUpdateOptions = {}): Promi
 
 function getLocalPackageVersion(): string {
   return packageVersion
+}
+
+/**
+ * Print the "update available" banner, but only on an interactive TTY.
+ *
+ * When stdout is piped (CI, scripts, `| jq`, etc.) the banner is noise that can
+ * corrupt machine-readable output, so it is suppressed. `print` and `tty` are
+ * injectable for testing.
+ */
+export function printUpdateBanner(
+  result: UpdateCheckStatus,
+  { tty = isTTY(), print = console.log }: { tty?: boolean; print?: (message: string) => void } = {}
+): void {
+  if (result.status !== 'update-available' || !tty) {
+    return
+  }
+
+  const header = `${pc.yellow(`Update available: filecoin-pin ${result.currentVersion} → ${result.latestVersion}`)}. Upgrade with ${pc.cyan('npm i -g filecoin-pin@latest')}`
+  const releasesLink = 'https://github.com/filecoin-project/filecoin-pin/releases'
+  const instruction = `Visit ${releasesLink} to view release notes or download the latest version.`
+  print(header)
+  print(instruction)
 }
 
 export type { UpdateCheckStatus }

--- a/src/test/unit/version-check.test.ts
+++ b/src/test/unit/version-check.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { checkForUpdate } from '../../common/version-check.js'
+import { checkForUpdate, printUpdateBanner, type UpdateCheckStatus } from '../../common/version-check.js'
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -59,5 +59,32 @@ describe('version check', () => {
       status: 'disabled',
       reason: 'Update check disabled by configuration',
     })
+  })
+})
+
+describe('printUpdateBanner', () => {
+  const updateAvailable: UpdateCheckStatus = {
+    status: 'update-available',
+    currentVersion: '0.11.0',
+    latestVersion: '0.12.0',
+  }
+
+  it('prints the banner on a TTY', () => {
+    const print = vi.fn()
+    printUpdateBanner(updateAvailable, { tty: true, print })
+    expect(print).toHaveBeenCalledTimes(2)
+    expect(print.mock.calls[0]?.[0]).toContain('Update available')
+  })
+
+  it('suppresses the banner when stdout is not a TTY', () => {
+    const print = vi.fn()
+    printUpdateBanner(updateAvailable, { tty: false, print })
+    expect(print).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when no update is available', () => {
+    const print = vi.fn()
+    printUpdateBanner({ status: 'up-to-date', currentVersion: '0.12.0', latestVersion: '0.12.0' }, { tty: true, print })
+    expect(print).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Part of #522 (GA CLI cleanup).

The "update available" banner printed unconditionally from the `postAction` hook, which pollutes piped/CI output (e.g. `filecoin-pin ... | jq`). It now prints only on an interactive TTY.

## Changes

- Add `printUpdateBanner(result, { tty, print })` in `src/common/version-check.ts`. It gates on the `isTTY()` helper from `src/utils/cli-logger.ts` and is no-op for non-`update-available` statuses. `tty`/`print` are injectable for testing.
- `src/cli.ts` postAction now calls `printUpdateBanner` instead of building and logging the banner inline (removes the now-unused `picocolors` import).

## Test plan

- [x] Unit tests: banner prints on TTY, is suppressed when not a TTY, and is a no-op when no update is available.
- [x] `node dist/cli.js --help` still loads.
- [x] `tsc --noEmit` and Biome pass.