### PR TITLE
fix(ci): override skip propagation on publish job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -153,6 +153,11 @@ jobs:
 
   publish:
     needs: build
+    # build needs both release-please and validate-dispatch, and exactly one of
+    # those is skipped on every trigger (release-please on dispatch, validate-dispatch
+    # on push). That skip propagates down the needs chain, so publish must override
+    # with always() the same way build does, then gate on build actually succeeding.
+    if: ${{ always() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # OIDC for npm trusted publishing


### PR DESCRIPTION
## What changed

`publish` now runs on `if: ${{ always() && needs.build.result == 'success' }}`. Without it, `publish` used the default `success()` condition and inherited a skip from its `needs` chain: `build` depends on both `release-please` and `validate-dispatch`, and exactly one of those is always skipped (`release-please` on a tag dispatch, `validate-dispatch` on a push). `build` overrides that skip with `always()`; `publish` did not, so it skipped on every release path.

The result: 0.23.0 (#529) created its `v0.23.0` tag and GitHub release but never published to npm, so `latest` is still 0.22.3. The same skip hit both the push run (`27130203514`) and the manual tag dispatch (`27131420461`).

Introduced by #514, which split `publish` out of `build` and left it without build's guard.

## How to verify

Merge, then dispatch this workflow on the `v0.23.0` tag (the `validate-dispatch` path that already passed `build`). `publish` should run instead of skipping, and `npm view filecoin-pin version` should report `0.23.0`.

## Notes

The `v0.23.0` tag and GitHub release already exist, so shipping it does not need a new release-please PR. Re-running this workflow on the tag is enough.
