### PR TITLE
fix!: gate payments preflight on needed transactions

### DIFF
--- a/src/core/payments/funding.ts
+++ b/src/core/payments/funding.ts
@@ -1,7 +1,7 @@
 import { CDN_FIXED_LOCKUP, USDFC_SYBIL_FEE } from '@filoz/synapse-core/utils'
 import { getServicePrice } from '@filoz/synapse-core/warm-storage'
 import { calibration, type Synapse } from '@filoz/synapse-sdk'
-import { MIN_FIL_FOR_GAS, USDFC_DECIMALS } from './constants.js'
+import { USDFC_DECIMALS } from './constants.js'
 import {
   checkAndSetAllowances,
   computeAdjustmentForExactDays,
@@ -423,8 +423,7 @@ export async function planFilecoinPayFunding(options: PlanFilecoinPayFundingOpti
   }
 
   const isCalibnet = status.chainId === calibration.id
-  const hasSufficientGas = status.filBalance >= MIN_FIL_FOR_GAS
-  const validation = validatePaymentRequirements(hasSufficientGas, status.walletUsdfcBalance, isCalibnet)
+  const validation = validatePaymentRequirements(status.filBalance, status.walletUsdfcBalance, isCalibnet)
   if (!validation.isValid) {
     const help = validation.helpMessage ? ` ${validation.helpMessage}` : ''
     throw new Error(`${validation.errorMessage}${help}`)

--- a/src/core/payments/index.ts
+++ b/src/core/payments/index.ts
@@ -25,6 +25,7 @@ import {
 import { calibration, SIZE_CONSTANTS, type Synapse, TIME_CONSTANTS, TOKENS } from '@filoz/synapse-sdk'
 import { formatUnits, type Hash } from 'viem'
 import { getClientAddress, isSessionKeyMode } from '../synapse/index.js'
+import { formatFIL } from '../utils/format.js'
 import { assertPriceNonZero } from '../utils/validate-pricing.js'
 import {
   DEFAULT_LOCKUP_DAYS,
@@ -206,20 +207,54 @@ export function getUsdfcAcquisitionHelpMessage(isCalibnet: boolean): string {
   ].join('\n  ')
 }
 
-export function validatePaymentRequirements(
-  hasSufficientGas: boolean,
-  walletUsdfcBalance: bigint,
-  isCalibnet: boolean
-): PaymentValidationResult {
-  if (!hasSufficientGas) {
+/**
+ * Validate that the wallet holds enough FIL to pay gas for transactions
+ *
+ * The failure message includes the current balance, the required minimum,
+ * and the shortfall so users know exactly how much FIL to add.
+ *
+ * @param filBalance - Wallet FIL balance in attoFIL
+ * @param isCalibnet - Whether the network is Calibration testnet
+ */
+export function validateGasRequirement(filBalance: bigint, isCalibnet: boolean): PaymentValidationResult {
+  if (filBalance < MIN_FIL_FOR_GAS) {
     const result: PaymentValidationResult = {
       isValid: false,
-      errorMessage: 'Insufficient FIL for gas fees',
+      errorMessage:
+        `Insufficient FIL for gas fees (balance: ${formatFIL(filBalance, isCalibnet)}, ` +
+        `minimum: ${formatFIL(MIN_FIL_FOR_GAS, isCalibnet)}, ` +
+        `add at least: ${formatFIL(MIN_FIL_FOR_GAS - filBalance, isCalibnet)})`,
     }
     if (isCalibnet) {
       result.helpMessage = 'Get test FIL from: https://faucet.calibnet.chainsafe-fil.io/'
     }
     return result
+  }
+
+  return { isValid: true }
+}
+
+/**
+ * Validate that the wallet can fund payment transactions: FIL for gas plus
+ * USDFC to deposit
+ *
+ * Only call this when the current operation will actually send transactions
+ * that spend wallet USDFC. For operations that spend gas alone (e.g. an
+ * allowance update), use {@link validateGasRequirement} so accounts that
+ * hold all their USDFC as deposits are not rejected.
+ *
+ * @param filBalance - Wallet FIL balance in attoFIL
+ * @param walletUsdfcBalance - Wallet USDFC balance (18 decimals)
+ * @param isCalibnet - Whether the network is Calibration testnet
+ */
+export function validatePaymentRequirements(
+  filBalance: bigint,
+  walletUsdfcBalance: bigint,
+  isCalibnet: boolean
+): PaymentValidationResult {
+  const gasCheck = validateGasRequirement(filBalance, isCalibnet)
+  if (!gasCheck.isValid) {
+    return gasCheck
   }
 
   if (walletUsdfcBalance === 0n) {

--- a/src/core/payments/index.ts
+++ b/src/core/payments/index.ts
@@ -218,17 +218,16 @@ export function getUsdfcAcquisitionHelpMessage(isCalibnet: boolean): string {
  */
 export function validateGasRequirement(filBalance: bigint, isCalibnet: boolean): PaymentValidationResult {
   if (filBalance < MIN_FIL_FOR_GAS) {
-    const result: PaymentValidationResult = {
+    return {
       isValid: false,
       errorMessage:
         `Insufficient FIL for gas fees (balance: ${formatFIL(filBalance, isCalibnet)}, ` +
         `minimum: ${formatFIL(MIN_FIL_FOR_GAS, isCalibnet)}, ` +
         `add at least: ${formatFIL(MIN_FIL_FOR_GAS - filBalance, isCalibnet)})`,
+      helpMessage: isCalibnet
+        ? 'Get test FIL from: https://faucet.calibnet.chainsafe-fil.io/'
+        : 'Acquire FIL for gas from an exchange',
     }
-    if (isCalibnet) {
-      result.helpMessage = 'Get test FIL from: https://faucet.calibnet.chainsafe-fil.io/'
-    }
-    return result
   }
 
   return { isValid: true }

--- a/src/core/upload/index.ts
+++ b/src/core/upload/index.ts
@@ -130,7 +130,7 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
   const filStatus = await checkFILBalance(synapse)
   const walletUsdfcBalance = await checkUSDFCBalance(synapse)
 
-  const validation = validatePaymentRequirements(filStatus.hasSufficientGas, walletUsdfcBalance, filStatus.isCalibnet)
+  const validation = validatePaymentRequirements(filStatus.balance, walletUsdfcBalance, filStatus.isCalibnet)
   if (!validation.isValid) {
     return {
       status: 'blocked',

--- a/src/core/utils/format.ts
+++ b/src/core/utils/format.ts
@@ -1,6 +1,6 @@
 import { formatEther, formatUnits } from 'viem'
-import type { StorageRunwaySummary } from '../payments/index.js'
-import { USDFC_DECIMALS } from '../payments/index.js'
+import { USDFC_DECIMALS } from '../payments/constants.js'
+import type { StorageRunwaySummary } from '../payments/types.js'
 
 const DAYS_PER_MONTH = 30
 const DAYS_PER_YEAR = 365

--- a/src/payments/auto.ts
+++ b/src/payments/auto.ts
@@ -11,6 +11,7 @@ import { parseUnits } from 'viem'
 import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import {
   calculateDepositCapacity,
+  checkAllowances,
   checkAndSetAllowances,
   checkFILBalance,
   checkUSDFCBalance,
@@ -18,6 +19,7 @@ import {
   depositUSDFC,
   getPaymentStatus,
   getServicePrice,
+  validateGasRequirement,
   validatePaymentRequirements,
 } from '../core/payments/index.js'
 import { DEFAULT_COPIES } from '../core/synapse/constants.js'
@@ -67,30 +69,21 @@ export async function runAutoSetup(options: PaymentSetupOptions): Promise<void> 
 
     spinner.stop(`${pc.green('✓')} Connected to ${pc.bold(network)}`)
 
-    // Check balances
+    // Check balances and on-chain payment state. Wallet funding is validated
+    // later, once the transactions this run needs are known: an
+    // already-configured account needs none, so it is never rejected for a
+    // low-gas wallet or for holding all of its USDFC as deposits.
     spinner.start('Checking balances...')
 
     const filStatus = await checkFILBalance(synapse)
     const walletUsdfcBalance = await checkUSDFCBalance(synapse)
+    const [status, accountSummary, allowanceCheck] = await Promise.all([
+      getPaymentStatus(synapse),
+      synapse.payments.accountSummary(),
+      checkAllowances(synapse),
+    ])
 
     spinner.stop(`${pc.green('✓')} Balance check complete`)
-
-    // Validate payment requirements
-    const validation = validatePaymentRequirements(filStatus.hasSufficientGas, walletUsdfcBalance, filStatus.isCalibnet)
-    if (!validation.isValid) {
-      const errorMsg = validation.errorMessage ?? 'Payment validation failed'
-      log.line(`${pc.red('✗')} ${errorMsg}`)
-      if (validation.helpMessage) {
-        log.line('')
-        log.line(`  ${pc.cyan(validation.helpMessage)}`)
-      }
-      log.flush()
-      cancel('Please fund your wallet and try again')
-      throw new CliFatal(errorMsg)
-    }
-
-    // Now safe to get payment status since we know account exists
-    const [status, accountSummary] = await Promise.all([getPaymentStatus(synapse), synapse.payments.accountSummary()])
 
     // Display account and balance info using shared function
     displayAccountInfo(
@@ -132,7 +125,30 @@ export async function runAutoSetup(options: PaymentSetupOptions): Promise<void> 
     let actionsTaken = false
     let actualFilecoinPayTopUp = 0n
 
-    if (status.filecoinPayBalance < targetFilecoinPayBalance) {
+    const needsDeposit = status.filecoinPayBalance < targetFilecoinPayBalance
+    const needsAllowanceUpdate = allowanceCheck.needsUpdate
+
+    // Gate on wallet funding only when this run will send transactions.
+    // A deposit spends wallet USDFC and gas; an allowance update spends gas
+    // alone, so wallet USDFC is not required for it.
+    if (needsDeposit || needsAllowanceUpdate) {
+      const validation = needsDeposit
+        ? validatePaymentRequirements(filStatus.balance, walletUsdfcBalance, filStatus.isCalibnet)
+        : validateGasRequirement(filStatus.balance, filStatus.isCalibnet)
+      if (!validation.isValid) {
+        const errorMsg = validation.errorMessage ?? 'Payment validation failed'
+        log.line(`${pc.red('✗')} ${errorMsg}`)
+        if (validation.helpMessage) {
+          log.line('')
+          log.line(`  ${pc.cyan(validation.helpMessage)}`)
+        }
+        log.flush()
+        cancel('Please fund your wallet and try again')
+        throw new CliFatal(errorMsg)
+      }
+    }
+
+    if (needsDeposit) {
       const neededFilecoinPayTopUp = targetFilecoinPayBalance - status.filecoinPayBalance
       actualFilecoinPayTopUp = neededFilecoinPayTopUp
 

--- a/src/payments/deposit.ts
+++ b/src/payments/deposit.ts
@@ -9,7 +9,13 @@
 import pc from 'picocolors'
 import { parseUnits } from 'viem'
 import { CliFatal, isCliFatal } from '../common/cli-errors.js'
-import { checkFILBalance, checkUSDFCBalance, depositUSDFC, toStorageRunwaySummary } from '../core/payments/index.js'
+import {
+  checkFILBalance,
+  checkUSDFCBalance,
+  depositUSDFC,
+  toStorageRunwaySummary,
+  validateGasRequirement,
+} from '../core/payments/index.js'
 import { initializeSynapse } from '../core/synapse/index.js'
 import { formatUSDFC } from '../core/utils/format.js'
 import { formatRunwaySummary } from '../core/utils/index.js'
@@ -49,15 +55,14 @@ export async function runDeposit(options: DepositOptions): Promise<void> {
     spinner.stop(`${pc.green('✓')} Connected`)
 
     // Validate balances
-    if (!filStatus.hasSufficientGas) {
-      log.line(`${pc.red('✗')} Insufficient FIL for gas fees`)
-      const help = filStatus.isCalibnet
-        ? 'Get test FIL from: https://faucet.calibnet.chainsafe-fil.io/'
-        : 'Acquire FIL for gas from an exchange'
-      log.line(`  ${pc.cyan(help)}`)
+    const gasCheck = validateGasRequirement(filStatus.balance, filStatus.isCalibnet)
+    if (!gasCheck.isValid) {
+      const errorMsg = gasCheck.errorMessage ?? 'Insufficient FIL for gas fees'
+      log.line(`${pc.red('✗')} ${errorMsg}`)
+      log.line(`  ${pc.cyan(gasCheck.helpMessage ?? 'Acquire FIL for gas from an exchange')}`)
       log.flush()
       cancel('Deposit aborted')
-      throw new CliFatal('Insufficient FIL for gas fees')
+      throw new CliFatal(errorMsg)
     }
 
     let depositAmount: bigint

--- a/src/payments/interactive.ts
+++ b/src/payments/interactive.ts
@@ -12,12 +12,14 @@ import { parseUnits } from 'viem'
 import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import {
   calculateDepositCapacity,
+  checkAllowances,
   checkAndSetAllowances,
   checkFILBalance,
   checkUSDFCBalance,
   DEFAULT_LOCKUP_DAYS,
   depositUSDFC,
   getPaymentStatus,
+  validateGasRequirement,
   validatePaymentRequirements,
 } from '../core/payments/index.js'
 import { getClientAddress, initializeSynapse } from '../core/synapse/index.js'
@@ -91,25 +93,31 @@ export async function runInteractiveSetup(options: PaymentSetupOptions): Promise
 
     const filStatus = await checkFILBalance(synapse)
     const walletUsdfcBalance = await checkUSDFCBalance(synapse)
+    const [status, allowanceCheck] = await Promise.all([getPaymentStatus(synapse), checkAllowances(synapse)])
 
     s.stop(`${pc.green('✓')} Balance check complete`)
 
-    // Validate payment requirements
-    const validation = validatePaymentRequirements(filStatus.hasSufficientGas, walletUsdfcBalance, filStatus.isCalibnet)
-    if (!validation.isValid) {
-      const errorMsg = validation.errorMessage ?? 'Payment validation failed'
-      log.line(`${pc.red('✗')} ${errorMsg}`)
-      if (validation.helpMessage) {
-        log.line('')
-        log.line(`  ${pc.cyan(validation.helpMessage)}`)
+    // Gate on wallet funding only when setup work remains. An account with a
+    // deposit and current allowances can complete this flow without sending a
+    // transaction. A first deposit spends wallet USDFC and gas; an allowance
+    // update spends gas alone, so wallet USDFC is not required for it.
+    const needsFirstDeposit = status.filecoinPayBalance === 0n
+    if (needsFirstDeposit || allowanceCheck.needsUpdate) {
+      const validation = needsFirstDeposit
+        ? validatePaymentRequirements(filStatus.balance, walletUsdfcBalance, filStatus.isCalibnet)
+        : validateGasRequirement(filStatus.balance, filStatus.isCalibnet)
+      if (!validation.isValid) {
+        const errorMsg = validation.errorMessage ?? 'Payment validation failed'
+        log.line(`${pc.red('✗')} ${errorMsg}`)
+        if (validation.helpMessage) {
+          log.line('')
+          log.line(`  ${pc.cyan(validation.helpMessage)}`)
+        }
+        log.flush()
+        cancel('Please fund your wallet and try again')
+        throw new CliFatal(errorMsg)
       }
-      log.flush()
-      cancel('Please fund your wallet and try again')
-      throw new CliFatal(errorMsg)
     }
-
-    // Now safe to get payment status since we know account exists
-    const status = await getPaymentStatus(synapse)
 
     displayAccountInfo(
       address,

--- a/src/payments/withdraw.ts
+++ b/src/payments/withdraw.ts
@@ -5,7 +5,7 @@
 import pc from 'picocolors'
 import { parseUnits } from 'viem'
 import { CliFatal, isCliFatal } from '../common/cli-errors.js'
-import { checkFILBalance, getPaymentStatus, withdrawUSDFC } from '../core/payments/index.js'
+import { checkFILBalance, getPaymentStatus, validateGasRequirement, withdrawUSDFC } from '../core/payments/index.js'
 import { initializeSynapse } from '../core/synapse/index.js'
 import { formatUSDFC } from '../core/utils/format.js'
 import { type CLIAuthOptions, getCLILogger, parseCLIAuth } from '../utils/cli-auth.js'
@@ -42,16 +42,15 @@ export async function runWithdraw(options: WithdrawOptions): Promise<void> {
     const logger = getCLILogger()
     const synapse = await initializeSynapse(authConfig, logger)
     const filStatus = await checkFILBalance(synapse)
-    if (!filStatus.hasSufficientGas) {
+    const gasCheck = validateGasRequirement(filStatus.balance, filStatus.isCalibnet)
+    if (!gasCheck.isValid) {
       spinner.stop()
-      log.line(`${pc.red('✗')} Insufficient FIL for gas fees`)
-      const help = filStatus.isCalibnet
-        ? 'Get test FIL from: https://faucet.calibnet.chainsafe-fil.io/'
-        : 'Acquire FIL for gas from an exchange'
-      log.line(`  ${pc.cyan(help)}`)
+      const errorMsg = gasCheck.errorMessage ?? 'Insufficient FIL for gas fees'
+      log.line(`${pc.red('✗')} ${errorMsg}`)
+      log.line(`  ${pc.cyan(gasCheck.helpMessage ?? 'Acquire FIL for gas from an exchange')}`)
       log.flush()
       cancel('Withdraw aborted')
-      throw new CliFatal('Insufficient FIL for gas fees')
+      throw new CliFatal(errorMsg)
     }
 
     spinner.stop(`${pc.green('✓')} Connected`)

--- a/src/test/unit/payment-validation.test.ts
+++ b/src/test/unit/payment-validation.test.ts
@@ -1,5 +1,10 @@
+import { parseEther } from 'viem'
 import { describe, expect, it } from 'vitest'
-import { getUsdfcAcquisitionHelpMessage, validatePaymentRequirements } from '../../core/payments/index.js'
+import {
+  getUsdfcAcquisitionHelpMessage,
+  validateGasRequirement,
+  validatePaymentRequirements,
+} from '../../core/payments/index.js'
 
 describe('getUsdfcAcquisitionHelpMessage', () => {
   it('returns testnet USDFC docs on calibration', () => {
@@ -17,12 +22,44 @@ describe('getUsdfcAcquisitionHelpMessage', () => {
   })
 })
 
+describe('validateGasRequirement', () => {
+  it('passes at or above the minimum', () => {
+    expect(validateGasRequirement(parseEther('0.1'), false).isValid).toBe(true)
+    expect(validateGasRequirement(parseEther('1'), false).isValid).toBe(true)
+  })
+
+  it('reports balance, minimum, and shortfall when below the minimum', () => {
+    const result = validateGasRequirement(parseEther('0.0989'), false)
+
+    expect(result.isValid).toBe(false)
+    expect(result.errorMessage).toContain('balance: 0.0989 FIL')
+    expect(result.errorMessage).toContain('minimum: 0.1000 FIL')
+    expect(result.errorMessage).toContain('add at least: 0.0011 FIL')
+  })
+
+  it('points at the FIL faucet on calibration', () => {
+    const result = validateGasRequirement(0n, true)
+
+    expect(result.isValid).toBe(false)
+    expect(result.errorMessage).toContain('tFIL')
+    expect(result.helpMessage).toContain('faucet.calibnet.chainsafe-fil.io')
+  })
+})
+
 describe('validatePaymentRequirements', () => {
   it('surfaces the mainnet USDFC docs when wallet balance is zero', () => {
-    const result = validatePaymentRequirements(true, 0n, false)
+    const result = validatePaymentRequirements(parseEther('1'), 0n, false)
 
     expect(result.isValid).toBe(false)
     expect(result.errorMessage).toBe('No USDFC tokens found')
     expect(result.helpMessage).toContain('https://app.usdfc.net/#/bridge')
+  })
+
+  it('reports the gas shortfall before the USDFC check', () => {
+    const result = validatePaymentRequirements(0n, 0n, false)
+
+    expect(result.isValid).toBe(false)
+    expect(result.errorMessage).toContain('Insufficient FIL for gas fees')
+    expect(result.errorMessage).toContain('add at least: 0.1000 FIL')
   })
 })

--- a/src/test/unit/payment-validation.test.ts
+++ b/src/test/unit/payment-validation.test.ts
@@ -35,6 +35,7 @@ describe('validateGasRequirement', () => {
     expect(result.errorMessage).toContain('balance: 0.0989 FIL')
     expect(result.errorMessage).toContain('minimum: 0.1000 FIL')
     expect(result.errorMessage).toContain('add at least: 0.0011 FIL')
+    expect(result.helpMessage).toContain('Acquire FIL for gas from an exchange')
   })
 
   it('points at the FIL faucet on calibration', () => {


### PR DESCRIPTION
### What changed

`payments setup` now reads on-chain state (deposit, operator allowances) before validating wallet funding, and only gates when the run will actually send transactions. A fully configured account reports "already configured" regardless of wallet FIL or USDFC balance. A deposit requires wallet USDFC and gas; an allowance update requires gas alone.

Gas failures now report the numbers: `Insufficient FIL for gas fees (balance: 0.0989 FIL, minimum: 0.1000 FIL, add at least: 0.0011 FIL)` via the new `validateGasRequirement`, used by setup, deposit, withdraw, fund, and upload preflight. `validatePaymentRequirements` takes the FIL balance instead of a precomputed boolean.

Fixes #557

### How to verify

Unit tests cover the message format and check ordering (`payment-validation.test.ts`). For the live path: with a configured account holding under 0.1 FIL, `payments setup --auto` completes instead of aborting; `payments deposit --amount 1` reports the exact shortfall.

### Notes / risks

The preflight gate and the allowance action both derive from `checkAllowances`, so they cannot disagree. Verified against FilOzone/synapse-sdk#823: no overlap with the Costs API reshape; the migration items it does create are tracked in #559.
