### PR TITLE
fix(ci): pass absolute tarball path to npm publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -191,7 +191,10 @@ jobs:
             echo "::error::Expected exactly one tarball in artifact/, found $COUNT"
             exit 1
           fi
-          TARBALL="artifact/$TARBALL_NAME"
+          # Absolute path: npm treats a bare "dir/file.tgz" arg as a GitHub
+          # owner/repo shorthand and tries to git-clone it. A leading "/" forces
+          # it to resolve as a local tarball file.
+          TARBALL="$PWD/artifact/$TARBALL_NAME"
           if [ ! -f "$TARBALL" ]; then
             echo "::error::Tarball $TARBALL not found"
             exit 1


### PR DESCRIPTION
## Problem

With the skip-propagation fix from #562 in place, the `publish` job finally **runs** on a release — and immediately fails ([run 27188599616](https://github.com/filecoin-project/filecoin-pin/actions/runs/27188599616/job/80263241099), the 0.23.1 release):

```
npm error code 128
npm error An unknown git error occurred
npm error command git --no-replace-objects ls-remote ssh://git@github.com/artifact/filecoin-pin-0.23.1.tgz.git
npm error git@github.com: Permission denied (publickey).
```

## Root cause — regression from #514

Publishing has been broken since #514 ("chore(ci): split build and publish jobs"). The last successful publish was **0.22.3 on 2026-06-01**, before #514 merged (2026-06-05); nothing has published since (0.23.0 skipped, 0.23.1 failed).

Before #514, publishing was a single step run in the repo root:

```yaml
run: npm publish --access public ${{ ...dry_run && '--dry-run' || '' }}
```

No path argument, so npm published the working directory. #514 changed this to publish a packed tarball by path:

```bash
TARBALL="artifact/$TARBALL_NAME"        # e.g. artifact/filecoin-pin-0.23.1.tgz
npm publish --access public "$TARBALL"
```

A bare `dir/file.tgz` argument has the `owner/repo` shape, so npm's package-arg parser classifies it as a **GitHub shorthand spec** (`owner=artifact`, `repo=filecoin-pin-0.23.1.tgz`) rather than a local file, and tries to `git ls-remote` it over SSH — which the runner has no key for, giving git exit code 128.

(#514 introduced *two* regressions: the publish job also lost its `if:` and was skipped — fixed separately in #562. This PR fixes the second.)

## Fix

Resolve the tarball to an absolute path so the leading `/` forces npm to treat it as a local file:

```bash
TARBALL="$PWD/artifact/$TARBALL_NAME"
```

The existing `-f` existence check and the `--dry-run` branch both keep working unchanged.

## Auth note

#514 preserved the OIDC trusted-publishing config that produced the last good publish (`id-token: write` on the publish job, `npm@11` ≥ 11.5.1). Since 0.22.3 published fine under that same config, auth is unlikely to be a further blocker — but it's the next step the job reaches, so worth a glance if the next run surprises us.

After this merges, `0.23.1` still needs a release run to actually publish (the failed run won't re-trigger on its own).