### PR TITLE
fix(ci): run publish job when build succeeds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -153,6 +153,11 @@ jobs:
 
   publish:
     needs: build
+    # build overrides its default condition with always(), and one of its needs
+    # (validate-dispatch) is skipped on the push path. The default success() check
+    # evaluates the whole transitive needs graph, so that skip would propagate here
+    # and skip publish even when build succeeded. Gate explicitly on build's result.
+    if: always() && needs.build.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # OIDC for npm trusted publishing


### PR DESCRIPTION
## Problem

The `publish` job in `release-please.yml` was silently **skipped** on a real release run ([run 27130203514](https://github.com/filecoin-project/filecoin-pin/actions/runs/27130203514/job/80069079347), the 0.23.0 release), even though everything upstream succeeded:

| Job | Conclusion |
|---|---|
| `release-please` | success |
| `validate-dispatch` | **skipped** (push event, not `workflow_dispatch`) |
| `build` | success |
| `publish` | **skipped** |

The release was cut and the `npm-tarball` artifact was built and uploaded — but nothing was published to npm.

## Root cause

`publish` had `needs: build` and **no explicit `if:`**, so it defaulted to `if: success()`. GitHub evaluates that implicit `success()` against the job's *entire transitive `needs` graph*, not just its direct dependency:

```
publish → build → validate-dispatch
```

On the push path, `validate-dispatch` is skipped (it only runs on `workflow_dispatch`). `build` survives that skip because it overrides its own condition with `always() && (...)`. But `publish` has no such override, so the skipped `validate-dispatch` propagates through `build` and skips `publish` too — despite `build` concluding `success`.

## Fix

Give `publish` an explicit condition that breaks the propagation and gates only on `build` actually succeeding:

```yaml
if: always() && needs.build.result == 'success'
```

`always()` stops the transitive-skip propagation; `needs.build.result == 'success'` ensures we still only publish when the tarball was built. This is correct for both trigger paths, since `build` only runs when `release_created == 'true'` (push) or `validate-dispatch` succeeded (dispatch).

## Note

This won't retroactively publish 0.23.0 — that release run won't re-trigger, so 0.23.0 still needs to be published to npm manually (e.g. via the `workflow_dispatch` path on the `v0.23.0` tag).