### PR TITLE
refactor(cli): rename rm command to remove, keep rm as alias

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,7 +4,7 @@ import { dataSetCommand } from './data-set.js'
 import { importCommand } from './import.js'
 import { paymentsCommand } from './payments.js'
 import { providerCommand } from './provider.js'
-import { rmCommand } from './rm.js'
+import { removeCommand } from './remove.js'
 import { serverCommand } from './server.js'
 import { sessionCommand } from './session.js'
 
@@ -14,7 +14,7 @@ export {
   importCommand,
   paymentsCommand,
   providerCommand,
-  rmCommand,
+  removeCommand,
   serverCommand,
   sessionCommand,
 }
@@ -31,7 +31,7 @@ export const ALL_CLI_COMMANDS: readonly Command[] = [
   dataSetCommand,
   importCommand,
   addCommand,
-  rmCommand,
+  removeCommand,
   providerCommand,
   sessionCommand,
 ]

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -4,18 +4,18 @@ import { runRmAllPieces, runRmPiece } from '../rm/index.js'
 import { log } from '../utils/cli-logger.js'
 import { addAuthOptions } from '../utils/cli-options.js'
 
-export const rmCommand = new Command('remove')
+export const removeCommand = new Command('remove')
   .alias('rm')
   .description('Remove piece(s) from a DataSet')
   .requiredOption('--data-set <id>', 'DataSet ID to remove the piece from')
   .option('--wait', 'Wait for transaction confirmation before exiting')
   .option('--force', 'Skip confirmation prompt when using --all')
 
-rmCommand.addOption(new Option('--piece <cid>', 'Piece CID to remove').conflicts('all'))
-rmCommand.addOption(new Option('--all', 'Remove ALL pieces from the DataSet').conflicts('piece'))
-rmCommand.addOption(new Option('--wait-for-confirmation', 'Deprecated alias for --wait').hideHelp())
+removeCommand.addOption(new Option('--piece <cid>', 'Piece CID to remove').conflicts('all'))
+removeCommand.addOption(new Option('--all', 'Remove ALL pieces from the DataSet').conflicts('piece'))
+removeCommand.addOption(new Option('--wait-for-confirmation', 'Deprecated alias for --wait').hideHelp())
 
-rmCommand.action(async (options) => {
+removeCommand.action(async (options) => {
   // Validate: at least one of --piece or --all is required.
   // This is a routing decision for the wrapper (which runner to dispatch to),
   // so it lives here rather than in either runner.
@@ -43,4 +43,4 @@ rmCommand.action(async (options) => {
   }
 })
 
-addAuthOptions(rmCommand)
+addAuthOptions(removeCommand)

--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -4,7 +4,8 @@ import { runRmAllPieces, runRmPiece } from '../rm/index.js'
 import { log } from '../utils/cli-logger.js'
 import { addAuthOptions } from '../utils/cli-options.js'
 
-export const rmCommand = new Command('rm')
+export const rmCommand = new Command('remove')
+  .alias('rm')
   .description('Remove piece(s) from a DataSet')
   .requiredOption('--data-set <id>', 'DataSet ID to remove the piece from')
   .option('--wait', 'Wait for transaction confirmation before exiting')

--- a/src/test/unit/cli-network-defaults.test.ts
+++ b/src/test/unit/cli-network-defaults.test.ts
@@ -40,3 +40,10 @@ describe('CLI --network option', () => {
     expect(networkOpt?.argChoices).toEqual(['mainnet', 'calibration', 'devnet'])
   })
 })
+
+describe('remove command naming', () => {
+  it('uses "remove" as the canonical name and keeps "rm" as an alias', () => {
+    expect(rmCommand.name()).toBe('remove')
+    expect(rmCommand.aliases()).toContain('rm')
+  })
+})

--- a/src/test/unit/cli-network-defaults.test.ts
+++ b/src/test/unit/cli-network-defaults.test.ts
@@ -18,7 +18,7 @@ function leafCommands(cmd: Command): Command[] {
 const roots: Array<[string, Command]> = [
   ['add', addCommand],
   ['import', importCommand],
-  ['rm', rmCommand],
+  ['remove', rmCommand],
   ['server', serverCommand],
   ['payments', paymentsCommand],
   ['data-set', dataSetCommand],

--- a/src/test/unit/cli-network-defaults.test.ts
+++ b/src/test/unit/cli-network-defaults.test.ts
@@ -6,7 +6,7 @@ import {
   importCommand,
   paymentsCommand,
   providerCommand,
-  rmCommand,
+  removeCommand,
   serverCommand,
   sessionCommand,
 } from '../../commands/index.js'
@@ -18,7 +18,7 @@ function leafCommands(cmd: Command): Command[] {
 const roots: Array<[string, Command]> = [
   ['add', addCommand],
   ['import', importCommand],
-  ['remove', rmCommand],
+  ['remove', removeCommand],
   ['server', serverCommand],
   ['payments', paymentsCommand],
   ['data-set', dataSetCommand],
@@ -43,7 +43,7 @@ describe('CLI --network option', () => {
 
 describe('remove command naming', () => {
   it('uses "remove" as the canonical name and keeps "rm" as an alias', () => {
-    expect(rmCommand.name()).toBe('remove')
-    expect(rmCommand.aliases()).toContain('rm')
+    expect(removeCommand.name()).toBe('remove')
+    expect(removeCommand.aliases()).toContain('rm')
   })
 })


### PR DESCRIPTION
## Summary
- Renames the `rm` command to `remove` for clarity and consistency with the rest of the CLI.
- Keeps `rm` as a backward-compatible alias, so existing scripts and muscle memory keep working.

## Details
`remove` is now the canonical command name shown in `--help` (`remove|rm`); both `filecoin-pin remove --help` and `filecoin-pin rm --help` resolve to the same command. No documentation referenced the `rm` command directly, so no doc updates were needed.

Part of #522.

## Test plan
- [x] `node dist/cli.js --help` lists `remove|rm`
- [x] `node dist/cli.js remove --help` works
- [x] `node dist/cli.js rm --help` (alias) works
- [x] typecheck + biome clean
- [x] unit tests pass (cli-network-defaults, rm-cmd)