### PR TITLE
feat(payments)!: disambiguate fund and deposit day flags

### DIFF
--- a/src/commands/payments.ts
+++ b/src/commands/payments.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander'
+import { Command, Option } from 'commander'
 import { runAutoSetup } from '../payments/auto.js'
 import { runDeposit } from '../payments/deposit.js'
 import { runFund } from '../payments/fund.js'
@@ -6,6 +6,7 @@ import { runInteractiveSetup } from '../payments/interactive.js'
 import { showPaymentStatus } from '../payments/status.js'
 import type { FundOptions, PaymentSetupOptions } from '../payments/types.js'
 import { runWithdraw } from '../payments/withdraw.js'
+import { log } from '../utils/cli-logger.js'
 import { addAuthOptions } from '../utils/cli-options.js'
 
 export const paymentsCommand = new Command('payments').description('Manage payment setup for Filecoin Onchain Cloud')
@@ -45,23 +46,29 @@ const setupCommand = new Command('setup')
 addAuthOptions(setupCommand)
 paymentsCommand.addCommand(setupCommand)
 
-// Fund command - adjust funds to an exact runway or deposited total
+// Fund command - reconciles the balance to an EXACT target; can deposit OR withdraw.
 const fundCommand = new Command('fund')
-  .description('Adjust funds to an exact runway (days) or total deposit')
-  .option('--days <n>', 'Set final runway to exactly N days (deposit or withdraw as needed)')
-  .option('--amount <usdfc>', 'Set final deposited total to exactly this USDFC amount (deposit or withdraw)')
+  .description('Reconcile your balance to an exact target runway or deposit total (deposits OR withdraws as needed)')
+  .option('--target-days <n>', 'Reconcile the balance so the final runway is exactly N days (deposits or withdraws)')
+  .option('--amount <usdfc>', 'Reconcile the balance to exactly this USDFC total (deposits or withdraws)')
   .option(
     '--mode <mode>',
     'Mode to use for funding: "exact" (default) or "minimum". "exact" will withdraw/deposit to exactly match the target. "minimum" will only deposit if below the minimum target.'
   )
+  // Deprecated: --days was ambiguous with `payments deposit --days`. Use --target-days.
+  .addOption(new Option('--days <n>', 'Deprecated alias for --target-days').hideHelp())
   .action(async (options) => {
     try {
+      if (options.days != null) {
+        log.warn('payments fund: --days is deprecated; use --target-days instead.')
+      }
+      const targetDays = options.targetDays ?? options.days
       const fundOptions: FundOptions = {
         ...options,
         amount: options.amount,
         mode: options.mode,
       }
-      if (options.days != null) fundOptions.days = Number(options.days)
+      if (targetDays != null) fundOptions.days = Number(targetDays)
       await runFund(fundOptions)
     } catch {
       process.exit(1)
@@ -106,17 +113,23 @@ const statusCommand = new Command('status')
 addAuthOptions(statusCommand)
 paymentsCommand.addCommand(statusCommand)
 
-// Deposit command
+// Deposit command - additive top-up ONLY; never withdraws.
 const depositCommand = new Command('deposit')
-  .description('Deposit or top-up funds in Filecoin Pay')
-  .option('--amount <usdfc>', 'USDFC amount to deposit (e.g., 10.5)')
-  .option('--days <n>', 'Fund enough to keep current spend alive for N days')
+  .description('Add funds to your balance (additive top-up only; never withdraws)')
+  .option('--amount <usdfc>', 'USDFC amount to add to your balance (e.g., 10.5)')
+  .option('--cover-days <n>', 'Add enough to cover N days at the current spend rate (additive; never withdraws)')
+  // Deprecated: --days was ambiguous with `payments fund --days`. Use --cover-days.
+  .addOption(new Option('--days <n>', 'Deprecated alias for --cover-days').hideHelp())
   .action(async (options) => {
     try {
+      if (options.days != null) {
+        log.warn('payments deposit: --days is deprecated; use --cover-days instead.')
+      }
+      const coverDays = options.coverDays ?? options.days
       await runDeposit({
         ...options,
         amount: options.amount,
-        days: options.days != null ? Number(options.days) : undefined, // Only pass days if explicitly provided
+        days: coverDays != null ? Number(coverDays) : undefined, // Only pass days if explicitly provided
       })
     } catch {
       process.exit(1)

--- a/src/commands/payments.ts
+++ b/src/commands/payments.ts
@@ -46,7 +46,7 @@ const setupCommand = new Command('setup')
 addAuthOptions(setupCommand)
 paymentsCommand.addCommand(setupCommand)
 
-// Fund command - reconciles the balance to an EXACT target; can deposit OR withdraw.
+// Fund command - reconciles the balance to an exact target; can deposit or withdraw.
 const fundCommand = new Command('fund')
   .description('Reconcile your balance to an exact target runway or deposit total (deposits OR withdraws as needed)')
   .option('--target-days <n>', 'Reconcile the balance so the final runway is exactly N days (deposits or withdraws)')
@@ -113,7 +113,7 @@ const statusCommand = new Command('status')
 addAuthOptions(statusCommand)
 paymentsCommand.addCommand(statusCommand)
 
-// Deposit command - additive top-up ONLY; never withdraws.
+// Deposit command - additive top-up only; never withdraws.
 const depositCommand = new Command('deposit')
   .description('Add funds to your balance (additive top-up only; never withdraws)')
   .option('--amount <usdfc>', 'USDFC amount to add to your balance (e.g., 10.5)')

--- a/src/commands/payments.ts
+++ b/src/commands/payments.ts
@@ -56,7 +56,7 @@ const fundCommand = new Command('fund')
     'Mode to use for funding: "exact" (default) or "minimum". "exact" will withdraw/deposit to exactly match the target. "minimum" will only deposit if below the minimum target.'
   )
   // Deprecated: --days was ambiguous with `payments deposit --days`. Use --target-days.
-  .addOption(new Option('--days <n>', 'Deprecated alias for --target-days').hideHelp())
+  .addOption(new Option('--days <n>', 'Deprecated alias for --target-days').hideHelp().conflicts('targetDays'))
   .action(async (options) => {
     try {
       if (options.days != null) {
@@ -119,7 +119,7 @@ const depositCommand = new Command('deposit')
   .option('--amount <usdfc>', 'USDFC amount to add to your balance (e.g., 10.5)')
   .option('--cover-days <n>', 'Add enough to cover N days at the current spend rate (additive; never withdraws)')
   // Deprecated: --days was ambiguous with `payments fund --days`. Use --cover-days.
-  .addOption(new Option('--days <n>', 'Deprecated alias for --cover-days').hideHelp())
+  .addOption(new Option('--days <n>', 'Deprecated alias for --cover-days').hideHelp().conflicts('coverDays'))
   .action(async (options) => {
     try {
       if (options.days != null) {

--- a/src/payments/deposit.ts
+++ b/src/payments/deposit.ts
@@ -42,9 +42,9 @@ export async function runDeposit(options: DepositOptions): Promise<void> {
   const hasDays = options.days != null
 
   if ((hasAmount && hasDays) || (!hasAmount && !hasDays)) {
-    log.line(pc.red('Error: Specify exactly one of --amount <USDFC> or --days <N>'))
+    log.line(pc.red('Error: Specify exactly one of --amount <USDFC> or --cover-days <N>'))
     log.flush()
-    throw new CliFatal('Specify exactly one of --amount <USDFC> or --days <N>')
+    throw new CliFatal('Specify exactly one of --amount <USDFC> or --cover-days <N>')
   }
 
   // Connect
@@ -92,7 +92,7 @@ export async function runDeposit(options: DepositOptions): Promise<void> {
     } else if (hasDays) {
       const days = Number(options.days)
       if (!Number.isFinite(days) || days <= 0) {
-        throw new Error('--days must be a positive number')
+        throw new Error('--cover-days must be a positive number')
       }
 
       const { topUp, rateUsed, perDay } = computeTopUpForDuration(accountSummary, status.filecoinPayBalance, days)

--- a/src/payments/fund.ts
+++ b/src/payments/fund.ts
@@ -230,9 +230,9 @@ export async function runFund(options: FundOptions): Promise<void> {
   const hasDays = options.days != null
   const hasAmount = options.amount != null
   if ((hasDays && hasAmount) || (!hasDays && !hasAmount)) {
-    log.line(pc.red('Error: Specify exactly one of --days <N> or --amount <USDFC>'))
+    log.line(pc.red('Error: Specify exactly one of --target-days <N> or --amount <USDFC>'))
     log.flush()
-    throw new CliFatal('Specify exactly one of --days <N> or --amount <USDFC>')
+    throw new CliFatal('Specify exactly one of --target-days <N> or --amount <USDFC>')
   }
   if (options.mode != null && !['exact', 'minimum'].includes(options.mode)) {
     log.line(pc.red(`Error: Invalid mode (must be "exact" or "minimum"), received: '${options.mode}'`))
@@ -252,7 +252,7 @@ export async function runFund(options: FundOptions): Promise<void> {
 
     const targetDays: number = hasDays ? Number(options.days) : 0
     if (hasDays && (!Number.isFinite(targetDays) || targetDays < 0)) {
-      throw new Error('--days must be a non-negative number')
+      throw new Error('--target-days must be a non-negative number')
     }
 
     let targetDeposit: bigint = 0n

--- a/src/test/unit/payments-day-flags.test.ts
+++ b/src/test/unit/payments-day-flags.test.ts
@@ -1,13 +1,13 @@
 import type { Command, Option } from 'commander'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { paymentsCommand } from '../../commands/index.js'
 
-function findSubcommand(name: string): Command {
-  const cmd = paymentsCommand.commands.find((c) => c.name() === name)
-  if (cmd == null) {
+function findSubcommand(cmd: Command, name: string): Command {
+  const sub = cmd.commands.find((c) => c.name() === name)
+  if (sub == null) {
     throw new Error(`payments subcommand "${name}" not found`)
   }
-  return cmd
+  return sub
 }
 
 function findOption(cmd: Command, long: string): Option {
@@ -18,36 +18,38 @@ function findOption(cmd: Command, long: string): Option {
   return opt
 }
 
-// Make a subcommand test-safe: throw instead of exiting on parse errors, and
-// swallow the error output Commander writes to stderr.
-function parseSafe(cmd: Command, args: string[]): Promise<Command> {
-  return cmd
+// Parsing mutates the command (exitOverride/configureOutput) and runs its
+// action, so import a fresh copy of the command tree to avoid leaking state
+// onto the shared `paymentsCommand` singleton other test files import.
+async function freshSubcommand(name: string): Promise<Command> {
+  vi.resetModules()
+  const { paymentsCommand: fresh } = await import('../../commands/index.js')
+  return findSubcommand(fresh, name)
     .exitOverride()
     .configureOutput({ writeErr: () => undefined })
-    .parseAsync(args, { from: 'user' })
 }
 
 describe('payments day-flag wiring', () => {
   it('fund exposes --target-days and hides the deprecated --days', () => {
-    const fund = findSubcommand('fund')
+    const fund = findSubcommand(paymentsCommand, 'fund')
     expect(findOption(fund, '--target-days').hidden).not.toBe(true)
     expect(findOption(fund, '--days').hidden).toBe(true)
   })
 
   it('deposit exposes --cover-days and hides the deprecated --days', () => {
-    const deposit = findSubcommand('deposit')
+    const deposit = findSubcommand(paymentsCommand, 'deposit')
     expect(findOption(deposit, '--cover-days').hidden).not.toBe(true)
     expect(findOption(deposit, '--days').hidden).toBe(true)
   })
 
   it('fund help lists --target-days but not the deprecated --days', () => {
-    const help = findSubcommand('fund').helpInformation()
+    const help = findSubcommand(paymentsCommand, 'fund').helpInformation()
     expect(help).toContain('--target-days')
     expect(help).not.toMatch(/(?<!target-)--days\b/)
   })
 
   it('deposit help lists --cover-days but not the deprecated --days', () => {
-    const help = findSubcommand('deposit').helpInformation()
+    const help = findSubcommand(paymentsCommand, 'deposit').helpInformation()
     expect(help).toContain('--cover-days')
     expect(help).not.toMatch(/(?<!cover-)--days\b/)
   })
@@ -55,13 +57,15 @@ describe('payments day-flag wiring', () => {
 
 describe('payments deprecated --days conflicts', () => {
   it('fund rejects --target-days together with the deprecated --days', async () => {
-    await expect(parseSafe(findSubcommand('fund'), ['--target-days', '10', '--days', '5'])).rejects.toThrow(
+    const fund = await freshSubcommand('fund')
+    await expect(fund.parseAsync(['--target-days', '10', '--days', '5'], { from: 'user' })).rejects.toThrow(
       /cannot be used with/
     )
   })
 
   it('deposit rejects --cover-days together with the deprecated --days', async () => {
-    await expect(parseSafe(findSubcommand('deposit'), ['--cover-days', '10', '--days', '5'])).rejects.toThrow(
+    const deposit = await freshSubcommand('deposit')
+    await expect(deposit.parseAsync(['--cover-days', '10', '--days', '5'], { from: 'user' })).rejects.toThrow(
       /cannot be used with/
     )
   })

--- a/src/test/unit/payments-day-flags.test.ts
+++ b/src/test/unit/payments-day-flags.test.ts
@@ -1,0 +1,29 @@
+import type { Command } from 'commander'
+import { describe, expect, it } from 'vitest'
+import { paymentsCommand } from '../../commands/index.js'
+
+// Grab a payments subcommand and make it test-safe: throw instead of exiting
+// on parse errors, and swallow the error output Commander writes to stderr.
+function subcommand(name: string): Command {
+  const cmd = paymentsCommand.commands.find((c) => c.name() === name)
+  if (cmd == null) {
+    throw new Error(`payments subcommand "${name}" not found`)
+  }
+  return cmd.exitOverride().configureOutput({ writeErr: () => undefined })
+}
+
+describe('payments deprecated --days conflicts', () => {
+  it('payments fund rejects --target-days together with the deprecated --days', async () => {
+    const fund = subcommand('fund')
+    await expect(fund.parseAsync(['--target-days', '10', '--days', '5'], { from: 'user' })).rejects.toThrow(
+      /cannot be used with/
+    )
+  })
+
+  it('payments deposit rejects --cover-days together with the deprecated --days', async () => {
+    const deposit = subcommand('deposit')
+    await expect(deposit.parseAsync(['--cover-days', '10', '--days', '5'], { from: 'user' })).rejects.toThrow(
+      /cannot be used with/
+    )
+  })
+})

--- a/src/test/unit/payments-day-flags.test.ts
+++ b/src/test/unit/payments-day-flags.test.ts
@@ -1,28 +1,67 @@
-import type { Command } from 'commander'
+import type { Command, Option } from 'commander'
 import { describe, expect, it } from 'vitest'
 import { paymentsCommand } from '../../commands/index.js'
 
-// Grab a payments subcommand and make it test-safe: throw instead of exiting
-// on parse errors, and swallow the error output Commander writes to stderr.
-function subcommand(name: string): Command {
+function findSubcommand(name: string): Command {
   const cmd = paymentsCommand.commands.find((c) => c.name() === name)
   if (cmd == null) {
     throw new Error(`payments subcommand "${name}" not found`)
   }
-  return cmd.exitOverride().configureOutput({ writeErr: () => undefined })
+  return cmd
 }
 
+function findOption(cmd: Command, long: string): Option {
+  const opt = cmd.options.find((o) => o.long === long)
+  if (opt == null) {
+    throw new Error(`${cmd.name()} is missing option ${long}`)
+  }
+  return opt
+}
+
+// Make a subcommand test-safe: throw instead of exiting on parse errors, and
+// swallow the error output Commander writes to stderr.
+function parseSafe(cmd: Command, args: string[]): Promise<Command> {
+  return cmd
+    .exitOverride()
+    .configureOutput({ writeErr: () => undefined })
+    .parseAsync(args, { from: 'user' })
+}
+
+describe('payments day-flag wiring', () => {
+  it('fund exposes --target-days and hides the deprecated --days', () => {
+    const fund = findSubcommand('fund')
+    expect(findOption(fund, '--target-days').hidden).not.toBe(true)
+    expect(findOption(fund, '--days').hidden).toBe(true)
+  })
+
+  it('deposit exposes --cover-days and hides the deprecated --days', () => {
+    const deposit = findSubcommand('deposit')
+    expect(findOption(deposit, '--cover-days').hidden).not.toBe(true)
+    expect(findOption(deposit, '--days').hidden).toBe(true)
+  })
+
+  it('fund help lists --target-days but not the deprecated --days', () => {
+    const help = findSubcommand('fund').helpInformation()
+    expect(help).toContain('--target-days')
+    expect(help).not.toMatch(/(?<!target-)--days\b/)
+  })
+
+  it('deposit help lists --cover-days but not the deprecated --days', () => {
+    const help = findSubcommand('deposit').helpInformation()
+    expect(help).toContain('--cover-days')
+    expect(help).not.toMatch(/(?<!cover-)--days\b/)
+  })
+})
+
 describe('payments deprecated --days conflicts', () => {
-  it('payments fund rejects --target-days together with the deprecated --days', async () => {
-    const fund = subcommand('fund')
-    await expect(fund.parseAsync(['--target-days', '10', '--days', '5'], { from: 'user' })).rejects.toThrow(
+  it('fund rejects --target-days together with the deprecated --days', async () => {
+    await expect(parseSafe(findSubcommand('fund'), ['--target-days', '10', '--days', '5'])).rejects.toThrow(
       /cannot be used with/
     )
   })
 
-  it('payments deposit rejects --cover-days together with the deprecated --days', async () => {
-    const deposit = subcommand('deposit')
-    await expect(deposit.parseAsync(['--cover-days', '10', '--days', '5'], { from: 'user' })).rejects.toThrow(
+  it('deposit rejects --cover-days together with the deprecated --days', async () => {
+    await expect(parseSafe(findSubcommand('deposit'), ['--cover-days', '10', '--days', '5'])).rejects.toThrow(
       /cannot be used with/
     )
   })


### PR DESCRIPTION
Part of #279. Addresses the final task of #522 (GA: CLI cleanup and consistency).

## Problem

`payments fund --days` and `payments deposit --days` shared a flag name but meant different things:

- **fund** reconciles your balance to an exact runway — it deposits **or withdraws** to hit the target.
- **deposit** is an additive top-up that **never withdraws**.

Same flag, opposite behavior. Easy to reach for the wrong command and get a surprising withdraw (or a no-op top-up).

## Change

Rename the flags so intent is explicit:

| Command | Old | New |
| --- | --- | --- |
| `payments fund` | `--days` | `--target-days` |
| `payments deposit` | `--days` | `--cover-days` |

- The old `--days` remains as a **hidden, deprecated alias** on both commands and prints a deprecation warning when used, so existing scripts keep working.
- Command descriptions and validation error messages now state the deposit/withdraw direction explicitly.

## Verification

- `npx tsc --noEmit` and `npx biome check` clean on changed files.
- `payments fund --help` shows `--target-days` (hides `--days`); `payments deposit --help` shows `--cover-days` (hides `--days`).
- Confirmed the deprecated `--days` still parses on both commands.
- Unit suite passes (the 4 unrelated `upload-action` failures are a pre-existing worktree package-resolution issue, not touched here).

## Breaking change

`--days` on `payments fund` and `payments deposit` is deprecated. Use `--target-days` and `--cover-days` respectively. The old flag still works but emits a deprecation warning.