### PR TITLE
feat(cli): finish Option.env() rollout

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -1,6 +1,6 @@
 import { Command, Option } from 'commander'
 import { startServer } from '../server.js'
-import { addNetworkOptions, addSigningAuthOptions } from '../utils/cli-options.js'
+import { addNetworkOptions, addSigningAuthOptions, rpcUrlOption } from '../utils/cli-options.js'
 
 export const serverCommand = new Command('server')
   .description('Start the IPFS Pinning Service API server')
@@ -8,8 +8,14 @@ export const serverCommand = new Command('server')
   .option('--host <string>', 'server host', '127.0.0.1')
   .option('--car-storage <path>', 'path for CAR file storage', './cars')
   .option('--database <path>', 'path to SQLite database', './pins.db')
-  .option('--access-token <token>', 'bearer token required on all API requests except GET / (env: ACCESS_TOKEN)')
+  .addOption(
+    new Option('--access-token <token>', 'bearer token required on all API requests except GET /').env('ACCESS_TOKEN')
+  )
   .option(
+    // ALLOW_NO_AUTH is intentionally NOT bound via .env(): Commander treats a
+    // defined env var as true for boolean options regardless of its value,
+    // while the config loader requires ALLOW_NO_AUTH === 'true'. Binding it
+    // would turn ALLOW_NO_AUTH=false into an enabled flag.
     '--allow-no-auth',
     'start the server without an access token, serving all requests unauthenticated (env: ALLOW_NO_AUTH)'
   )
@@ -17,7 +23,7 @@ export const serverCommand = new Command('server')
 addSigningAuthOptions(serverCommand)
 addNetworkOptions(serverCommand)
   .addOption(
-    new Option('--rpc-url <url>', 'RPC URL for Filecoin network (overrides --network)').env('RPC_URL')
+    rpcUrlOption('RPC URL for Filecoin network (overrides --network)')
     // default rpcUrl value is defined in ../common/get-rpc-url.ts
   )
   .action(async (options) => {

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -5,9 +5,9 @@
  * errors to exit codes. All user-facing output lives in the runners.
  */
 
-import { Command, Option } from 'commander'
+import { Command } from 'commander'
 import { runSessionAuthorize, runSessionCreate, runSessionGenerate } from '../session/index.js'
-import { addOwnerAuthOptions } from '../utils/cli-options.js'
+import { addOwnerAuthOptions, sessionKeyOption } from '../utils/cli-options.js'
 
 export const sessionCommand = new Command('session').description(
   'Authorize and manage session keys for delegated FWSS access'
@@ -18,7 +18,7 @@ export const sessionCommand = new Command('session').description(
 const createCommand = new Command('create')
   .description('Generate (or reuse) a session key and authorize it on-chain')
   .option('--validity-days <days>', 'Number of days the session key should be valid (max 365)', '10')
-  .addOption(new Option('--session-key <key>', 'Reuse an existing session private key').env('SESSION_KEY'))
+  .addOption(sessionKeyOption('Reuse an existing session private key'))
   .action(async (options) => {
     try {
       await runSessionCreate(options)

--- a/src/payments/interactive.ts
+++ b/src/payments/interactive.ts
@@ -47,7 +47,7 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
   try {
     // Get private key
-    let privateKey = options.privateKey || process.env.PRIVATE_KEY
+    let privateKey = options.privateKey
 
     if (!privateKey) {
       const input = await password({

--- a/src/session/run-authorize.ts
+++ b/src/session/run-authorize.ts
@@ -26,7 +26,7 @@ import type { SessionAuthorizeOptions } from './types.js'
 export async function runSessionAuthorize(options: SessionAuthorizeOptions): Promise<AuthorizeSessionResult> {
   intro(pc.bold('Filecoin Pin Session Authorize'))
 
-  const privateKey = options.privateKey || process.env.PRIVATE_KEY
+  const privateKey = options.privateKey
   if (!privateKey) {
     cancel('PRIVATE_KEY environment variable or --private-key option is required')
     throw new Error('PRIVATE_KEY environment variable or --private-key option is required')

--- a/src/session/run-create.ts
+++ b/src/session/run-create.ts
@@ -25,13 +25,13 @@ export async function runSessionCreate(options: SessionCreateOptions): Promise<C
 
   const spinner = createSpinner()
 
-  const privateKey = options.privateKey || process.env.PRIVATE_KEY
+  const privateKey = options.privateKey
   if (!privateKey) {
     cancel('PRIVATE_KEY environment variable or --private-key option is required')
     throw new Error('PRIVATE_KEY environment variable or --private-key option is required')
   }
 
-  const sessionPrivateKey = options.sessionKey || process.env.SESSION_KEY
+  const sessionPrivateKey = options.sessionKey
 
   let validityDays: number
   try {

--- a/src/test/unit/cli-options.test.ts
+++ b/src/test/unit/cli-options.test.ts
@@ -1,10 +1,13 @@
 import { Command, Option } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { serverCommand } from '../../commands/server.js'
+import { sessionCommand } from '../../commands/session.js'
 import { log } from '../../utils/cli-logger.js'
 import {
   addAuthOptions,
   addDataSetIdOption,
   addNetworkOptions,
+  addOwnerAuthOptions,
   addProviderIdOption,
   addSigningAuthOptions,
   validateAndNormalizeAutoFundOptions,
@@ -136,6 +139,26 @@ describe('auth and context option env bindings', () => {
     const command = addAuthOptions(new Command())
     expect(envVarFor(command, '--private-key')).toBe('PRIVATE_KEY')
     expect(envVarFor(command, '--view-address')).toBe('VIEW_ADDRESS')
+  })
+
+  it('addOwnerAuthOptions binds its flags to their env vars', () => {
+    const command = addOwnerAuthOptions(new Command())
+    expect(envVarFor(command, '--private-key')).toBe('PRIVATE_KEY')
+    expect(envVarFor(command, '--rpc-url')).toBe('RPC_URL')
+  })
+
+  it('binds the server auth and rpc flags to their env vars', () => {
+    expect(envVarFor(serverCommand, '--access-token')).toBe('ACCESS_TOKEN')
+    expect(envVarFor(serverCommand, '--rpc-url')).toBe('RPC_URL')
+    expect(envVarFor(serverCommand, '--allow-no-auth')).toBeUndefined()
+  })
+
+  it('binds session create --session-key to its env var', () => {
+    const createCommand = sessionCommand.commands.find((c) => c.name() === 'create')
+    expect(createCommand).toBeDefined()
+    if (createCommand) {
+      expect(envVarFor(createCommand, '--session-key')).toBe('SESSION_KEY')
+    }
   })
 })
 

--- a/src/utils/cli-auth.ts
+++ b/src/utils/cli-auth.ts
@@ -60,11 +60,10 @@ export function parseCLIAuth(options: CLIAuthOptions): SynapseSetupConfig {
   const hasRpcUrl = options.rpcUrl != null && options.rpcUrl !== ''
 
   // For devnet, fall back to the devnet user's private key if none provided
-  const privateKey =
-    options.privateKey || process.env.PRIVATE_KEY || (isDevnet ? resolveDevnetConfig().privateKey : undefined)
-  const walletAddress = options.walletAddress || process.env.WALLET_ADDRESS
-  const sessionKey = options.sessionKey || process.env.SESSION_KEY
-  const viewAddress = options.viewAddress || process.env.VIEW_ADDRESS
+  const privateKey = options.privateKey || (isDevnet ? resolveDevnetConfig().privateKey : undefined)
+  const walletAddress = options.walletAddress
+  const sessionKey = options.sessionKey
+  const viewAddress = options.viewAddress
   const rpcUrl = getRpcUrl(options)
 
   // --network and --rpc-url are mutually exclusive at the Commander level. Set the chain hint

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -12,6 +12,24 @@ import { USDFC_DECIMALS } from '../core/payments/constants.js'
 import { log } from './cli-logger.js'
 
 /**
+ * Option factories for flags declared on more than one command. Each pairs a
+ * flag with its backing env var exactly once; only the description varies per
+ * command. `--help` shows the env var (e.g. `[env: PRIVATE_KEY]`) and the CLI
+ * flag wins over the env var.
+ */
+export function privateKeyOption(description: string): Option {
+  return new Option('--private-key <key>', description).env('PRIVATE_KEY')
+}
+
+export function sessionKeyOption(description: string): Option {
+  return new Option('--session-key <key>', description).env('SESSION_KEY')
+}
+
+export function rpcUrlOption(description: string): Option {
+  return new Option('--rpc-url <url>', description).env('RPC_URL')
+}
+
+/**
  * Add the signing-auth flags shared by every authenticated command:
  * `--private-key`, `--wallet-address`, `--session-key`.
  *
@@ -22,9 +40,9 @@ import { log } from './cli-logger.js'
  */
 export function addSigningAuthOptions(command: Command): Command {
   return command
-    .addOption(new Option('--private-key <key>', 'Private key for standard auth').env('PRIVATE_KEY'))
+    .addOption(privateKeyOption('Private key for standard auth'))
     .addOption(new Option('--wallet-address <address>', 'Wallet address for session key auth').env('WALLET_ADDRESS'))
-    .addOption(new Option('--session-key <key>', 'Session key for session key auth').env('SESSION_KEY'))
+    .addOption(sessionKeyOption('Session key for session key auth'))
 }
 
 /**
@@ -66,7 +84,7 @@ export function addAuthOptions(command: Command): Command {
   )
 
   return addNetworkOptions(command).addOption(
-    new Option('--rpc-url <url>', 'RPC endpoint').env('RPC_URL')
+    rpcUrlOption('RPC endpoint')
     // default rpcUrl value is defined in ../common/get-rpc-url.ts
   )
 }
@@ -130,6 +148,11 @@ export function addProviderIdOption(command: Command): Command {
   return command
     .addOption(
       withAttributeName(
+        // PROVIDER_IDS is intentionally NOT bound via .env(): gatherIdSelection
+        // (cli-auth.ts) comma-splits the env value and lets a flag fully
+        // replace it. Binding .env() here would feed the raw env string
+        // through collectId and leave that read dead, so the env var is named
+        // in the description instead.
         new Option(
           '--provider-id <id>',
           'Target a specific provider by ID; repeatable (can also use PROVIDER_IDS env)'
@@ -161,6 +184,8 @@ export function addDataSetIdOption(command: Command, config: DataSetIdOptionConf
   command
     .addOption(
       withAttributeName(
+        // DATA_SET_IDS is intentionally NOT bound via .env(); see the
+        // PROVIDER_IDS note in addProviderIdOption.
         new Option(
           '--data-set-id <id>',
           'Target a specific data set by ID; repeatable (can also use DATA_SET_IDS env)'
@@ -209,9 +234,9 @@ export function addContextSelectionOptions(command: Command): Command {
  * command.
  */
 export function addOwnerAuthOptions(command: Command): Command {
-  return addNetworkOptions(
-    command.addOption(new Option('--private-key <key>', 'Owner private key for signing').env('PRIVATE_KEY'))
-  ).addOption(new Option('--rpc-url <url>', 'RPC endpoint').env('RPC_URL'))
+  return addNetworkOptions(command.addOption(privateKeyOption('Owner private key for signing'))).addOption(
+    rpcUrlOption('RPC endpoint')
+  )
 }
 
 const ALLOWED_NETWORKS = ['mainnet', 'calibration', 'devnet']


### PR DESCRIPTION
## What changed

Completes the `Option.env()` convention #536 establishes:

- Shared option factories `privateKeyOption` / `sessionKeyOption` / `rpcUrlOption` in `cli-options.ts`, so each flag/env pairing is declared once and only descriptions vary per command. `addSigningAuthOptions`, `addOwnerAuthOptions`, `addAuthOptions`, `session create`, and `server` now share them.
- `server --access-token` migrates to `Option.env('ACCESS_TOKEN')`, removing the last hand-written `(env: ...)` prose on that help screen for a string flag.
- Comments document the intentional exemptions: `--allow-no-auth` (Commander treats a defined env var as true for boolean options regardless of value, while the config loader requires `ALLOW_NO_AUTH === 'true'`) and `--provider-id` / `--data-set-id` (env handling lives in `gatherIdSelection`, which comma-splits and lets a flag fully replace the env value).
- Removes the `options.x || process.env.X` fallbacks in `cli-auth.ts`, `run-create.ts`, `run-authorize.ts`, and `payments/interactive.ts`. Every command that reaches these paths binds the same env vars through Commander, which owns flag-over-env precedence; the devnet private-key fallback stays.
- Env-binding tests for `addOwnerAuthOptions`, the `server` command, and `session create --session-key`.

## Notes / risks

Based on #536; merge that first (this PR targets its branch and will retarget to master when it merges). Behavior is unchanged for every flag/env combination; the fallback removal relies on the `.env()` bindings delivering the same values at parse time.

`--port` / `--host` are not migrated here; #553 tracks that separately because it changes the effective default port.