### PR TITLE
feat: organize CLI `--help` with command groups

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import './instrument.js'
-import { Command } from 'commander'
+import { Command, type Help } from 'commander'
+import pc from 'picocolors'
 
-import { ALL_CLI_COMMANDS } from './commands/index.js'
+import { CLI_COMMAND_GROUPS } from './commands/index.js'
 import { checkForUpdate, printUpdateBanner, type UpdateCheckStatus } from './common/version-check.js'
 import { configureTelemetry, flushTelemetry } from './core/telemetry/index.js'
 import { version as packageVersion } from './core/utils/version.js'
@@ -12,26 +13,94 @@ import { applyVerboseLogLevel } from './utils/cli-logger.js'
 // Apply CLI env vars to the telemetry library before any subcommand runs.
 configureTelemetry({ ...readTelemetryConfigFromEnv(), affordance: 'CLI' })
 
+function formatTopLevelHelp(command: Command, helper: Help): string {
+  const termWidth = helper.padWidth(command, helper)
+  const helpWidth = helper.helpWidth ?? 80
+  const output: string[] = []
+  const formatItem = (term: string, description: string): string =>
+    helper.formatItem(term, termWidth, description, helper)
+  const formatGroup = (heading: string, items: string[]): void => {
+    output.push(...helper.formatItemList(heading, items, helper))
+  }
+
+  const description = helper.commandDescription(command)
+  if (description.length > 0) {
+    output.push(helper.boxWrap(helper.styleCommandDescription(description), helpWidth), '')
+  }
+
+  output.push(helper.styleTitle('USAGE'), `  ${helper.styleUsage(helper.commandUsage(command))}`, '')
+
+  const commandGroups = helper.groupItems(
+    [...command.commands],
+    helper.visibleCommands(command),
+    (subcommand) => subcommand.helpGroup() || 'COMMANDS'
+  )
+  for (const [heading, commands] of commandGroups) {
+    const items = commands.map((subcommand) =>
+      formatItem(
+        helper.styleSubcommandTerm(helper.subcommandTerm(subcommand)),
+        helper.styleSubcommandDescription(helper.subcommandDescription(subcommand))
+      )
+    )
+    formatGroup(heading, items)
+  }
+
+  const optionGroups = helper.groupItems(
+    [...command.options],
+    helper.visibleOptions(command),
+    (option) => option.helpGroupHeading ?? 'OPTIONS'
+  )
+  for (const [heading, options] of optionGroups) {
+    const items = options.map((option) =>
+      formatItem(
+        helper.styleOptionTerm(helper.optionTerm(option)),
+        helper.styleOptionDescription(helper.optionDescription(option))
+      )
+    )
+    formatGroup(heading, items)
+  }
+
+  return output.join('\n')
+}
+
 // Create the main program
 const program = new Command()
   .name('filecoin-pin')
-  .description('IPFS Pinning Service with Filecoin storage via Synapse SDK')
+  .description('IPFS Pinning Service with Filecoin storage')
+  .optionsGroup('OPTIONS')
   .version(packageVersion)
   .option('-v, --verbose', 'enable debug-level logging (sets LOG_LEVEL=debug)')
   .option('--no-update-check', 'skip check for updates')
+  .helpOption(true)
+  .configureHelp({
+    formatHelp: formatTopLevelHelp,
+    styleTitle: (str) => pc.bold(str.replace(/:$/, '')),
+  })
   .addHelpText(
     'after',
-    `
-Exit codes:
+    () => `
+${pc.bold('EXAMPLES')}
+  $ filecoin-pin payments setup --auto
+  $ filecoin-pin add ./myfile.txt
+  $ filecoin-pin import ./archive.car
+  $ filecoin-pin dataset ls
+
+${pc.bold('EXIT CODES')}
   0  success
   1  error (the operation failed)
   2  incomplete (the operation neither succeeded nor failed: a confirmation
-     was declined, or a requested confirmation wait timed out after submission)`
+     was declined, or a requested confirmation wait timed out after submission)
+
+${pc.bold('DOCUMENTATION')}
+  https://docs.filecoin.cloud/getting-started/filecoin-pin/`
   )
 
 // Add subcommands
-for (const command of ALL_CLI_COMMANDS) {
-  program.addCommand(command)
+for (const { heading, commands } of CLI_COMMAND_GROUPS) {
+  program.commandsGroup(heading)
+  for (const command of commands) {
+    program.addCommand(command)
+  }
 }
 
 // Default action - show help if no command specified

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -10,7 +10,7 @@ import { addEgressOptions } from '../utils/cli-options-egress.js'
 import { addMetadataOptions } from '../utils/cli-options-metadata.js'
 
 export const addCommand = new Command('add')
-  .description('Add a file or directory to Filecoin via Synapse (creates UnixFS CAR)')
+  .description('Upload a file or directory to Filecoin')
   .argument('<path>', 'Path to the file or directory to add')
   .option(
     '--include-hidden',

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -10,7 +10,7 @@ import { addEgressOptions } from '../utils/cli-options-egress.js'
 import { addMetadataOptions } from '../utils/cli-options-metadata.js'
 
 export const importCommand = new Command('import')
-  .description('Import an existing CAR file to Filecoin via Synapse')
+  .description('Upload an existing CAR file to Filecoin')
   .argument('<file>', 'Path to the CAR file to import')
   .option('--copies <n>', 'Number of storage copies to create (default: 2)', Number.parseInt)
   .action(async (file: string, options) => {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -19,19 +19,15 @@ export {
   sessionCommand,
 }
 
-/**
- * Every top-level CLI command in the order they're registered on the program.
- *
- * Adding a new command? Append it here. cli.ts and the network-default tests
- * iterate this list, so registration and coverage stay in sync.
- */
-export const ALL_CLI_COMMANDS: readonly Command[] = [
-  serverCommand,
-  paymentsCommand,
-  dataSetCommand,
-  importCommand,
-  addCommand,
-  removeCommand,
-  providerCommand,
-  sessionCommand,
+interface CliCommandGroup {
+  heading: string
+  commands: readonly Command[]
+}
+
+/** Every top-level CLI command, grouped and ordered for help output. */
+export const CLI_COMMAND_GROUPS: readonly CliCommandGroup[] = [
+  { heading: 'UPLOAD', commands: [addCommand, importCommand] },
+  { heading: 'PAYMENTS', commands: [paymentsCommand] },
+  { heading: 'MANAGEMENT', commands: [dataSetCommand, providerCommand, removeCommand] },
+  { heading: 'ADVANCED', commands: [sessionCommand, serverCommand] },
 ]

--- a/src/commands/payments.ts
+++ b/src/commands/payments.ts
@@ -8,7 +8,9 @@ import type { FundOptions, PaymentSetupOptions } from '../payments/types.js'
 import { runWithdraw } from '../payments/withdraw.js'
 import { addAuthOptions } from '../utils/cli-options.js'
 
-export const paymentsCommand = new Command('payments').description('Manage payment setup for Filecoin Onchain Cloud')
+export const paymentsCommand = new Command('payments').description(
+  'Manage storage payments (required before your first upload)'
+)
 
 // Setup command
 const setupCommand = new Command('setup')

--- a/src/commands/provider.ts
+++ b/src/commands/provider.ts
@@ -3,7 +3,7 @@ import { runProviderList, runProviderPing, runProviderShow } from '../provider/i
 import type { ProviderListOptions, ProviderPingOptions, ProviderShowOptions } from '../provider/types.js'
 import { addAuthOptions } from '../utils/cli-options.js'
 
-export const providerCommand = new Command('provider').description('Inspect and interact with storage providers')
+export const providerCommand = new Command('provider').description('List and inspect storage providers')
 
 const listCommand = new Command('list')
   .alias('ls')

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -7,7 +7,7 @@ import { addAuthOptions, addDataSetIdOption } from '../utils/cli-options.js'
 
 export const removeCommand = new Command('remove')
   .alias('rm')
-  .description('Remove piece(s) from one or more DataSets')
+  .description('Remove stored pieces from your data sets')
   .option('--wait', 'Wait for transaction confirmation before exiting')
   .option('--force', 'Skip confirmation prompt when using --all')
 

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3,7 +3,7 @@ import { startServer } from '../server.js'
 import { addNetworkOptions, addSigningAuthOptions, rpcUrlOption } from '../utils/cli-options.js'
 
 export const serverCommand = new Command('server')
-  .description('Start the IPFS Pinning Service API server')
+  .description('Run a local IPFS Pinning Service API server')
   .addOption(new Option('-p, --port <number>', 'server port').env('PORT').default('3000'))
   .addOption(new Option('--host <string>', 'server host').env('HOST').default('127.0.0.1'))
   .option('--car-storage <path>', 'path for CAR file storage', './cars')

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -9,9 +9,7 @@ import { Command } from 'commander'
 import { runSessionAuthorize, runSessionCreate, runSessionGenerate, runSessionRevoke } from '../session/index.js'
 import { addOwnerAuthOptions, sessionKeyOption } from '../utils/cli-options.js'
 
-export const sessionCommand = new Command('session').description(
-  'Authorize and manage session keys for delegated FWSS access'
-)
+export const sessionCommand = new Command('session').description('Manage session keys for delegated upload access')
 
 // session create — single-party: owner generates (or reuses) a session key and
 // authorizes it on-chain.

--- a/src/test/integration/cli.test.ts
+++ b/src/test/integration/cli.test.ts
@@ -20,6 +20,47 @@ describe('CLI entrypoint', () => {
     }).not.toThrow()
   })
 
+  it('groups commands and provides a user-facing quick start in --help', { timeout: 15000 }, () => {
+    const out = execSync('node dist/cli.js --help', {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    })
+
+    const headings = [
+      'USAGE',
+      'UPLOAD',
+      'PAYMENTS',
+      'MANAGEMENT',
+      'ADVANCED',
+      'OPTIONS',
+      'EXAMPLES',
+      'EXIT CODES',
+      'DOCUMENTATION',
+    ]
+    const headingPositions = headings.map((heading) => out.indexOf(heading))
+    expect(headingPositions.every((position) => position >= 0)).toBe(true)
+    expect(headingPositions).toEqual([...headingPositions].sort((left, right) => left - right))
+
+    for (const heading of headings) {
+      expect(out).not.toContain(`${heading}:`)
+    }
+
+    expect(out.indexOf('IPFS Pinning Service with Filecoin storage')).toBeLessThan(out.indexOf('USAGE'))
+    expect(out).toContain('\nUSAGE\n  filecoin-pin [options] [command]\n')
+    expect(out).toMatch(/add .*<path>/)
+    expect(out).toContain('Upload a file or directory to Filecoin')
+    expect(out).toMatch(/import .*<file>/)
+    expect(out).toContain('Upload an existing CAR file to Filecoin')
+    expect(out).toMatch(/Manage storage payments \(required before your first\s+upload\)/)
+    expect(out).toContain('filecoin-pin payments setup --auto')
+    expect(out).toContain('filecoin-pin add ./myfile.txt')
+    expect(out).toContain('filecoin-pin import ./archive.car')
+    expect(out).toContain('filecoin-pin dataset ls')
+    expect(out).toContain('https://docs.filecoin.cloud/getting-started/filecoin-pin/')
+    expect(out).not.toMatch(/Synapse SDK|UnixFS CAR|FWSS/)
+  })
+
   it('add command exposes --egress-provider in --help', { timeout: 15000 }, () => {
     const out = execSync('node dist/cli.js add --help', {
       cwd: process.cwd(),


### PR DESCRIPTION
Closes #576

### What

- Reorganize top-level CLI help into task-focused groups for `uploads`, `payments`, `management`, and `advanced` commands. 
- Replace internal terminology with user-facing descriptions and add practical examples and documentation link.

### Verification

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- Manually inspect `node dist/cli.js --help`

<img width="600" height="800" alt="image" src="https://github.com/user-attachments/assets/fa9a9727-e29c-4721-9fb3-c1e60b3094d3" />


### Notes

Top-level help now displays the description first, followed by usage, grouped commands, options, examples, exit codes, and documentation. Running the CLI without arguments continues to display full help.