### PR TITLE
docs: pad test uploads past SP minimum size in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -164,8 +164,14 @@ exercise the full path:
 
 ```bash
 # Small, unique, and easy to eyeball on retrieval.
-TMPFILE=$(mktemp) && date > "$TMPFILE" && filecoin-pin add "$TMPFILE"
+# Pad past CAR overhead: a lone `date` line can pack to a CAR under the SP
+# minimum (e.g. 127 bytes on some calibration providers).
+TMPFILE=$(mktemp) && { date; echo "padding-for-min-size"; } > "$TMPFILE" && \
+  npx tsx src/cli.ts add "$TMPFILE"
 ```
+
+Without padding, the failure may surface as a generic `Network request failed`
+rather than an upload-size error until [FilOzone/synapse-sdk#841](https://github.com/FilOzone/synapse-sdk/issues/841) is fixed.
 
 For larger unique files use `head -c <bytes> /dev/urandom > "$TMPFILE"`.
 


### PR DESCRIPTION
## Summary
- Update the “upload unique data during testing” one-liner to pad past CAR overhead so packed uploads clear the SP minimum (e.g. 127 bytes on some calibration providers).
- Switch the example to `npx tsx src/cli.ts add` to match the rest of the dev guide.
- Note that undersized uploads can still fail with an opaque `Network request failed` until the root error propagation is fixed upstream in [FilOzone/synapse-sdk#841](https://github.com/FilOzone/synapse-sdk/issues/841).

## Test plan
- [x] Doc-only change; verified the padded one-liner succeeds on calibration with `--provider-id 2` during local debugging.


Made with [Cursor](https://cursor.com)