### PR TITLE
feat(cli)!: standardize confirmation-wait flag on --wait

### DIFF
--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -7,11 +7,12 @@ import { addAuthOptions } from '../utils/cli-options.js'
 export const rmCommand = new Command('rm')
   .description('Remove piece(s) from a DataSet')
   .requiredOption('--data-set <id>', 'DataSet ID to remove the piece from')
-  .option('--wait-for-confirmation', 'Wait for transaction confirmation before exiting')
+  .option('--wait', 'Wait for transaction confirmation before exiting')
   .option('--force', 'Skip confirmation prompt when using --all')
 
 rmCommand.addOption(new Option('--piece <cid>', 'Piece CID to remove').conflicts('all'))
 rmCommand.addOption(new Option('--all', 'Remove ALL pieces from the DataSet').conflicts('piece'))
+rmCommand.addOption(new Option('--wait-for-confirmation', 'Deprecated alias for --wait').hideHelp())
 
 rmCommand.action(async (options) => {
   // Validate: at least one of --piece or --all is required.
@@ -23,11 +24,17 @@ rmCommand.action(async (options) => {
     process.exit(1)
   }
 
+  // --wait is canonical; --wait-for-confirmation is a deprecated alias.
+  if (options.waitForConfirmation) {
+    log.warn('--wait-for-confirmation is deprecated; use --wait instead.')
+  }
+  const waitForConfirmation = Boolean(options.wait || options.waitForConfirmation)
+
   try {
     if (options.all) {
-      await runRmAllPieces(options)
+      await runRmAllPieces({ ...options, waitForConfirmation })
     } else {
-      await runRmPiece(options)
+      await runRmPiece({ ...options, waitForConfirmation })
     }
   } catch {
     // Error already displayed by clack UI


### PR DESCRIPTION
Part of #279. Implements the "standardize the confirmation-wait flag on `--wait`" breaking-change item from #522.

## Summary
- `rm` now uses `--wait` for confirmation waiting, matching `data-set terminate`.
- `--wait-for-confirmation` is kept as a hidden, deprecated alias that prints a warning and still works.
- `data-set terminate`'s existing unset-`--wait`-triggers-a-prompt behavior is preserved (unchanged).

## Breaking change
`rm --wait-for-confirmation` is deprecated in favor of `rm --wait`. The old flag still parses (with a deprecation warning).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `biome check` passes
- [x] `rm` / `data-set terminate` unit tests pass
- [x] `rm --help` shows `--wait` and hides `--wait-for-confirmation`
- [x] Verified `--wait-for-confirmation` still parses and maps to the confirmation-wait behavior