### PR TITLE
feat: add dataSetIds input parsing to upload action

### DIFF
--- a/src/test/unit/upload-action.test.ts
+++ b/src/test/unit/upload-action.test.ts
@@ -47,6 +47,7 @@ interface ParseInputsModule {
     contentPath: string
     network: 'mainnet' | 'calibration'
     dryRun: boolean
+    dataSetIds?: bigint[]
   }
 }
 
@@ -55,7 +56,7 @@ interface FilecoinModule {
     synapse: unknown,
     carPath: string,
     ipfsRootCid: string,
-    options: { withCDN: boolean; providerIds?: bigint[] },
+    options: { withCDN: boolean; providerIds?: bigint[]; dataSetIds?: bigint[] },
     logger: unknown
   ) => Promise<{
     dataSetId: string
@@ -119,6 +120,64 @@ describe('upload action inputs', () => {
     const { parseInputs } = (await import(inputsModulePath)) as ParseInputsModule
 
     expect(() => parseInputs('upload')).toThrow('walletPrivateKey is required')
+  })
+
+  it('parses a comma-separated dataSetIds input into bigints', async () => {
+    process.env.INPUTS_JSON = JSON.stringify({
+      path: './dist',
+      network: 'calibration',
+      dryRun: true,
+      dataSetIds: '13260,13261',
+    })
+
+    const { parseInputs } = (await import(inputsModulePath)) as ParseInputsModule
+
+    expect(parseInputs('upload')).toMatchObject({
+      dataSetIds: [13260n, 13261n],
+    })
+  })
+
+  it('leaves dataSetIds undefined when the input is omitted', async () => {
+    process.env.INPUTS_JSON = JSON.stringify({
+      path: './dist',
+      network: 'calibration',
+      dryRun: true,
+    })
+
+    const { parseInputs } = (await import(inputsModulePath)) as ParseInputsModule
+
+    const result = parseInputs('upload')
+    expect(result.dataSetIds).toBeUndefined()
+  })
+
+  it('rejects a non-numeric dataSetIds value with a clear error', async () => {
+    process.env.INPUTS_JSON = JSON.stringify({
+      path: './dist',
+      network: 'calibration',
+      dryRun: true,
+      dataSetIds: '13260,abc',
+    })
+
+    const { parseInputs } = (await import(inputsModulePath)) as ParseInputsModule
+
+    expect(() => parseInputs('upload')).toThrow(/Invalid dataSetIds.*abc.*positive integer/)
+  })
+
+  it('rejects dataSetIds when PROVIDER_IDS env is also set', async () => {
+    process.env.INPUTS_JSON = JSON.stringify({
+      path: './dist',
+      network: 'calibration',
+      dryRun: true,
+      dataSetIds: '13260',
+    })
+    process.env.PROVIDER_IDS = '1'
+
+    try {
+      const { parseInputs } = (await import(inputsModulePath)) as ParseInputsModule
+      expect(() => parseInputs('upload')).toThrow(/Cannot specify both dataSetIds and PROVIDER_IDS/)
+    } finally {
+      delete process.env.PROVIDER_IDS
+    }
   })
 })
 
@@ -229,6 +288,44 @@ describe('upload action Filecoin upload', () => {
 
     logSpy.mockRestore()
   })
+
+  it('forwards dataSetIds to executeUpload', async () => {
+    mocks.executeUpload.mockResolvedValue({
+      pieceCid: 'bafkzcibe2hzbcd4t6clvsb3mfrezyxl75gl3gzcsqi42dd27gktq4nk75rr62ciuaq',
+      size: 3,
+      requestedCopies: 1,
+      complete: true,
+      copies: [
+        {
+          providerId: 2n,
+          dataSetId: 13260n,
+          pieceId: 1n,
+          role: 'primary',
+          retrievalUrl: 'https://calib2.ezpdpz.net/piece/test',
+          isNewDataSet: false,
+        },
+      ],
+      failedAttempts: [],
+      network: 'calibration',
+      ipniValidated: true,
+    })
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const { uploadCarToFilecoin } = (await import(filecoinModulePath)) as FilecoinModule
+
+    await uploadCarToFilecoin(
+      {},
+      carPath,
+      TEST_CID,
+      { withCDN: false, dataSetIds: [13260n, 13261n] },
+      { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() }
+    )
+
+    logSpy.mockRestore()
+
+    const executeUploadOptions = mocks.executeUpload.mock.calls[0]?.[3]
+    expect(executeUploadOptions).toMatchObject({ dataSetIds: [13260n, 13261n] })
+  })
 })
 
 describe('upload action payments', () => {
@@ -307,6 +404,67 @@ describe('upload action payments', () => {
 
     // The funding planner (real, not mocked) ran and required the service price.
     expect(payments.getServicePrice).toHaveBeenCalledWith(synapse.client)
+  })
+
+  it('forwards dataSetIds to createContexts', async () => {
+    const payments = (await import('filecoin-pin/core/payments')) as typeof import('filecoin-pin/core/payments')
+    const utils = (await import('filecoin-pin/core/utils')) as typeof import('filecoin-pin/core/utils')
+
+    vi.mocked(payments.getPaymentStatus).mockResolvedValue({
+      network: 'calibration',
+      chainId: 314159,
+      address: '0x0000000000000000000000000000000000000000',
+      filBalance: 1_000_000_000_000_000_000n,
+      walletUsdfcBalance: 1_000_000_000_000_000_000n,
+      filecoinPayBalance: 1_000_000_000_000_000_000n,
+      currentAllowances: {
+        isApproved: true,
+        rateAllowance: 0n,
+        lockupAllowance: 0n,
+        lockupUsage: 0n,
+        rateUsage: 0n,
+        maxLockupPeriod: 30n * 2880n,
+      },
+    } as never)
+    vi.mocked(payments.getServicePrice).mockResolvedValue({ minimumPricePerMonth: 1_000_000n } as never)
+    vi.mocked(payments.executeTopUp).mockResolvedValue({ success: true, deposited: 0n, message: '' } as never)
+    vi.mocked(payments.getStorageRunway).mockResolvedValue({} as never)
+    vi.mocked(utils.formatRunwaySummary).mockReturnValue({ coverage: 'covered', runway: 'plenty' } as never)
+
+    const createContexts = vi.fn().mockResolvedValue([])
+    const synapse = {
+      client: {},
+      payments: {
+        accountSummary: async () => ({
+          funds: 1_000_000_000_000_000_000n,
+          availableFunds: 1_000_000_000_000_000_000n,
+          debt: 0n,
+          totalLockup: 0n,
+          lockupRatePerEpoch: 0n,
+          runwayInEpochs: 0n,
+          grossCoverageInEpochs: 0n,
+        }),
+      },
+      storage: {
+        getStorageInfo: async () => ({ pricing: { noCDN: { perTiBPerEpoch: 1_000_000n } } }),
+        createContexts,
+      },
+    }
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const { handlePayments } = (await import(filecoinModulePath)) as {
+      handlePayments: (synapse: unknown, options: unknown, logger: unknown) => Promise<unknown>
+    }
+
+    await handlePayments(
+      synapse,
+      { minStorageDays: 0, withCDN: false, dataSetIds: [13260n, 13261n] },
+      { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() }
+    )
+
+    logSpy.mockRestore()
+
+    expect(createContexts).toHaveBeenCalledWith(expect.objectContaining({ dataSetIds: [13260n, 13261n] }))
   })
 })
 

--- a/upload-action/README.md
+++ b/upload-action/README.md
@@ -17,6 +17,7 @@ See the two-workflow approach in the [examples directory](./examples/) for compl
 See [action.yml](./action.yml) for complete input documentation including:
 - **Core**: `path`, `walletPrivateKey`, `network`
 - **Financial**: `minRunwayDays`, `maxBalance`
+- **Dataset targeting**: `dataSetIds`
 - **Advanced**: `egressProvider`, `dryRun`, `disableTelemetry`
 
 **Outputs**: `ipfsRootCid`, `dataSetId`, `pieceCid`, `providerId`, `providerName`, `carPath`, `uploadStatus`
@@ -56,6 +57,21 @@ For most users, automatic provider selection is recommended. However, for advanc
 When omitted, the SDK selects providers automatically (recommended). With multi-copy uploads it picks an endorsed primary and approved secondaries; setting `PROVIDER_IDS` overrides that selection.
 
 ⚠️ **Warning**: Overriding providers may cause uploads to fail if a specified provider is unavailable or doesn't support IPFS indexing.
+
+### Advanced: Targeting Existing Datasets
+
+To append an upload to one or more existing Synapse datasets instead of creating a new one, set the `dataSetIds` input to a comma-separated list of numeric dataset IDs:
+
+```yaml
+- name: Upload to Filecoin
+  uses: filecoin-project/filecoin-pin/upload-action@v0
+  with:
+    path: dist
+    walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
+    dataSetIds: "13260,13261"
+```
+
+When omitted, the SDK selects or creates a dataset automatically (recommended). `dataSetIds` and `PROVIDER_IDS` are mutually exclusive, setting both will fail with a clear error.
 
 ## Security Checklist
 

--- a/upload-action/action.yml
+++ b/upload-action/action.yml
@@ -46,6 +46,16 @@ inputs:
       SECURITY: Hardcode this in trusted workflows.
     required: false
 
+  # Dataset targeting
+  dataSetIds:
+    description: >-
+      Comma-separated list of existing Synapse data set IDs to append this upload to
+      (e.g. "13260,13261"). When supplied, the action routes the upload into those
+      datasets and skips creating a new one. Must be positive integers; non-numeric
+      values are rejected. Cannot be combined with the PROVIDER_IDS environment
+      variable. Omit to preserve current behavior (SDK smart-select or new dataset).
+    required: false
+
   # Optional/Advanced configuration
   egressProvider:
     description: "Egress provider for piece retrieval: \"beam\" (FilBeam CDN) or \"none\" (default). A new CDN data set requires an extra 1 USDFC lockup, which is included in the deposit estimate. CDN egress is paid from funds the data set owner locks up, consumed as retrievals happen, and cannot be estimated upfront."

--- a/upload-action/src/filecoin.js
+++ b/upload-action/src/filecoin.js
@@ -105,7 +105,7 @@ async function readCarRoots(filePath) {
  * @returns {Promise<SimplifiedPaymentStatus>} Updated payment status
  */
 export async function handlePayments(synapse, options, logger) {
-  const { minStorageDays, filecoinPayBalanceLimit, pieceSizeBytes, withCDN, providerIds } = options
+  const { minStorageDays, filecoinPayBalanceLimit, pieceSizeBytes, withCDN, providerIds, dataSetIds } = options
 
   console.log('Checking current Filecoin Pay account balance...')
   const [rawStatus, accountSummary, storageInfo, contexts, servicePrice] = await Promise.all([
@@ -114,6 +114,7 @@ export async function handlePayments(synapse, options, logger) {
     synapse.storage.getStorageInfo(),
     synapse.storage.createContexts({
       ...(providerIds != null && providerIds.length > 0 ? { providerIds } : {}),
+      ...(dataSetIds != null && dataSetIds.length > 0 ? { dataSetIds } : {}),
       ...(withCDN ? { withCDN } : {}),
     }),
     getServicePrice(synapse.client),
@@ -230,6 +231,12 @@ export async function uploadCarToFilecoin(synapse, carPath, ipfsRootCid, options
     )
   }
 
+  /** @type {bigint[] | undefined} */
+  const dataSetIds = options.dataSetIds != null && options.dataSetIds.length > 0 ? options.dataSetIds : undefined
+  if (dataSetIds) {
+    logger.info({ event: 'upload.dataset_override', dataSetIds: dataSetIds.map(String) }, 'Using data set ID override')
+  }
+
   console.log('\nStarting upload to storage provider...')
   console.log('Uploading data to PDP server...')
   logger.info({ event: 'upload.stream_ready', carPath, size }, 'Streaming CAR upload from disk')
@@ -238,6 +245,7 @@ export async function uploadCarToFilecoin(synapse, carPath, ipfsRootCid, options
     logger,
     contextId: `gha-upload-${Date.now()}`,
     ...(providerIds != null && { providerIds }),
+    ...(dataSetIds != null && { dataSetIds }),
     onProgress: (event) => {
       switch (event.type) {
         case 'uploadProgress': {

--- a/upload-action/src/inputs.js
+++ b/upload-action/src/inputs.js
@@ -89,6 +89,7 @@ export function parseInputs(phase = 'single') {
   const networkRaw = getInput('network', 'mainnet')
   const minStorageDaysRaw = getInput('minRunwayDays', '')
   const filecoinPayBalanceLimitRaw = getInput('maxBalance', '')
+  const rawDataSetIds = getInput('dataSetIds').trim()
   const egressProvider = getInput('egressProvider', 'none')
   if (egressProvider !== 'beam' && egressProvider !== 'none') {
     throw new FilecoinPinError(
@@ -165,6 +166,42 @@ export function parseInputs(phase = 'single') {
     }
   }
 
+  // Parse data set ID override from the action input.
+  //
+  // dataSetIds (comma-separated) routes the upload into existing datasets,
+  // skipping new dataset creation. Example: dataSetIds: "13260,13261"
+  //
+  // Cannot be combined with PROVIDER_IDS — they are mutually exclusive.
+  /** @type {bigint[] | undefined} */
+  let dataSetIds
+  if (rawDataSetIds) {
+    const parts = rawDataSetIds
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s !== '')
+    if (parts.length === 0) {
+      throw new FilecoinPinError(
+        `Invalid dataSetIds: "${rawDataSetIds}". Provide one or more comma-separated numeric IDs.`,
+        ERROR_CODES.INVALID_INPUT
+      )
+    }
+    for (const part of parts) {
+      if (!/^\d+$/.test(part) || BigInt(part) <= 0n) {
+        throw new FilecoinPinError(
+          `Invalid dataSetIds: "${part}" is not a positive integer. Provide comma-separated numeric IDs (e.g. "13260,13261").`,
+          ERROR_CODES.INVALID_INPUT
+        )
+      }
+    }
+    if (providerIds != null) {
+      throw new FilecoinPinError(
+        'Cannot specify both dataSetIds and PROVIDER_IDS. Use dataSetIds to target existing datasets or PROVIDER_IDS to target specific providers — not both.',
+        ERROR_CODES.INVALID_INPUT
+      )
+    }
+    dataSetIds = parts.map((s) => BigInt(s))
+  }
+
   /** @type {ParsedInputs} */
   const parsedInputs = {
     walletPrivateKey,
@@ -174,6 +211,7 @@ export function parseInputs(phase = 'single') {
     filecoinPayBalanceLimit,
     withCDN,
     providerIds,
+    dataSetIds,
     dryRun,
   }
 

--- a/upload-action/src/types.ts
+++ b/upload-action/src/types.ts
@@ -57,6 +57,7 @@ export interface CombinedContext extends Partial<UploadResult>, Partial<BuildRes
   filecoinPayBalanceLimit?: bigint
   withCDN?: boolean
   providerIds?: bigint[]
+  dataSetIds?: bigint[]
   paymentStatus?: PaymentStatus
   dryRun?: boolean
 }
@@ -95,11 +96,13 @@ export interface PaymentConfig {
 export interface PaymentFundingConfig extends PaymentConfig {
   withCDN: boolean
   providerIds?: bigint[] | undefined
+  dataSetIds?: bigint[] | undefined
 }
 
 export interface UploadConfig {
   withCDN: boolean
   providerIds?: bigint[] | undefined
+  dataSetIds?: bigint[] | undefined
 }
 
 export interface ParsedInputs extends PaymentConfig, UploadConfig {

--- a/upload-action/src/upload.js
+++ b/upload-action/src/upload.js
@@ -42,6 +42,7 @@ export async function runUpload(buildContext = {}) {
     filecoinPayBalanceLimit,
     withCDN,
     providerIds,
+    dataSetIds,
     dryRun,
   } = inputs
 
@@ -167,6 +168,7 @@ export async function runUpload(buildContext = {}) {
         pieceSizeBytes: context.carSize,
         withCDN,
         providerIds,
+        dataSetIds,
       },
       logger
     )
@@ -181,7 +183,7 @@ export async function runUpload(buildContext = {}) {
     })
 
     /** @type {UploadConfig} */
-    const uploadOptions = { withCDN, providerIds }
+    const uploadOptions = { withCDN, providerIds, dataSetIds }
 
     const uploadResult = await uploadCarToFilecoin(synapse, carPath, rootCid, uploadOptions, logger)
     pieceCid = uploadResult.pieceCid


### PR DESCRIPTION
Closes #436 

### What
Add a dataSetIds input to the upload action so CI workflows can route uploads into existing datasets instead of always creating new ones or relying on SDK smart-select.

### Verification
- `pnpm vitest run src/test/unit/upload-action.test.ts` - all 12 tests pass

### Notes 
`dataSetIds` and `PROVIDER_IDS` are mutually exclusive, passing both fails at input parsing with a clear error. 

