### PR TITLE
feat: prompt dataset selection on ambiguous --data-set-metadata match

### DIFF
--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -13,7 +13,7 @@ import pino from 'pino'
 import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { DEVNET_CHAIN_ID } from '../common/get-rpc-url.js'
 import { describeLockupShortfall } from '../common/lockup-error.js'
-import { displayUploadResults, performAutoFunding, performUpload, validatePaymentSetup } from '../common/upload-flow.js'
+import { displayUploadResults, performAutoFunding, performUpload, promptDataSetSelection, validatePaymentSetup } from '../common/upload-flow.js'
 import { carInputError, INPUT_IS_CAR, isCar } from '../core/car/index.js'
 import { resolveDataSetIdsByMetadata } from '../core/data-set/index.js'
 import { normalizeMetadataConfig, withDerivedNameMetadata } from '../core/metadata/index.js'
@@ -197,11 +197,9 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
           `${pc.green('✓')} Matched existing data sets ${resolution.dataSetIds.join(', ')} via metadata filter`
         )
       } else if (resolution.kind === 'too-many-matches') {
-        spinner.stop(`${pc.red('✗')} --data-set-metadata matched too many data sets`)
-        throw new Error(
-          `--data-set-metadata matched ${resolution.matchedIds.length} data sets (${resolution.matchedIds.join(', ')}) ` +
-            `but expected ${resolution.expected} (narrow the filter or pass --data-set-id to pin the target).`
-        )
+        const chosenIds = await promptDataSetSelection(resolution.matchedDataSets, resolution.expected, spinner)
+        contextSelection.dataSetIds = chosenIds
+        effectiveDataSetMetadata = undefined
       } else if (resolution.kind === 'too-few-matches') {
         spinner.stop(`${pc.red('✗')} --data-set-metadata matched too few data sets`)
         throw new Error(

--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -13,7 +13,13 @@ import pino from 'pino'
 import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { DEVNET_CHAIN_ID } from '../common/get-rpc-url.js'
 import { describeLockupShortfall } from '../common/lockup-error.js'
-import { displayUploadResults, performAutoFunding, performUpload, promptDataSetSelection, validatePaymentSetup } from '../common/upload-flow.js'
+import {
+  displayUploadResults,
+  performAutoFunding,
+  performUpload,
+  promptDataSetSelection,
+  validatePaymentSetup,
+} from '../common/upload-flow.js'
 import { carInputError, INPUT_IS_CAR, isCar } from '../core/car/index.js'
 import { resolveDataSetIdsByMetadata } from '../core/data-set/index.js'
 import { normalizeMetadataConfig, withDerivedNameMetadata } from '../core/metadata/index.js'

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -5,10 +5,12 @@
  * including payment validation, storage context creation, and result display.
  */
 
+import { isCancel, multiselect } from '@clack/prompts'
 import type { CopyResult, FailedAttempt, Synapse } from '@filoz/synapse-sdk'
 import type { CID } from 'multiformats/cid'
 import pc from 'picocolors'
 import type { Logger } from 'pino'
+import type { DataSetSummary } from '../core/data-set/types.js'
 import { DEFAULT_LOCKUP_DAYS, type PaymentCapacityCheck } from '../core/payments/index.js'
 import {
   checkUploadReadiness,
@@ -21,10 +23,71 @@ import { formatUSDFC } from '../core/utils/format.js'
 import { autoFund } from '../payments/fund.js'
 import type { AutoFundOptions } from '../payments/types.js'
 import type { Spinner } from '../utils/cli-helpers.js'
-import { cancel, formatFileSize } from '../utils/cli-helpers.js'
+import { cancel, formatFileSize, isInteractive } from '../utils/cli-helpers.js'
 import { log } from '../utils/cli-logger.js'
 import { createSpinnerFlow } from '../utils/multi-operation-spinner.js'
 import { CliFatal } from './cli-errors.js'
+
+/**
+ * Prompt the user to select exactly `expectedCopies` data sets from a list of candidates.
+ *
+ * Only called when `--data-set-metadata` matched more datasets than `--copies` requires and
+ * the process is running in an interactive TTY. In non-interactive contexts the caller must
+ * throw before reaching here.
+ *
+ * Stops the spinner before rendering the Clack prompt (they cannot coexist).
+ */
+export async function promptDataSetSelection(
+  matchedDataSets: DataSetSummary[],
+  expectedCopies: number,
+  spinner: Spinner
+): Promise<bigint[]> {
+  if (!isInteractive()) {
+    throw new Error(
+      `--data-set-metadata matched ${matchedDataSets.length} data sets (${matchedDataSets.map((d) => d.dataSetId).join(', ')}) ` +
+        `but expected ${expectedCopies}. Narrow the filter, pass --data-set-ids, or run in a TTY to pick interactively.`
+    )
+  }
+
+  spinner.stop(`${pc.yellow('?')} --data-set-metadata matched ${matchedDataSets.length} data sets — select ${expectedCopies} to upload to`)
+
+  const options = matchedDataSets.map((ds) => {
+    const spaceName = ds.metadata?.['space-name']
+    const spaceDid = ds.metadata?.['space-did']
+    const pieces = Number(ds.activePieceCount ?? 0n)
+    const didDisplay = spaceDid ? `${spaceDid.slice(0, 20)}…${spaceDid.slice(-6)}` : undefined
+
+    const label = [
+      `#${ds.dataSetId}`,
+      spaceName,
+      didDisplay,
+      `(${pieces} piece${pieces !== 1 ? 's' : ''})`,
+    ]
+      .filter(Boolean)
+      .join('  ')
+
+    return { value: ds.dataSetId, label }
+  })
+
+  const chosen = await multiselect<bigint>({
+    message: `Select exactly ${expectedCopies} data set${expectedCopies !== 1 ? 's' : ''}:`,
+    options,
+    required: true,
+  })
+
+  if (isCancel(chosen)) {
+    cancel('Cancelled')
+    throw new CliFatal('Dataset selection cancelled')
+  }
+
+  if (chosen.length !== expectedCopies) {
+    throw new CliFatal(
+      `Select exactly ${expectedCopies} data set${expectedCopies !== 1 ? 's' : ''} — got ${chosen.length}. Re-run and select the correct number.`
+    )
+  }
+
+  return chosen
+}
 
 export interface UploadFlowOptions {
   /**

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -28,6 +28,52 @@ import { log } from '../utils/cli-logger.js'
 import { createSpinnerFlow } from '../utils/multi-operation-spinner.js'
 import { CliFatal } from './cli-errors.js'
 
+function truncate(str: string, max: number): string {
+  if (str.length <= max) return str
+  return `${str.slice(0, max - 7)}…${str.slice(-6)}`
+}
+
+/**
+ * Find the metadata keys whose values differ across the candidate set.
+ * Keys with identical values on every dataset add no signal to the prompt.
+ * Falls back to all keys when everything is uniform.
+ */
+function differentiatingKeys(dataSets: DataSetSummary[]): string[] {
+  if (dataSets.length === 0) return []
+
+  const allKeys = [...new Set(dataSets.flatMap((ds) => Object.keys(ds.metadata ?? {})))]
+
+  const varying = allKeys.filter((key) => {
+    const values = dataSets.map((ds) => ds.metadata?.[key])
+    return values.some((v) => v !== values[0])
+  })
+
+  return varying.length > 0 ? varying : allKeys
+}
+
+function buildOptionLabel(ds: DataSetSummary, keys: string[]): { label: string } {
+  const MAX_LABEL_PAIRS = 3
+  const MAX_VALUE_LENGTH = 20
+
+  const pairs = keys
+    .filter((key) => ds.metadata != null && key in ds.metadata)
+    .map((key) => {
+      const raw = ds.metadata?.[key] ?? ''
+      return raw === '' ? key : `${key}=${truncate(raw, MAX_VALUE_LENGTH)}`
+    })
+
+  const visible = pairs.slice(0, MAX_LABEL_PAIRS)
+  const overflow = pairs.length - visible.length
+  const overflowSuffix = overflow > 0 ? `  (+${overflow} more)` : ''
+
+  const pieces = Number(ds.activePieceCount ?? 0n)
+  const piecesLabel = `(${pieces} piece${pieces !== 1 ? 's' : ''})`
+
+  const label = [`#${ds.dataSetId}`, ...visible, piecesLabel].join('  ') + overflowSuffix
+
+  return { label }
+}
+
 /**
  * Prompt the user to select exactly `expectedCopies` data sets from a list of candidates.
  *
@@ -53,37 +99,28 @@ export async function promptDataSetSelection(
     `${pc.yellow('?')} --data-set-metadata matched ${matchedDataSets.length} data sets — select ${expectedCopies} to upload to`
   )
 
+  const keys = differentiatingKeys(matchedDataSets)
+
   const options = matchedDataSets.map((ds) => {
-    const spaceName = ds.metadata?.['space-name']
-    const spaceDid = ds.metadata?.['space-did']
-    const pieces = Number(ds.activePieceCount ?? 0n)
-    const didDisplay = spaceDid ? `${spaceDid.slice(0, 20)}…${spaceDid.slice(-6)}` : undefined
-
-    const label = [`#${ds.dataSetId}`, spaceName, didDisplay, `(${pieces} piece${pieces !== 1 ? 's' : ''})`]
-      .filter(Boolean)
-      .join('  ')
-
+    const { label } = buildOptionLabel(ds, keys)
     return { value: ds.dataSetId, label }
   })
 
-  const chosen = await multiselect<bigint>({
-    message: `Select exactly ${expectedCopies} data set${expectedCopies !== 1 ? 's' : ''}:`,
-    options,
-    required: true,
-  })
+  const exact = `exactly ${expectedCopies} data set${expectedCopies !== 1 ? 's' : ''}`
+  let message = `Select ${exact}:`
 
-  if (isCancel(chosen)) {
-    cancel('Cancelled')
-    throw new CliFatal('Dataset selection cancelled')
+  while (true) {
+    const chosen = await multiselect<bigint>({ message, options, required: true })
+
+    if (isCancel(chosen)) {
+      cancel('Cancelled')
+      throw new CliFatal('Dataset selection cancelled')
+    }
+
+    if (chosen.length === expectedCopies) return chosen
+
+    message = `${pc.yellow(`Please select ${exact} — got ${chosen.length}. Try again:`)}`
   }
-
-  if (chosen.length !== expectedCopies) {
-    throw new CliFatal(
-      `Select exactly ${expectedCopies} data set${expectedCopies !== 1 ? 's' : ''} — got ${chosen.length}. Re-run and select the correct number.`
-    )
-  }
-
-  return chosen
 }
 
 export interface UploadFlowOptions {

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -28,8 +28,25 @@ import { log } from '../utils/cli-logger.js'
 import { createSpinnerFlow } from '../utils/multi-operation-spinner.js'
 import { CliFatal } from './cli-errors.js'
 
-function truncate(str: string, max: number): string {
+/**
+ * Truncates a string to a maximum length while preserving its suffix when
+ * possible.
+ *
+ * For lengths greater than 7, the string is truncated in the middle,
+ * preserving the last 6 characters and inserting an ellipsis (`…`).
+ * For shorter limits, the string is truncated at the end and suffixed with
+ * an ellipsis.
+ *
+ * The returned string will never exceed `max` characters.
+ */
+export function truncate(str: string, max: number): string {
   if (str.length <= max) return str
+  if (max <= 0) return ''
+
+  if (max <= 7) {
+    return `${str.slice(0, max - 1)}…`
+  }
+
   return `${str.slice(0, max - 7)}…${str.slice(-6)}`
 }
 
@@ -38,7 +55,7 @@ function truncate(str: string, max: number): string {
  * Keys with identical values on every dataset add no signal to the prompt.
  * Falls back to all keys when everything is uniform.
  */
-function differentiatingKeys(dataSets: DataSetSummary[]): string[] {
+export function differentiatingKeys(dataSets: DataSetSummary[]): string[] {
   if (dataSets.length === 0) return []
 
   const allKeys = [...new Set(dataSets.flatMap((ds) => Object.keys(ds.metadata ?? {})))]
@@ -51,7 +68,7 @@ function differentiatingKeys(dataSets: DataSetSummary[]): string[] {
   return varying.length > 0 ? varying : allKeys
 }
 
-function buildOptionLabel(ds: DataSetSummary, keys: string[]): { label: string } {
+export function buildOptionLabel(ds: DataSetSummary, keys: string[]): string {
   const MAX_LABEL_PAIRS = 3
   const MAX_VALUE_LENGTH = 20
 
@@ -71,15 +88,14 @@ function buildOptionLabel(ds: DataSetSummary, keys: string[]): { label: string }
 
   const label = [`#${ds.dataSetId}`, ...visible, piecesLabel].join('  ') + overflowSuffix
 
-  return { label }
+  return label
 }
 
 /**
  * Prompt the user to select exactly `expectedCopies` data sets from a list of candidates.
  *
  * Only called when `--data-set-metadata` matched more datasets than `--copies` requires and
- * the process is running in an interactive TTY. In non-interactive contexts the caller must
- * throw before reaching here.
+ * the process is running in an interactive TTY. Throws in non-interactive contexts.
  *
  * Stops the spinner before rendering the Clack prompt (they cannot coexist).
  */
@@ -102,7 +118,7 @@ export async function promptDataSetSelection(
   const keys = differentiatingKeys(matchedDataSets)
 
   const options = matchedDataSets.map((ds) => {
-    const { label } = buildOptionLabel(ds, keys)
+    const label = buildOptionLabel(ds, keys)
     return { value: ds.dataSetId, label }
   })
 

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -49,7 +49,9 @@ export async function promptDataSetSelection(
     )
   }
 
-  spinner.stop(`${pc.yellow('?')} --data-set-metadata matched ${matchedDataSets.length} data sets — select ${expectedCopies} to upload to`)
+  spinner.stop(
+    `${pc.yellow('?')} --data-set-metadata matched ${matchedDataSets.length} data sets — select ${expectedCopies} to upload to`
+  )
 
   const options = matchedDataSets.map((ds) => {
     const spaceName = ds.metadata?.['space-name']
@@ -57,12 +59,7 @@ export async function promptDataSetSelection(
     const pieces = Number(ds.activePieceCount ?? 0n)
     const didDisplay = spaceDid ? `${spaceDid.slice(0, 20)}…${spaceDid.slice(-6)}` : undefined
 
-    const label = [
-      `#${ds.dataSetId}`,
-      spaceName,
-      didDisplay,
-      `(${pieces} piece${pieces !== 1 ? 's' : ''})`,
-    ]
+    const label = [`#${ds.dataSetId}`, spaceName, didDisplay, `(${pieces} piece${pieces !== 1 ? 's' : ''})`]
       .filter(Boolean)
       .join('  ')
 

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -91,7 +91,7 @@ export async function promptDataSetSelection(
   if (!isInteractive()) {
     throw new Error(
       `--data-set-metadata matched ${matchedDataSets.length} data sets (${matchedDataSets.map((d) => d.dataSetId).join(', ')}) ` +
-        `but expected ${expectedCopies}. Narrow the filter, pass --data-set-ids, or run in a TTY to pick interactively.`
+        `but expected ${expectedCopies}. Narrow the filter, pass --data-set-id, or run in a TTY to pick interactively.`
     )
   }
 

--- a/src/core/data-set/resolve-by-metadata.ts
+++ b/src/core/data-set/resolve-by-metadata.ts
@@ -1,11 +1,12 @@
 import type { Synapse } from '@filoz/synapse-sdk'
 import type { Logger } from 'pino'
 import { listDataSets } from './list-data-sets.js'
+import type { DataSetSummary } from './types.js'
 
 export type MetadataResolution =
   | { kind: 'no-match' }
   | { kind: 'matched'; dataSetIds: bigint[] }
-  | { kind: 'too-many-matches'; matchedIds: bigint[]; expected: number }
+  | { kind: 'too-many-matches'; matchedIds: bigint[]; matchedDataSets: DataSetSummary[]; expected: number }
   | { kind: 'too-few-matches'; matchedIds: bigint[]; expected: number }
 
 export interface ResolveByMetadataOptions {
@@ -58,7 +59,7 @@ export async function resolveDataSetIdsByMetadata(
   const matchedIds = matched.map((d) => d.dataSetId)
 
   if (matched.length > options.expectedCopies) {
-    return { kind: 'too-many-matches', matchedIds, expected: options.expectedCopies }
+    return { kind: 'too-many-matches', matchedIds, matchedDataSets: matched, expected: options.expectedCopies }
   }
 
   if (matched.length < options.expectedCopies) {

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -15,7 +15,7 @@ import pino from 'pino'
 import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { DEVNET_CHAIN_ID } from '../common/get-rpc-url.js'
 import { describeLockupShortfall } from '../common/lockup-error.js'
-import { displayUploadResults, performAutoFunding, performUpload, validatePaymentSetup } from '../common/upload-flow.js'
+import { displayUploadResults, performAutoFunding, performUpload, promptDataSetSelection, validatePaymentSetup } from '../common/upload-flow.js'
 import { resolveDataSetIdsByMetadata } from '../core/data-set/index.js'
 import { normalizeMetadataConfig } from '../core/metadata/index.js'
 import { DEFAULT_COPIES } from '../core/synapse/constants.js'
@@ -264,11 +264,9 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
           `${pc.green('✓')} Matched existing data sets ${resolution.dataSetIds.join(', ')} via metadata filter`
         )
       } else if (resolution.kind === 'too-many-matches') {
-        spinner.stop(`${pc.red('✗')} --data-set-metadata matched too many data sets`)
-        throw new Error(
-          `--data-set-metadata matched ${resolution.matchedIds.length} data sets (${resolution.matchedIds.join(', ')}) ` +
-            `but expected ${resolution.expected} (narrow the filter or pass --data-set-id to pin the target).`
-        )
+        const chosenIds = await promptDataSetSelection(resolution.matchedDataSets, resolution.expected, spinner)
+        contextSelection.dataSetIds = chosenIds
+        effectiveDataSetMetadata = undefined
       } else if (resolution.kind === 'too-few-matches') {
         spinner.stop(`${pc.red('✗')} --data-set-metadata matched too few data sets`)
         throw new Error(

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -15,7 +15,13 @@ import pino from 'pino'
 import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { DEVNET_CHAIN_ID } from '../common/get-rpc-url.js'
 import { describeLockupShortfall } from '../common/lockup-error.js'
-import { displayUploadResults, performAutoFunding, performUpload, promptDataSetSelection, validatePaymentSetup } from '../common/upload-flow.js'
+import {
+  displayUploadResults,
+  performAutoFunding,
+  performUpload,
+  promptDataSetSelection,
+  validatePaymentSetup,
+} from '../common/upload-flow.js'
 import { resolveDataSetIdsByMetadata } from '../core/data-set/index.js'
 import { normalizeMetadataConfig } from '../core/metadata/index.js'
 import { DEFAULT_COPIES } from '../core/synapse/constants.js'

--- a/src/test/unit/add.test.ts
+++ b/src/test/unit/add.test.ts
@@ -23,6 +23,7 @@ const { mockCarPath, mockFindDataSets } = vi.hoisted(() => ({
 vi.mock('../../common/upload-flow.js', () => ({
   validatePaymentSetup: vi.fn(),
   performAutoFunding: vi.fn(),
+  promptDataSetSelection: vi.fn().mockRejectedValue(new Error('not interactive')),
   performUpload: vi.fn().mockResolvedValue({
     pieceCid: 'bafkzcibtest1234567890',
     size: 1024,
@@ -282,7 +283,7 @@ describe('Add Command', () => {
       expect(lastCall?.[3]).not.toHaveProperty('metadata')
     })
 
-    it('throws when --data-set-metadata matches too many data sets', async () => {
+    it('calls promptDataSetSelection when --data-set-metadata matches too many data sets', async () => {
       mockFindDataSets.mockResolvedValueOnce([
         { pdpVerifierDataSetId: 1n, providerId: 1n, isLive: true, metadata: { source: 'storacha-migration' } },
         { pdpVerifierDataSetId: 2n, providerId: 2n, isLive: true, metadata: { source: 'storacha-migration' } },
@@ -297,7 +298,14 @@ describe('Add Command', () => {
           rpcUrl: 'wss://test.rpc.url',
           dataSetMetadata: { source: 'storacha-migration' },
         })
-      ).rejects.toThrow(/matched 4 data sets.*expected 2/)
+      ).rejects.toThrow()
+
+      const { promptDataSetSelection } = await import('../../common/upload-flow.js')
+      expect(vi.mocked(promptDataSetSelection)).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ dataSetId: 1n })]),
+        2,
+        expect.any(Object)
+      )
     })
 
     it('throws when --data-set-metadata matches too few data sets', async () => {

--- a/src/test/unit/import.test.ts
+++ b/src/test/unit/import.test.ts
@@ -29,6 +29,7 @@ const ZERO_CID = 'bafkqaaa' // Zero CID used when CAR has no roots
 vi.mock('@filoz/synapse-sdk', async () => await import('../mocks/synapse-sdk.js'))
 vi.mock('../../common/upload-flow.js', () => ({
   validatePaymentSetup: vi.fn(),
+  promptDataSetSelection: vi.fn().mockRejectedValue(new Error('not interactive')),
   performUpload: vi.fn().mockResolvedValue({
     pieceCid: 'bafkzcibtest1234567890',
     size: 1024,
@@ -444,7 +445,7 @@ describe('CAR Import', () => {
       expect(lastCall?.[3]).not.toHaveProperty('metadata')
     })
 
-    it('throws when --data-set-metadata matches too many data sets', async () => {
+    it('calls promptDataSetSelection when --data-set-metadata matches too many data sets', async () => {
       const carPath = join(testDir, 'resolve-too-many.car')
       await createTestCarFile(carPath, [], [{ content: 'too-many' }])
 
@@ -461,7 +462,14 @@ describe('CAR Import', () => {
           privateKey: testPrivateKey,
           dataSetMetadata: { source: 'storacha-migration' },
         })
-      ).rejects.toThrow(/matched 4 data sets.*expected 2/)
+      ).rejects.toThrow()
+
+      const { promptDataSetSelection } = await import('../../common/upload-flow.js')
+      expect(vi.mocked(promptDataSetSelection)).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ dataSetId: 1n })]),
+        2,
+        expect.any(Object)
+      )
     })
 
     it('throws when --data-set-metadata matches too few data sets', async () => {

--- a/src/test/unit/resolve-by-metadata.test.ts
+++ b/src/test/unit/resolve-by-metadata.test.ts
@@ -66,7 +66,8 @@ describe('resolveDataSetIdsByMetadata', () => {
       { expectedCopies: 2 }
     )
 
-    expect(result).toEqual({ kind: 'too-many-matches', matchedIds: [1n, 2n, 3n, 4n], expected: 2 })
+    expect(result).toMatchObject({ kind: 'too-many-matches', matchedIds: [1n, 2n, 3n, 4n], expected: 2 })
+    expect((result as any).matchedDataSets).toHaveLength(4)
   })
 
   it('returns too-few-matches when fewer datasets match than expected', async () => {

--- a/src/test/unit/upload-flow.test.ts
+++ b/src/test/unit/upload-flow.test.ts
@@ -37,7 +37,14 @@ vi.mock('../../core/upload/index.js', async () => {
   }
 })
 
-import { displayUploadResults, performUpload, promptDataSetSelection } from '../../common/upload-flow.js'
+import {
+  buildOptionLabel,
+  differentiatingKeys,
+  displayUploadResults,
+  performUpload,
+  promptDataSetSelection,
+  truncate,
+} from '../../common/upload-flow.js'
 import { createLogger } from '../../logger.js'
 
 const TEST_CID = CID.parse('bafkreia5fn4rmshmb7cl7fufkpcw733b5anhuhydtqstnglpkzosqln5kq')
@@ -263,5 +270,103 @@ describe('performUpload', () => {
     expect(spinner.message).toHaveBeenNthCalledWith(1, 'Uploading to Filecoin... 1.0 B/4.0 B (25%)')
     expect(spinner.message).toHaveBeenNthCalledWith(2, 'Uploading to Filecoin... 2.0 B/4.0 B (50%)')
     expect(spinner.message).toHaveBeenNthCalledWith(3, 'Uploading to Filecoin... 4.0 B/4.0 B (100%)')
+  })
+})
+
+describe('truncate', () => {
+  it('returns the string unchanged when it fits within the limit', () => {
+    expect(truncate('hello', 10)).toBe('hello')
+    expect(truncate('exactly20chars123456', 20)).toBe('exactly20chars123456')
+  })
+
+  it('returns an empty string when max is 0 or negative', () => {
+    expect(truncate('hello', 0)).toBe('')
+    expect(truncate('hello', -1)).toBe('')
+  })
+
+  it('truncates at the end with an ellipsis when max is 7 or less', () => {
+    expect(truncate('abcdefgh', 5)).toBe('abcd…')
+    expect(truncate('abcdefgh', 7)).toBe('abcdef…')
+  })
+
+  it('middle-truncates when max is greater than 7, preserving the last 6 characters', () => {
+    // 26-char input, max=20: slice(0,13)='abcdefghijklm', slice(-6)='uvwxyz'
+    expect(truncate('abcdefghijklmnopqrstuvwxyz', 20)).toBe('abcdefghijklm…uvwxyz')
+  })
+
+  it('result never exceeds max characters', () => {
+    const result = truncate('abcdefghijklmnopqrstuvwxyz', 20)
+    expect([...result].length).toBeLessThanOrEqual(20)
+  })
+})
+
+describe('differentiatingKeys', () => {
+  it('returns an empty array for an empty dataset list', () => {
+    expect(differentiatingKeys([])).toEqual([])
+  })
+
+  it('falls back to all keys when all datasets have uniform metadata values', () => {
+    const datasets = [
+      { dataSetId: 1n, activePieceCount: 0n, metadata: { env: 'prod', region: 'us-east' } },
+      { dataSetId: 2n, activePieceCount: 0n, metadata: { env: 'prod', region: 'us-east' } },
+    ] as any[]
+    expect(differentiatingKeys(datasets)).toEqual(expect.arrayContaining(['env', 'region']))
+  })
+
+  it('returns only the keys whose values differ across datasets', () => {
+    const datasets = [
+      { dataSetId: 1n, activePieceCount: 0n, metadata: { source: 'alpha', env: 'prod' } },
+      { dataSetId: 2n, activePieceCount: 0n, metadata: { source: 'beta', env: 'prod' } },
+    ] as any[]
+    expect(differentiatingKeys(datasets)).toEqual(['source'])
+  })
+
+  it('collects keys that appear on any dataset, not just all of them', () => {
+    const datasets = [
+      { dataSetId: 1n, activePieceCount: 0n, metadata: { source: 'a' } },
+      { dataSetId: 2n, activePieceCount: 0n, metadata: { source: 'a', region: 'us' } },
+    ] as any[]
+    // 'region' only exists on one dataset — undefined vs 'us' differs, so it's included
+    expect(differentiatingKeys(datasets)).toContain('region')
+  })
+})
+
+describe('buildOptionLabel', () => {
+  it('shows dataset ID and piece count with no metadata keys', () => {
+    const ds = { dataSetId: 5n, activePieceCount: 0n, metadata: {} } as any
+    expect(buildOptionLabel(ds, [])).toBe('#5  (0 pieces)')
+  })
+
+  it('uses singular "piece" when activePieceCount is 1', () => {
+    const ds = { dataSetId: 5n, activePieceCount: 1n, metadata: {} } as any
+    expect(buildOptionLabel(ds, [])).toBe('#5  (1 piece)')
+  })
+
+  it('shows key=value pairs for the provided keys', () => {
+    const ds = { dataSetId: 1n, activePieceCount: 2n, metadata: { source: 'alpha' } } as any
+    const label = buildOptionLabel(ds, ['source'])
+    expect(label).toContain('source=alpha')
+    expect(label).toContain('(2 pieces)')
+  })
+
+  it('shows just the key name when the metadata value is an empty string', () => {
+    const ds = { dataSetId: 1n, activePieceCount: 0n, metadata: { source: '' } } as any
+    const label = buildOptionLabel(ds, ['source'])
+    expect(label).toContain('source')
+    expect(label).not.toContain('source=')
+  })
+
+  it('caps visible pairs at 3 and appends an overflow suffix for the rest', () => {
+    const ds = { dataSetId: 1n, activePieceCount: 0n, metadata: { a: '1', b: '2', c: '3', d: '4' } } as any
+    const label = buildOptionLabel(ds, ['a', 'b', 'c', 'd'])
+    expect(label).toContain('(+1 more)')
+    expect(label).toContain('a=1')
+    expect(label).not.toContain('d=4')
+  })
+
+  it('truncates metadata values longer than 20 characters', () => {
+    const ds = { dataSetId: 1n, activePieceCount: 0n, metadata: { v: 'abcdefghijklmnopqrstuvwxyz' } } as any
+    const label = buildOptionLabel(ds, ['v'])
+    expect(label).toContain('v=abcdefghijklm…uvwxyz')
   })
 })

--- a/src/test/unit/upload-flow.test.ts
+++ b/src/test/unit/upload-flow.test.ts
@@ -9,8 +9,24 @@ vi.mock('../../utils/cli-logger.js', () => ({
   },
 }))
 
+vi.mock('../../utils/cli-helpers.js', async () => {
+  const actual = await vi.importActual('../../utils/cli-helpers.js')
+  return {
+    ...actual,
+    isInteractive: vi.fn().mockReturnValue(false),
+    cancel: vi.fn(),
+  }
+})
+
 const mocks = vi.hoisted(() => ({
   executeUpload: vi.fn(),
+  multiselect: vi.fn(),
+  isCancel: vi.fn().mockReturnValue(false),
+}))
+
+vi.mock('@clack/prompts', () => ({
+  multiselect: mocks.multiselect,
+  isCancel: mocks.isCancel,
 }))
 
 vi.mock('../../core/upload/index.js', async () => {
@@ -21,7 +37,7 @@ vi.mock('../../core/upload/index.js', async () => {
   }
 })
 
-import { displayUploadResults, performUpload } from '../../common/upload-flow.js'
+import { displayUploadResults, performUpload, promptDataSetSelection } from '../../common/upload-flow.js'
 import { createLogger } from '../../logger.js'
 
 const TEST_CID = CID.parse('bafkreia5fn4rmshmb7cl7fufkpcw733b5anhuhydtqstnglpkzosqln5kq')
@@ -44,6 +60,62 @@ const sampleResult = {
   ],
   failedAttempts: [],
 }
+
+describe('promptDataSetSelection', () => {
+  const spinner = { start: vi.fn(), stop: vi.fn(), message: vi.fn(), clear: vi.fn() }
+
+  beforeEach(() => {
+    mocks.multiselect.mockReset()
+    mocks.isCancel.mockReturnValue(false)
+  })
+
+  const dataSets = [
+    { dataSetId: 1n, activePieceCount: 2n, metadata: { source: 'a' } },
+    { dataSetId: 2n, activePieceCount: 3n, metadata: { source: 'b' } },
+    { dataSetId: 3n, activePieceCount: 1n, metadata: { source: 'c' } },
+  ] as any[]
+
+  it('throws with the hard error message when not in a TTY', async () => {
+    const { isInteractive } = await import('../../utils/cli-helpers.js')
+    vi.mocked(isInteractive).mockReturnValue(false)
+
+    await expect(promptDataSetSelection(dataSets, 1, spinner)).rejects.toThrow(/matched 3 data sets.*expected 1/)
+  })
+
+  it('returns the chosen data set ids when the user selects the correct count', async () => {
+    const { isInteractive } = await import('../../utils/cli-helpers.js')
+    vi.mocked(isInteractive).mockReturnValue(true)
+    mocks.multiselect.mockResolvedValueOnce([1n, 2n])
+
+    const result = await promptDataSetSelection(dataSets, 2, spinner)
+
+    expect(result).toEqual([1n, 2n])
+    expect(mocks.multiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('2'),
+        options: expect.arrayContaining([
+          expect.objectContaining({ value: 1n }),
+          expect.objectContaining({ value: 2n }),
+          expect.objectContaining({ value: 3n }),
+        ]),
+      })
+    )
+  })
+
+  it('re-prompts when the user selects the wrong count, then returns on correct selection', async () => {
+    const { isInteractive } = await import('../../utils/cli-helpers.js')
+    vi.mocked(isInteractive).mockReturnValue(true)
+    mocks.multiselect
+      .mockResolvedValueOnce([1n]) // wrong: only 1 selected
+      .mockResolvedValueOnce([1n, 2n]) // correct
+
+    const result = await promptDataSetSelection(dataSets, 2, spinner)
+
+    expect(result).toEqual([1n, 2n])
+    expect(mocks.multiselect).toHaveBeenCalledTimes(2)
+    expect(mocks.multiselect.mock.calls[1]?.[0].message).toMatch(/Please select exactly 2/)
+  })
+})
 
 describe('displayUploadResults egress block', () => {
   beforeEach(async () => {


### PR DESCRIPTION
Closes #437 

### What
  
When `--data-set-metadata` matches more datasets than `--copies` requires, `add` and `import` now prompt the user to pick which datasets to upload to instead of throwing a hard error.

Each option shows the dataset ID, the metadata keys that differ across the matched candidates (values truncated if long, empty-string values shown as bare keys), and the active piece count. Non-interactive contexts (CI, GitHub
Actions, no TTY) keep the hard error, the prompt only runs when `isInteractive()` is `true`.

### Verification

- `pnpm test` - all 627 tests pass.
- Run `filecoin-pin add file.json --data-set-metadata "space-name=X" --data-set-metadata "space-did=did:key:..."` against a wallet with 2+ datasets matching. Confirm the multiselect prompt appears and upload proceeds to the chosen pair.
- Run `filecoin-pin add file.json --data-set-metadata "space-name=X" --data-set-metadata "space-did=did:key:..."` against a wallet with exactly one matching pair. Confirm no prompt, resolves directly via matched path.

<img width="519" height="281" alt="image" src="https://github.com/user-attachments/assets/b6f81c32-bb02-4b42-9327-c2201e245cc6" />



###   Notes

- `isInteractive()` (not `isTTY()`) is the gate, it also blocks `CI=true` and `GITHUB_ACTIONS=true`, so the GitHub Action and pinning server are covered without additional handling.
- The prompt enforces exact selection count (`expectedCopies`). If the user selects the wrong number, it uses a loop that halts the prompt and ask again.
