### PR TITLE
chore: force next release to 1.0.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
+      "release-as": "1.0.1",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,


### PR DESCRIPTION
Adds `release-as: 1.0.1` to the release-please config so the next release lands as 1.0.1.

1.0.0 was already claimed by the accidental release #356 (npm + the v1.0.0 tag), so the synapse-sdk v1 upgrade can't reuse it. `release-as` overrides only the version label; the changelog baseline stays at `v0.23.2`. The proper-semver flags from #582 are already on master, so this is the only remaining piece. Merge method does not matter here, unlike a commit trailer.

## After this ships

`release-as` is sticky: it pins every later release to 1.0.1 until removed. Drop the line in a one-line follow-up once 1.0.1 is out (the same cleanup synapse-sdk did in their #846).

## How to verify

After merge, release-please regenerates #566 to 1.0.1. Confirm its changelog compares from `v0.23.2`.