### PR TITLE
feat(core)!: remove authorizeSession:resolving event

### DIFF
--- a/src/core/session/authorize-session.ts
+++ b/src/core/session/authorize-session.ts
@@ -65,11 +65,6 @@ export async function authorizeSessionAddress(
     throw new Error(`No session key registry address configured for chain id ${client.chain.id}`)
   }
 
-  options.onProgress?.({
-    type: 'authorizeSession:resolving',
-    data: { sessionAddress, ownerAddress },
-  })
-
   const expiry = Math.floor(Date.now() / 1000) + validityDays * 24 * 60 * 60
 
   options.onProgress?.({

--- a/src/core/session/types.ts
+++ b/src/core/session/types.ts
@@ -10,7 +10,6 @@ import type { ProgressEvent } from '../utils/types.js'
  * Progress events emitted while authorizing a session key on-chain.
  */
 export type AuthorizeSessionProgressEvents =
-  | ProgressEvent<'authorizeSession:resolving', { sessionAddress: Address; ownerAddress: Address }>
   | ProgressEvent<'authorizeSession:submitting', { sessionAddress: Address; registryAddress: Address }>
   | ProgressEvent<'authorizeSession:submitted', { txHash: Hash; sessionAddress: Address }>
   | ProgressEvent<

--- a/src/test/unit/session-authorize.test.ts
+++ b/src/test/unit/session-authorize.test.ts
@@ -61,7 +61,6 @@ describe('authorizeSessionAddress', () => {
     expect(result.chainId).toBe(calibration.id)
     expect(result.validityDays).toBe(7)
     expect(events).toEqual([
-      'authorizeSession:resolving',
       'authorizeSession:submitting',
       'authorizeSession:submitted',
       'authorizeSession:confirmed',

--- a/src/test/unit/session-authorize.test.ts
+++ b/src/test/unit/session-authorize.test.ts
@@ -60,10 +60,6 @@ describe('authorizeSessionAddress', () => {
     expect(result.blockNumber).toBe(42n)
     expect(result.chainId).toBe(calibration.id)
     expect(result.validityDays).toBe(7)
-    expect(events).toEqual([
-      'authorizeSession:submitting',
-      'authorizeSession:submitted',
-      'authorizeSession:confirmed',
-    ])
+    expect(events).toEqual(['authorizeSession:submitting', 'authorizeSession:submitted', 'authorizeSession:confirmed'])
   })
 })


### PR DESCRIPTION
## Problem

`authorizeSession:resolving` does not mark an observable phase. It fires synchronously back-to-back with `authorizeSession:submitting`; the only statement between the two emissions is a synchronous expiry calculation, and the resolution work it claims to mark (`getAddress` checksumming, registry address lookup) completes before the event is emitted. Neither CLI runner (`run-create.ts`, `run-authorize.ts`) consumes it; both progress switches start at `submitting`.

## Change

Removes the event from `AuthorizeSessionProgressEvents`, its emission in `authorizeSessionAddress`, and the test assertion. `ownerAddress` remains available in the function's return value.

BREAKING CHANGE: `AuthorizeSessionProgressEvents` no longer includes `authorizeSession:resolving`. Progress handlers should treat `authorizeSession:submitting` as the first event.

## Context

Came out of the #518 review, where the same vestigial event was about to be copied into `revokeSessionAddress` for symmetry. #518 drops `revokeSession:resolving`; this PR removes the original.