### PR TITLE
feat(cli): add data-set piece-status command, export reconcilePieceStatus

### DIFF
--- a/src/commands/data-set.ts
+++ b/src/commands/data-set.ts
@@ -1,5 +1,10 @@
 import { Command } from 'commander'
-import { runDataSetDetailsCommand, runDataSetListCommand, runTerminateDataSetCommand } from '../data-set/run.js'
+import {
+  runDataSetDetailsCommand,
+  runDataSetListCommand,
+  runDataSetPieceStatusCommand,
+  runTerminateDataSetCommand,
+} from '../data-set/run.js'
 import type { DataSetListCommandOptions } from '../data-set/types.js'
 import { addAuthOptions } from '../utils/cli-options.js'
 import { addMetadataOptions, resolveMetadataOptions } from '../utils/cli-options-metadata.js'
@@ -66,6 +71,20 @@ export const dataSetTerminateCommand = new Command('terminate')
   })
 addAuthOptions(dataSetTerminateCommand)
 
+export const dataSetPieceStatusCommand = new Command('piece-status')
+  .description("Show the reconciled status of a data set's pieces")
+  .argument('<dataSetId>', 'Data set ID to inspect')
+  .argument('[pieceCid]', 'Optional PieceCID (or IPFS root CID) to filter to a single piece')
+  .action(async (dataSetId: string, pieceCid: string | undefined, options) => {
+    try {
+      await runDataSetPieceStatusCommand(parseStrictId(dataSetId), pieceCid, { ...options })
+    } catch {
+      process.exit(1)
+    }
+  })
+addAuthOptions(dataSetPieceStatusCommand)
+
 dataSetCommand.addCommand(dataSetShowCommand)
 dataSetCommand.addCommand(dataSetListCommand)
 dataSetCommand.addCommand(dataSetTerminateCommand)
+dataSetCommand.addCommand(dataSetPieceStatusCommand)

--- a/src/core/piece/index.ts
+++ b/src/core/piece/index.ts
@@ -1,2 +1,3 @@
+export * from './piece-status.js'
 export * from './remove-all-pieces.js'
 export * from './remove-piece.js'

--- a/src/core/piece/piece-status.ts
+++ b/src/core/piece/piece-status.ts
@@ -2,7 +2,7 @@ import type { DataSetPieceData } from '@filoz/synapse-sdk'
 import { PieceStatus } from '../data-set/types.js'
 import type { Warning } from '../utils/types.js'
 
-interface PieceStatusContext {
+export interface PieceStatusContext {
   pieceId: bigint
   pieceCid: unknown
   /**
@@ -18,7 +18,7 @@ interface PieceStatusContext {
   providerPiecesById: Map<DataSetPieceData['pieceId'], DataSetPieceData> | null
 }
 
-interface PieceStatusResult {
+export interface PieceStatusResult {
   status: PieceStatus
   warning?: Warning
 }

--- a/src/data-set/display.ts
+++ b/src/data-set/display.ts
@@ -181,6 +181,33 @@ function renderPieces(dataSet: DataSetSummary, indentLevel: number = 0): void {
 }
 
 /**
+ * Print the status of a data set's pieces (optionally filtered to a single piece).
+ */
+export function displayPieceStatuses(
+  pieces: PieceInfo[],
+  dataSetId: number,
+  network: string,
+  address: string,
+  emptyMessage?: string
+): void {
+  renderNetworkDetails(network, address)
+  log.line(`${pc.bold(`Data Set #${dataSetId}`)}`)
+
+  if (pieces.length === 0) {
+    log.line(pc.yellow(emptyMessage ?? 'No pieces found.'))
+    log.flush()
+    return
+  }
+
+  log.line('')
+  for (const piece of pieces) {
+    renderPiece(piece, 1)
+  }
+
+  log.flush()
+}
+
+/**
  * Print the lightweight dataset list used for the default command output.
  */
 export function displayDataSets(

--- a/src/data-set/display.ts
+++ b/src/data-set/display.ts
@@ -181,7 +181,8 @@ function renderPieces(dataSet: DataSetSummary, indentLevel: number = 0): void {
 }
 
 /**
- * Print the status of a data set's pieces (optionally filtered to a single piece).
+ * Print the status of the given pieces under a data set header.
+ * Callers may pass the full piece list or a pre-filtered subset.
  */
 export function displayPieceStatuses(
   pieces: PieceInfo[],

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -62,12 +62,13 @@ export async function runDataSetDetailsCommand(dataSetId: number, options: DataS
 /**
  * Display the reconciled status of a data set's pieces.
  *
- * When `pieceCid` is provided, only the matching piece (by PieceCID or IPFS root
+ * When `cid` is provided, only the matching piece (by PieceCID or IPFS root
  * CID) is shown; otherwise every piece in the data set is listed.
  */
 export async function runDataSetPieceStatusCommand(
   dataSetId: number,
-  pieceCid: string | undefined,
+  // pieceCid or ipfsRootCid
+  cid: string | undefined,
   options: DataSetCommandOptions
 ): Promise<void> {
   if (Number.isNaN(dataSetId) || dataSetId <= 0) {
@@ -95,10 +96,10 @@ export async function runDataSetPieceStatusCommand(
 
     let pieces: PieceInfo[] = allPieces
     let emptyMessage: string | undefined
-    if (pieceCid != null) {
-      pieces = allPieces.filter((piece) => piece.pieceCid === pieceCid || piece.rootIpfsCid === pieceCid)
+    if (cid != null) {
+      pieces = allPieces.filter((piece) => piece.pieceCid === cid || piece.rootIpfsCid === cid)
       if (pieces.length === 0) {
-        emptyMessage = `No piece matching ${pieceCid} was found in data set ${dataSetId}.`
+        emptyMessage = `No piece matching ${cid} was found in data set ${dataSetId}.`
       }
     }
 

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -3,11 +3,12 @@ import type { EnhancedDataSetInfo, Synapse } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
 import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { type DataSetSummary, getDetailedDataSet, listDataSets } from '../core/data-set/index.js'
+import type { PieceInfo } from '../core/data-set/types.js'
 import { getClientAddress } from '../core/synapse/index.js'
 import { getCliSynapse } from '../utils/cli-auth.js'
 import { cancel, createSpinner, intro, isInteractive, outro } from '../utils/cli-helpers.js'
 import { log } from '../utils/cli-logger.js'
-import { displayDataSets } from './display.js'
+import { displayDataSets, displayPieceStatuses } from './display.js'
 import type { DataSetCommandOptions, DataSetListCommandOptions } from './types.js'
 
 /**
@@ -54,6 +55,68 @@ export async function runDataSetDetailsCommand(dataSetId: number, options: DataS
     log.line(`${pc.red('Error:')} ${msg}`)
     log.flush()
     cancel('Inspection failed')
+    throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
+  }
+}
+
+/**
+ * Display the reconciled status of a data set's pieces.
+ *
+ * When `pieceCid` is provided, only the matching piece (by PieceCID or IPFS root
+ * CID) is shown; otherwise every piece in the data set is listed.
+ */
+export async function runDataSetPieceStatusCommand(
+  dataSetId: number,
+  pieceCid: string | undefined,
+  options: DataSetCommandOptions
+): Promise<void> {
+  if (Number.isNaN(dataSetId) || dataSetId <= 0) {
+    intro(pc.bold('Filecoin Onchain Cloud Piece Status'))
+    log.line('')
+    log.line(`${pc.red('Error:')} Provided data set ID is invalid or not a positive integer`)
+    log.flush()
+    cancel('Piece status lookup failed')
+    throw new CliFatal('Invalid data set ID')
+  }
+
+  intro(pc.bold(`Filecoin Onchain Cloud Piece Status for Data Set #${dataSetId}`))
+  const spinner = createSpinner()
+  spinner.start('Connecting to Synapse...')
+
+  try {
+    const synapse = await getCliSynapse(options)
+    const network = synapse.chain.name
+    const address = getClientAddress(synapse)
+
+    spinner.message('Fetching piece status...')
+
+    const dataSet: DataSetSummary = await getDetailedDataSet(synapse, BigInt(dataSetId))
+    const allPieces = dataSet.pieces ?? []
+
+    let pieces: PieceInfo[] = allPieces
+    let emptyMessage: string | undefined
+    if (pieceCid != null) {
+      pieces = allPieces.filter((piece) => piece.pieceCid === pieceCid || piece.rootIpfsCid === pieceCid)
+      if (pieces.length === 0) {
+        emptyMessage = `No piece matching ${pieceCid} was found in data set ${dataSetId}.`
+      }
+    }
+
+    spinner.stop('━━━ Piece Status ━━━')
+    displayPieceStatuses(pieces, dataSetId, network, address, emptyMessage)
+
+    outro('Piece status lookup complete')
+  } catch (error) {
+    if (isCliFatal(error)) {
+      spinner.stop()
+      throw error
+    }
+    const msg = error instanceof Error ? error.message : String(error)
+    spinner.stop(`${pc.red('✗')} Failed to look up piece status`)
+    log.line('')
+    log.line(`${pc.red('Error:')} ${msg}`)
+    log.flush()
+    cancel('Piece status lookup failed')
     throw new CliFatal(msg, { cause: error instanceof Error ? error : undefined })
   }
 }

--- a/src/test/unit/data-set.test.ts
+++ b/src/test/unit/data-set.test.ts
@@ -1,10 +1,16 @@
 import { METADATA_KEYS } from '@filoz/synapse-sdk'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { DataSetSummary } from '../../core/data-set/types.js'
-import { runDataSetDetailsCommand, runDataSetListCommand, runTerminateDataSetCommand } from '../../data-set/run.js'
+import type { DataSetSummary, PieceInfo } from '../../core/data-set/types.js'
+import {
+  runDataSetDetailsCommand,
+  runDataSetListCommand,
+  runDataSetPieceStatusCommand,
+  runTerminateDataSetCommand,
+} from '../../data-set/run.js'
 
 const {
   displayDataSetListMock,
+  displayPieceStatusesMock,
   spinnerMock,
   cancelMock,
   mockFindDataSets,
@@ -17,6 +23,7 @@ const {
   state,
 } = vi.hoisted(() => {
   const displayDataSetListMock = vi.fn()
+  const displayPieceStatusesMock = vi.fn()
   const cancelMock = vi.fn()
   const spinnerMock = {
     start: vi.fn(),
@@ -94,6 +101,7 @@ const {
 
   return {
     displayDataSetListMock,
+    displayPieceStatusesMock,
     cancelMock,
     spinnerMock,
     mockFindDataSets,
@@ -110,6 +118,7 @@ const {
 
 vi.mock('../../data-set/display.js', () => ({
   displayDataSets: displayDataSetListMock,
+  displayPieceStatuses: displayPieceStatusesMock,
 }))
 
 vi.mock('../../core/synapse/index.js', () => ({
@@ -565,5 +574,102 @@ describe('runTerminateDataSetCommand', () => {
     ).rejects.toThrow('Invalid data set ID')
 
     expect(cancelMock).toHaveBeenCalledWith('Termination failed')
+  })
+})
+
+describe('runDataSetPieceStatusCommand', () => {
+  const summaryDataSet = {
+    pdpVerifierDataSetId: 158n,
+    providerId: 2n,
+    isManaged: true,
+    withCDN: false,
+    clientDataSetId: 1n,
+    pdpRailId: 327n,
+    cdnRailId: 0n,
+    cacheMissRailId: 0n,
+    payer: '0x123',
+    payee: '0x456',
+    serviceProvider: '0xservice',
+    commissionBps: 100,
+    pdpEndEpoch: 0,
+    cdnEndEpoch: 0,
+    metadata: {
+      [METADATA_KEYS.WITH_IPFS_INDEXING]: '',
+      source: 'filecoin-pin',
+    },
+  }
+
+  const provider = {
+    id: 2n,
+    name: 'Test Provider',
+    serviceProvider: '0xservice',
+    description: 'demo provider',
+    payee: '0x456',
+    active: true,
+    pdp: { serviceURL: 'https://pdp.local' },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.pieceMetadata = {}
+    state.pieceList = [
+      { pieceId: 0n, pieceCid: 'bafkpiece0' },
+      { pieceId: 1n, pieceCid: 'bafkpiece1' },
+    ]
+    mockGetProvider.mockResolvedValue(provider)
+    mockGetAllPieceMetadata.mockResolvedValue({})
+    mockGetPdpDataSet.mockResolvedValue(toPdpDataSet(summaryDataSet, provider))
+  })
+
+  afterEach(() => {
+    delete process.env.PRIVATE_KEY
+    process.exitCode = 0
+  })
+
+  it('displays all pieces when no pieceCid is provided', async () => {
+    await runDataSetPieceStatusCommand(158, undefined, {
+      privateKey: 'test-key',
+      rpcUrl: 'wss://sample',
+    })
+
+    expect(displayPieceStatusesMock).toHaveBeenCalledTimes(1)
+    const [pieces, dataSetId] = displayPieceStatusesMock.mock.calls[0] as [PieceInfo[], number]
+    expect(dataSetId).toBe(158)
+    expect(pieces).toHaveLength(2)
+    expect(pieces.map((p) => p.pieceCid)).toEqual(['bafkpiece0', 'bafkpiece1'])
+  })
+
+  it('filters to a single piece when a pieceCid is provided', async () => {
+    await runDataSetPieceStatusCommand(158, 'bafkpiece1', {
+      privateKey: 'test-key',
+      rpcUrl: 'wss://sample',
+    })
+
+    const [pieces] = displayPieceStatusesMock.mock.calls[0] as [PieceInfo[]]
+    expect(pieces).toHaveLength(1)
+    expect(pieces[0]?.pieceCid).toBe('bafkpiece1')
+  })
+
+  it('passes an empty list and message when the pieceCid is not found', async () => {
+    await runDataSetPieceStatusCommand(158, 'bafkmissing', {
+      privateKey: 'test-key',
+      rpcUrl: 'wss://sample',
+    })
+
+    const call = displayPieceStatusesMock.mock.calls[0] as [PieceInfo[], number, string, string, string | undefined]
+    expect(call[0]).toHaveLength(0)
+    expect(call[4]).toMatch(/No piece matching bafkmissing/)
+  })
+
+  it('rejects invalid dataset IDs', async () => {
+    await expect(
+      runDataSetPieceStatusCommand(0, undefined, {
+        privateKey: 'test-key',
+        rpcUrl: 'wss://sample',
+      })
+    ).rejects.toThrow('Invalid data set ID')
+
+    expect(cancelMock).toHaveBeenCalledWith('Piece status lookup failed')
+    expect(displayPieceStatusesMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Adds a read-only `data-set piece-status <dataSetId> [pieceCid]` command that prints the reconciled status of a data set's pieces.
- When a `pieceCid` is supplied, the output is filtered to the matching piece (by PieceCID or IPFS root CID); otherwise every piece is listed.
- Exports `reconcilePieceStatus` (and its `PieceStatusContext` / `PieceStatusResult` types) from `core/piece`, which was previously unexported.

## Details
The command reuses `getDetailedDataSet` (which already reconciles on-chain and provider-reported piece status via `reconcilePieceStatus`) and renders results through a new `displayPieceStatuses` helper that shares the existing per-piece renderer. Because there is no piece-to-dataset reverse lookup, the command is scoped to a single dataset, as called out in the issue.

Part of #522.

## Test plan
- [x] `data-set --help` lists `piece-status`
- [x] `data-set piece-status --help` shows both arguments
- [x] `reconcilePieceStatus` is importable from `filecoin-pin/core/piece`
- [x] unit tests: lists all pieces, filters by pieceCid, empty-message on miss, rejects invalid id
- [x] cli-network-defaults includes the new leaf (has `--network`)
- [x] typecheck + biome clean