### PR TITLE
 feat: add `--dry-run` flag to `add` and `import` commands

### DIFF
--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -14,7 +14,9 @@ import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { DEVNET_CHAIN_ID } from '../common/get-rpc-url.js'
 import { describeLockupShortfall } from '../common/lockup-error.js'
 import {
+  displayDryRunEstimate,
   displayUploadResults,
+  estimateUploadCost,
   performAutoFunding,
   performUpload,
   promptDataSetSelection,
@@ -33,7 +35,7 @@ import { log } from '../utils/cli-logger.js'
 import { validateAndNormalizeAutoFundOptions } from '../utils/cli-options.js'
 import { buildFilbeamUrl, chainSupportsFilbeam, printEgressNotice } from '../utils/cli-options-egress.js'
 import { resolveMetadataOptions } from '../utils/cli-options-metadata.js'
-import type { AddOptions, AddResult } from './types.js'
+import type { AddDryRunResult, AddOptions, AddResult } from './types.js'
 
 /**
  * Validate that a path exists and is a regular file or directory
@@ -73,7 +75,7 @@ async function validatePath(path: string): Promise<{
  * Commander wiring calls this so option validation errors are displayed by the
  * command UI layer and command files only own exit-code handling.
  */
-export async function runAddFromCli(path: string, options: Record<string, any>): Promise<AddResult> {
+export async function runAddFromCli(path: string, options: Record<string, any>): Promise<AddResult | AddDryRunResult> {
   let addOptions: AddOptions
   try {
     const autoFundOptions = validateAndNormalizeAutoFundOptions(options)
@@ -118,7 +120,7 @@ export async function runAddFromCli(path: string, options: Record<string, any>):
  *
  * @param options - Add configuration
  */
-export async function runAdd(options: AddOptions): Promise<AddResult> {
+export async function runAdd(options: AddOptions): Promise<AddResult | AddDryRunResult> {
   intro(pc.bold('Filecoin Pin Add'))
 
   const spinner = createSpinner()
@@ -219,8 +221,10 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
       }
     }
 
-    // Check payment setup (may configure permissions if needed)
-    if (!options.autoFund) {
+    // Check payment setup (may configure permissions if needed).
+    // Skipped for --dry-run: this can submit an allowance-approval transaction,
+    // which a dry run must never do.
+    if (!options.autoFund && !options.dryRun) {
       spinner.start('Checking payment setup...')
       await validatePaymentSetup(synapse, 0, spinner, {
         suppressSuggestions: true,
@@ -251,6 +255,33 @@ export async function runAdd(options: AddOptions): Promise<AddResult> {
     const { size: carSize } = await stat(tempCarPath)
     const carData = Readable.toWeb(createReadStream(tempCarPath)) as ReadableStream<Uint8Array>
     spinner.stop(`${pc.green('✓')} Packed IPFS content ready (${formatFileSize(carSize)})`)
+
+    if (options.dryRun) {
+      spinner.start('Estimating upload cost...')
+      const estimate = await estimateUploadCost(synapse, carSize, {
+        ...(options.copies != null && { copies: options.copies }),
+        ...(contextSelection.providerIds && { providerIds: contextSelection.providerIds }),
+        ...(contextSelection.dataSetIds && { dataSetIds: contextSelection.dataSetIds }),
+        ...(effectiveDataSetMetadata && { metadata: effectiveDataSetMetadata }),
+        withCDN,
+      })
+      spinner.stop(`${pc.green('✓')} Cost estimate ready`)
+
+      const result: AddDryRunResult = {
+        dryRun: true,
+        filePath: options.filePath,
+        fileSize: carSize,
+        ...(isDirectory && { isDirectory }),
+        rootCid: rootCid.toString(),
+        requestedCopies: estimate.requestedCopies,
+        newDataSetCount: estimate.newDataSetCount,
+        costs: estimate.costs,
+      }
+
+      displayDryRunEstimate(result, estimate, network)
+      outro('Dry run complete — no upload performed')
+      return result
+    }
 
     const autoFundOptions: Parameters<typeof performAutoFunding>[3] = {
       withCDN,

--- a/src/add/types.ts
+++ b/src/add/types.ts
@@ -1,4 +1,5 @@
 import type { CopyResult, FailedAttempt } from '@filoz/synapse-sdk'
+import type { UploadDryRunResult } from '../common/upload-flow.js'
 import type { CLIAuthOptions } from '../utils/cli-auth.js'
 import type { CLIAutoFundOptions } from '../utils/cli-options.js'
 import type { EgressProvider } from '../utils/cli-options-egress.js'
@@ -17,6 +18,8 @@ export interface AddOptions extends CLIAuthOptions, CLIAutoFundOptions {
   includeHidden?: boolean
   /** Egress provider for piece retrieval ('beam' enables FilBeam CDN). Defaults to off when unset. */
   egressProvider?: EgressProvider
+  /** Estimate upload cost and exit before any upload or deposit transaction */
+  dryRun?: boolean
 }
 
 export interface AddResult {
@@ -29,4 +32,8 @@ export interface AddResult {
   requestedCopies: number
   copies: CopyResult[]
   failedAttempts: FailedAttempt[]
+}
+
+export interface AddDryRunResult extends UploadDryRunResult {
+  isDirectory?: boolean
 }

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -29,6 +29,7 @@ Retrieving your content after an add:
 addCommand.action(async (path: string, options: any) => {
   try {
     const result = await runAddFromCli(path, options)
+    if ('dryRun' in result) return
     if (result.copies.length < result.requestedCopies) {
       process.exitCode = 1
     }

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -16,6 +16,7 @@ export const importCommand = new Command('import')
   .action(async (file: string, options) => {
     try {
       const result = await runCarImportFromCli(file, options)
+      if ('dryRun' in result) return
       if (result.copies.length < result.requestedCopies) {
         process.exitCode = 1
       }

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -6,12 +6,14 @@
  */
 
 import { isCancel, multiselect } from '@clack/prompts'
-import type { CopyResult, FailedAttempt, Synapse } from '@filoz/synapse-sdk'
+import type { CopyResult, FailedAttempt, Synapse, UploadCosts } from '@filoz/synapse-sdk'
+import { METADATA_KEYS } from '@filoz/synapse-sdk'
 import type { CID } from 'multiformats/cid'
 import pc from 'picocolors'
 import type { Logger } from 'pino'
 import type { DataSetSummary } from '../core/data-set/types.js'
 import { DEFAULT_LOCKUP_DAYS, type PaymentCapacityCheck } from '../core/payments/index.js'
+import { DEFAULT_COPIES } from '../core/synapse/constants.js'
 import {
   checkUploadReadiness,
   executeUpload,
@@ -419,6 +421,139 @@ function displayPaymentIssues(capacityCheck: PaymentCapacityCheck, fileSize: num
 
   log.line(`${pc.yellow('⚠')} To fix this, run:`)
   log.indent(pc.cyan(`filecoin-pin payments setup --deposit ${suggestedDeposit} --auto`))
+  log.flush()
+}
+
+export interface EstimateUploadCostOptions {
+  /** Number of storage copies to create. Ignored if `providerIds`/`dataSetIds` are set. */
+  copies?: number
+  /** Specific provider IDs to target. Determines copy count when set. */
+  providerIds?: bigint[]
+  /** Specific existing data set IDs to target. Determines copy count when set. */
+  dataSetIds?: bigint[]
+  /** Data set metadata used to match/create contexts. */
+  metadata?: Record<string, string>
+  /** Whether CDN (FilBeam) is enabled for the upload. */
+  withCDN?: boolean
+}
+
+export interface UploadCostEstimate {
+  /** Number of copies the estimate was computed for. */
+  requestedCopies: number
+  /** How many of those copies would create a new data set. */
+  newDataSetCount: number
+  /** Aggregated cost breakdown across all copies. */
+  costs: UploadCosts
+}
+
+/**
+ * Shared shape returned by `add`/`import` when run with `--dry-run`.
+ * Extend per command for any command-specific fields (e.g. `isDirectory` on add).
+ */
+export interface UploadDryRunResult {
+  dryRun: true
+  filePath: string
+  fileSize: number
+  rootCid: string
+  requestedCopies: number
+  newDataSetCount: number
+  costs: UploadCosts
+}
+
+/**
+ * Estimate the cost of an upload without submitting any transaction.
+ *
+ * Resolves contexts via `createContexts()` using the same selectors the real
+ * upload would use, then aggregates costs across all of them with
+ * `calculateMultiContextCosts()`. That function sums per-context lockup/fees
+ * while computing account-level debt/runway/buffer exactly once; calling the
+ * single-context `getUploadCosts()` once per copy and summing the results
+ * would double-count those account-level terms.
+ *
+ * @param synapse - Initialized Synapse instance (read-only auth is sufficient)
+ * @param fileSize - Size of the data to upload, in bytes
+ * @param options - Copy count / targeting / metadata, mirroring the real upload's selectors
+ */
+export async function estimateUploadCost(
+  synapse: Synapse,
+  fileSize: number,
+  options: EstimateUploadCostOptions
+): Promise<UploadCostEstimate> {
+  const requestedCopies = options.providerIds?.length ?? options.dataSetIds?.length ?? options.copies ?? DEFAULT_COPIES
+
+  // Mirror uploadToSynapse's metadata injection: when not targeting specific data
+  // sets by ID, prepend WITH_IPFS_INDEXING so metadataMatches() finds existing
+  // data sets that the real upload would also resolve to (it uses exact key-count
+  // matching — omitting this key causes all contexts to resolve as new data sets).
+  const resolvedMetadata: Record<string, string> =
+    options.dataSetIds != null
+      ? (options.metadata ?? {})
+      : { [METADATA_KEYS.WITH_IPFS_INDEXING]: '', ...(options.metadata ?? {}) }
+
+  const contexts = await synapse.storage.createContexts({
+    copies: requestedCopies,
+    ...(options.providerIds && { providerIds: options.providerIds }),
+    ...(options.dataSetIds && { dataSetIds: options.dataSetIds }),
+    metadata: resolvedMetadata,
+    ...(options.withCDN && { withCDN: options.withCDN }),
+  })
+
+  const newDataSetCount = contexts.filter((context) => context.dataSetId == null).length
+  const costs = await synapse.storage.calculateMultiContextCosts(contexts, { dataSize: BigInt(fileSize) })
+
+  return { requestedCopies, newDataSetCount, costs }
+}
+
+/**
+ * Display a dry-run cost estimate. No upload happens and no funds move.
+ */
+export function displayDryRunEstimate(
+  fileInfo: { filePath: string; fileSize: number; rootCid: string },
+  estimate: UploadCostEstimate,
+  networkDisplay: string
+): void {
+  const { requestedCopies, newDataSetCount, costs } = estimate
+  const existingDataSetCount = requestedCopies - newDataSetCount
+
+  log.line(`Network: ${pc.bold(networkDisplay)}`)
+  log.line('')
+
+  log.line(pc.bold('Content'))
+  log.indent(`File: ${fileInfo.filePath}`)
+  log.indent(`Size: ${formatFileSize(fileInfo.fileSize)}`)
+  log.indent(`Root CID: ${fileInfo.rootCid}`)
+  log.line('')
+
+  log.line(pc.bold('Copies'))
+  const dataSetParts = [
+    newDataSetCount > 0 && `${newDataSetCount} new`,
+    existingDataSetCount > 0 && `${existingDataSetCount} existing`,
+  ].filter((part): part is string => Boolean(part))
+  const dataSetSuffix =
+    dataSetParts.length > 0 ? ` (${dataSetParts.join(', ')} data set${requestedCopies !== 1 ? 's' : ''})` : ''
+  log.indent(`Requested: ${requestedCopies}${dataSetSuffix}`)
+  log.line('')
+
+  log.line(pc.bold('Estimated Cost'))
+  log.indent(`Storage rate: ${formatUSDFC(costs.rates.perMonth)} USDFC/month`)
+  log.indent(`One-time fees: ${formatUSDFC(costs.fees.total)} USDFC`)
+  log.indent(`Lockup (held while active): ${formatUSDFC(costs.lockups.total)} USDFC`)
+  log.indent(`Deposit needed: ${formatUSDFC(costs.depositNeeded)} USDFC`)
+  log.line('')
+
+  if (costs.ready) {
+    log.line(`${pc.green('✓')} Account is ready to upload — no deposit or approval needed`)
+  } else {
+    log.line(`${pc.yellow('⚠')} Account is not ready to upload:`)
+    if (costs.depositNeeded > 0n) {
+      log.indent(`Deposit ${formatUSDFC(costs.depositNeeded)} USDFC before uploading`)
+    }
+    if (costs.needsFwssMaxApproval) {
+      log.indent('WarmStorage operator approval required')
+    }
+  }
+  log.line('')
+  log.line(pc.gray('Dry run — no upload performed, no funds moved.'))
   log.flush()
 }
 

--- a/src/common/upload-flow.ts
+++ b/src/common/upload-flow.ts
@@ -7,11 +7,11 @@
 
 import { isCancel, multiselect } from '@clack/prompts'
 import type { CopyResult, FailedAttempt, Synapse, UploadCosts } from '@filoz/synapse-sdk'
-import { METADATA_KEYS } from '@filoz/synapse-sdk'
 import type { CID } from 'multiformats/cid'
 import pc from 'picocolors'
 import type { Logger } from 'pino'
 import type { DataSetSummary } from '../core/data-set/types.js'
+import { resolveIpfsIndexedMetadata } from '../core/metadata/index.js'
 import { DEFAULT_LOCKUP_DAYS, type PaymentCapacityCheck } from '../core/payments/index.js'
 import { DEFAULT_COPIES } from '../core/synapse/constants.js'
 import {
@@ -481,14 +481,7 @@ export async function estimateUploadCost(
 ): Promise<UploadCostEstimate> {
   const requestedCopies = options.providerIds?.length ?? options.dataSetIds?.length ?? options.copies ?? DEFAULT_COPIES
 
-  // Mirror uploadToSynapse's metadata injection: when not targeting specific data
-  // sets by ID, prepend WITH_IPFS_INDEXING so metadataMatches() finds existing
-  // data sets that the real upload would also resolve to (it uses exact key-count
-  // matching — omitting this key causes all contexts to resolve as new data sets).
-  const resolvedMetadata: Record<string, string> =
-    options.dataSetIds != null
-      ? (options.metadata ?? {})
-      : { [METADATA_KEYS.WITH_IPFS_INDEXING]: '', ...(options.metadata ?? {}) }
+  const resolvedMetadata = resolveIpfsIndexedMetadata(options.metadata, options.dataSetIds)
 
   const contexts = await synapse.storage.createContexts({
     copies: requestedCopies,

--- a/src/core/metadata/index.ts
+++ b/src/core/metadata/index.ts
@@ -1,3 +1,7 @@
+import { IPFS_INDEXED_METADATA } from '../synapse/constants.js'
+
+export { IPFS_INDEXED_METADATA }
+
 export const ERC8004_TYPES = ['registration', 'validationrequest', 'validationresponse', 'feedback'] as const
 
 export type ERC8004Type = (typeof ERC8004_TYPES)[number]
@@ -25,6 +29,23 @@ export interface MetadataConfigInput {
 export interface MetadataConfigResult {
   pieceMetadata?: Record<string, string> | undefined
   dataSetMetadata?: Record<string, string> | undefined
+}
+
+/**
+ * Returns the metadata to pass to `createContexts()` when resolving storage contexts.
+ *
+ * When targeting contexts by explicit `dataSetIds`, the caller's metadata is used as-is —
+ * injecting defaults would risk silent mismatches on the resolve-by-id path.
+ * Otherwise, `IPFS_INDEXED_METADATA` is prepended so `metadataMatches()` finds existing
+ * data sets (it uses exact key-count matching; omitting the key causes all contexts to
+ * resolve as new data sets).
+ */
+export function resolveIpfsIndexedMetadata(
+  metadata: Record<string, string> | undefined,
+  dataSetIds: bigint[] | undefined
+): Record<string, string> {
+  if (dataSetIds != null) return metadata ?? {}
+  return { ...IPFS_INDEXED_METADATA, ...(metadata ?? {}) }
 }
 
 export function normalizeMetadataConfig(input: MetadataConfigInput): MetadataConfigResult {

--- a/src/core/payments/index.ts
+++ b/src/core/payments/index.ts
@@ -21,7 +21,7 @@ import {
   calculateAdditionalLockupRequired,
   calculateBufferAmount,
   calculateRunwayAmount,
-  type getPriceList,
+  getPriceList,
 } from '@filoz/synapse-core/warm-storage'
 import { calibration, SIZE_CONSTANTS, type Synapse, TIME_CONSTANTS, TOKENS } from '@filoz/synapse-sdk'
 import { formatUnits, type Hash } from 'viem'
@@ -921,11 +921,11 @@ export async function validatePaymentCapacity(synapse: Synapse, pieceSizeBytes: 
   // Ensure allowances are at max (automatically skips if in session key mode)
   await checkAndSetAllowances(synapse)
 
-  const [status, storageInfo] = await Promise.all([getPaymentStatus(synapse), synapse.storage.getStorageInfo()])
+  const [status, priceList] = await Promise.all([getPaymentStatus(synapse), getPriceList(synapse.client)])
 
   const storageTiB = pieceSizeBytes / Number(SIZE_CONSTANTS.TiB)
 
-  const uploadRequirements = calculatePieceUploadRequirements(status, pieceSizeBytes, storageInfo.pricing.priceList)
+  const uploadRequirements = calculatePieceUploadRequirements(status, pieceSizeBytes, priceList)
 
   const result: PaymentCapacityCheck = {
     canUpload: uploadRequirements.canUpload,

--- a/src/core/synapse/constants.ts
+++ b/src/core/synapse/constants.ts
@@ -6,11 +6,20 @@ import { METADATA_KEYS } from '@filoz/synapse-sdk'
 export const APPLICATION_SOURCE = 'filecoin-pin'
 
 /**
+ * Base metadata that opts a data set into IPFS indexing.
+ * Injected whenever contexts are resolved by smart-select (not by explicit dataSetIds/contexts),
+ * so metadataMatches() finds existing data sets using exact key-count matching.
+ */
+export const IPFS_INDEXED_METADATA = {
+  [METADATA_KEYS.WITH_IPFS_INDEXING]: '',
+} as const
+
+/**
  * Default metadata for Synapse data sets created by filecoin-pin
  */
 export const DEFAULT_DATA_SET_METADATA = {
-  [METADATA_KEYS.WITH_IPFS_INDEXING]: '', // Enable IPFS indexing for all data sets
-  [METADATA_KEYS.SOURCE]: APPLICATION_SOURCE, // Identify the source application
+  ...IPFS_INDEXED_METADATA,
+  [METADATA_KEYS.SOURCE]: APPLICATION_SOURCE,
 } as const
 
 /**

--- a/src/core/upload/index.ts
+++ b/src/core/upload/index.ts
@@ -162,7 +162,7 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
 
   onProgress?.({ type: 'validatingCapacity' })
 
-  const capacityCheck = await validatePaymentCapacity(synapse, fileSize) // TODO: checks allowances and set max allowances
+  const capacityCheck = await validatePaymentCapacity(synapse, fileSize) // issue #599: validatePaymentCapacity also calls checkAndSetAllowances internally, making autoConfigureAllowances: false ineffective
   const capacityStatus = determineCapacityStatus(capacityCheck)
 
   if (capacityStatus === 'insufficient') {

--- a/src/core/upload/index.ts
+++ b/src/core/upload/index.ts
@@ -162,7 +162,7 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
 
   onProgress?.({ type: 'validatingCapacity' })
 
-  const capacityCheck = await validatePaymentCapacity(synapse, fileSize)
+  const capacityCheck = await validatePaymentCapacity(synapse, fileSize) // TODO: checks allowances and set max allowances
   const capacityStatus = determineCapacityStatus(capacityCheck)
 
   if (capacityStatus === 'insufficient') {

--- a/src/core/upload/synapse.ts
+++ b/src/core/upload/synapse.ts
@@ -11,7 +11,7 @@ import type { StorageContext, StorageManagerUploadOptions } from '@filoz/synapse
 import type { CID } from 'multiformats/cid'
 import type { Logger } from 'pino'
 import type { Hash } from 'viem'
-import { APPLICATION_SOURCE } from '../synapse/constants.js'
+import { APPLICATION_SOURCE, IPFS_INDEXED_METADATA } from '../synapse/constants.js'
 import type { ProgressEvent, ProgressEventHandler } from '../utils/types.js'
 
 export type UploadProgressEvents =
@@ -319,9 +319,7 @@ export async function uploadToSynapse(
   } else {
     const hasCallerSource = options.metadata?.[METADATA_KEYS.SOURCE] != null || synapse.storage.source != null
 
-    const baseMetadata: Record<string, string> = {
-      [METADATA_KEYS.WITH_IPFS_INDEXING]: '',
-    }
+    const baseMetadata: Record<string, string> = { ...IPFS_INDEXED_METADATA }
     if (!hasCallerSource) {
       baseMetadata[METADATA_KEYS.SOURCE] = APPLICATION_SOURCE
     }

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -16,7 +16,9 @@ import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { DEVNET_CHAIN_ID } from '../common/get-rpc-url.js'
 import { describeLockupShortfall } from '../common/lockup-error.js'
 import {
+  displayDryRunEstimate,
   displayUploadResults,
+  estimateUploadCost,
   performAutoFunding,
   performUpload,
   promptDataSetSelection,
@@ -33,7 +35,7 @@ import { log } from '../utils/cli-logger.js'
 import { validateAndNormalizeAutoFundOptions } from '../utils/cli-options.js'
 import { buildFilbeamUrl, chainSupportsFilbeam, printEgressNotice } from '../utils/cli-options-egress.js'
 import { resolveMetadataOptions } from '../utils/cli-options-metadata.js'
-import type { ImportOptions, ImportResult } from './types.js'
+import type { ImportDryRunResult, ImportOptions, ImportResult } from './types.js'
 
 /**
  * Zero CID used when CAR has no roots
@@ -140,7 +142,10 @@ async function validateFilePath(filePath: string): Promise<{ exists: boolean; st
  * Commander wiring calls this so option validation errors are displayed by the
  * command UI layer and command files only own exit-code handling.
  */
-export async function runCarImportFromCli(file: string, options: Record<string, any>): Promise<ImportResult> {
+export async function runCarImportFromCli(
+  file: string,
+  options: Record<string, any>
+): Promise<ImportResult | ImportDryRunResult> {
   let importOptions: ImportOptions
   try {
     const autoFundOptions = validateAndNormalizeAutoFundOptions(options)
@@ -185,7 +190,7 @@ export async function runCarImportFromCli(file: string, options: Record<string, 
  *
  * @param options - Import configuration
  */
-export async function runCarImport(options: ImportOptions): Promise<ImportResult> {
+export async function runCarImport(options: ImportOptions): Promise<ImportResult | ImportDryRunResult> {
   intro(pc.bold('Filecoin Pin CAR Import'))
 
   const spinner = createSpinner()
@@ -284,6 +289,32 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
           `${pc.gray('•')} No existing data sets matched --data-set-metadata; SDK will create a new data set with the requested metadata`
         )
       }
+    }
+
+    if (options.dryRun) {
+      spinner.start('Estimating upload cost...')
+      const estimate = await estimateUploadCost(synapse, fileStat.size, {
+        ...(options.copies != null && { copies: options.copies }),
+        ...(contextSelection.providerIds && { providerIds: contextSelection.providerIds }),
+        ...(contextSelection.dataSetIds && { dataSetIds: contextSelection.dataSetIds }),
+        ...(effectiveDataSetMetadata && { metadata: effectiveDataSetMetadata }),
+        withCDN,
+      })
+      spinner.stop(`${pc.green('✓')} Cost estimate ready`)
+
+      const result: ImportDryRunResult = {
+        dryRun: true,
+        filePath: options.filePath,
+        fileSize: fileStat.size,
+        rootCid: rootCidString,
+        requestedCopies: estimate.requestedCopies,
+        newDataSetCount: estimate.newDataSetCount,
+        costs: estimate.costs,
+      }
+
+      displayDryRunEstimate(result, estimate, network)
+      outro('Dry run complete — no upload performed')
+      return result
     }
 
     if (options.autoFund) {

--- a/src/import/types.ts
+++ b/src/import/types.ts
@@ -1,4 +1,5 @@
 import type { CopyResult, FailedAttempt } from '@filoz/synapse-sdk'
+import type { UploadDryRunResult } from '../common/upload-flow.js'
 import type { CLIAuthOptions } from '../utils/cli-auth.js'
 import type { CLIAutoFundOptions } from '../utils/cli-options.js'
 import type { EgressProvider } from '../utils/cli-options-egress.js'
@@ -15,6 +16,8 @@ export interface ImportOptions extends CLIAuthOptions, CLIAutoFundOptions {
   skipIpniVerification?: boolean
   /** Egress provider for piece retrieval ('beam' enables FilBeam CDN). Defaults to off when unset. */
   egressProvider?: EgressProvider
+  /** Estimate upload cost and exit before any upload or deposit transaction */
+  dryRun?: boolean
 }
 
 export interface ImportResult {
@@ -27,3 +30,5 @@ export interface ImportResult {
   copies: CopyResult[]
   failedAttempts: FailedAttempt[]
 }
+
+export type ImportDryRunResult = UploadDryRunResult

--- a/src/payments/fund.ts
+++ b/src/payments/fund.ts
@@ -6,6 +6,7 @@
 
 import { confirm, isCancel } from '@clack/prompts'
 import type { Synapse } from '@filoz/synapse-sdk'
+import { METADATA_KEYS } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
 import { parseUnits } from 'viem'
 import { CliFatal, CliIncomplete, isCliFatal, isCliIncomplete, setIncompleteExitCode } from '../common/cli-errors.js'
@@ -142,11 +143,18 @@ export async function autoFund(options: AutoFundOptions): Promise<FundingAdjustm
 
   spinner?.message('Checking wallet readiness...')
 
+  // Mirror uploadToSynapse's metadata injection: when not targeting specific data
+  // sets by ID, prepend WITH_IPFS_INDEXING so metadataMatches() finds existing
+  // data sets (it uses exact key-count matching — omitting this key causes all
+  // contexts to appear new, inflating the computed deposit).
+  const resolvedMetadata: Record<string, string> =
+    dataSetIds != null ? (metadata ?? {}) : { [METADATA_KEYS.WITH_IPFS_INDEXING]: '', ...(metadata ?? {}) }
+
   const contexts = await synapse.storage.createContexts({
     ...(copies != null ? { copies } : {}),
     ...(providerIds != null ? { providerIds } : {}),
     ...(dataSetIds != null ? { dataSetIds } : {}),
-    ...(metadata != null ? { metadata } : {}),
+    metadata: resolvedMetadata,
   })
   const newDataSetCount = contexts.filter((context) => context.dataSetId == null).length
 

--- a/src/payments/fund.ts
+++ b/src/payments/fund.ts
@@ -6,11 +6,11 @@
 
 import { confirm, isCancel } from '@clack/prompts'
 import type { Synapse } from '@filoz/synapse-sdk'
-import { METADATA_KEYS } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
 import { parseUnits } from 'viem'
 import { CliFatal, CliIncomplete, isCliFatal, isCliIncomplete, setIncompleteExitCode } from '../common/cli-errors.js'
 import { MIN_RUNWAY_DAYS } from '../common/constants.js'
+import { resolveIpfsIndexedMetadata } from '../core/metadata/index.js'
 import {
   checkUSDFCBalance,
   clampDepositToLimit,
@@ -143,12 +143,7 @@ export async function autoFund(options: AutoFundOptions): Promise<FundingAdjustm
 
   spinner?.message('Checking wallet readiness...')
 
-  // Mirror uploadToSynapse's metadata injection: when not targeting specific data
-  // sets by ID, prepend WITH_IPFS_INDEXING so metadataMatches() finds existing
-  // data sets (it uses exact key-count matching — omitting this key causes all
-  // contexts to appear new, inflating the computed deposit).
-  const resolvedMetadata: Record<string, string> =
-    dataSetIds != null ? (metadata ?? {}) : { [METADATA_KEYS.WITH_IPFS_INDEXING]: '', ...(metadata ?? {}) }
+  const resolvedMetadata = resolveIpfsIndexedMetadata(metadata, dataSetIds)
 
   const contexts = await synapse.storage.createContexts({
     ...(copies != null ? { copies } : {}),

--- a/src/test/unit/add.test.ts
+++ b/src/test/unit/add.test.ts
@@ -13,6 +13,7 @@ import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runAdd, runAddFromCli } from '../../add/add.js'
+import type { AddDryRunResult, AddResult } from '../../add/types.js'
 
 const { mockCarPath, mockFindDataSets } = vi.hoisted(() => ({
   mockCarPath: 'test-add-files/mock.car',
@@ -41,6 +42,19 @@ vi.mock('../../common/upload-flow.js', () => ({
     network: 'calibration',
   }),
   displayUploadResults: vi.fn(),
+  estimateUploadCost: vi.fn().mockResolvedValue({
+    requestedCopies: 2,
+    newDataSetCount: 0,
+    costs: {
+      rates: { perEpoch: 100n, perMonth: 3000n },
+      fees: { total: 500n },
+      lockups: { total: 90000n },
+      depositNeeded: 0n,
+      needsFwssMaxApproval: false,
+      ready: true,
+    },
+  }),
+  displayDryRunEstimate: vi.fn(),
 }))
 
 vi.mock('../../core/synapse/index.js', () => ({
@@ -125,11 +139,11 @@ describe('Add Command', () => {
 
   describe('runAdd command', () => {
     it('should successfully add a file (no directory wrapper)', async () => {
-      const result = await runAdd({
+      const result = (await runAdd({
         filePath: testFile,
         privateKey: 'test-private-key',
         rpcUrl: 'wss://test.rpc.url',
-      })
+      })) as AddResult
 
       // Verify the result structure (multi-copy format)
       expect(result).toMatchObject({
@@ -429,6 +443,100 @@ describe('Add Command', () => {
       const calls = vi.mocked(displayUploadResults).mock.calls
       const last = calls[calls.length - 1]
       expect(last?.[4]).toBeUndefined()
+    })
+
+    describe('dry-run', () => {
+      it('returns AddDryRunResult and skips upload, funding, and payment validation', async () => {
+        const result = (await runAdd({
+          filePath: testFile,
+          privateKey: 'test-private-key',
+          rpcUrl: 'wss://test.rpc.url',
+          dryRun: true,
+        })) as AddDryRunResult
+
+        expect(result).toMatchObject({
+          dryRun: true,
+          filePath: testFile,
+          fileSize: expect.any(Number),
+          rootCid: TEST_FILE_CID,
+          requestedCopies: 2,
+          newDataSetCount: 0,
+          costs: expect.objectContaining({ ready: true }),
+        })
+
+        const { performUpload, performAutoFunding, validatePaymentSetup } = await import('../../common/upload-flow.js')
+        expect(vi.mocked(performUpload)).not.toHaveBeenCalled()
+        expect(vi.mocked(performAutoFunding)).not.toHaveBeenCalled()
+        expect(vi.mocked(validatePaymentSetup)).not.toHaveBeenCalled()
+      })
+
+      it('passes copies to estimateUploadCost', async () => {
+        await runAdd({
+          filePath: testFile,
+          privateKey: 'test-private-key',
+          rpcUrl: 'wss://test.rpc.url',
+          dryRun: true,
+          copies: 3,
+        })
+
+        const { estimateUploadCost } = await import('../../common/upload-flow.js')
+        expect(vi.mocked(estimateUploadCost)).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.any(Number),
+          expect.objectContaining({ copies: 3 })
+        )
+      })
+
+      it('passes providerIds to estimateUploadCost', async () => {
+        await runAdd({
+          filePath: testFile,
+          privateKey: 'test-private-key',
+          rpcUrl: 'wss://test.rpc.url',
+          dryRun: true,
+          providerIds: ['7', '8'],
+        })
+
+        const { estimateUploadCost } = await import('../../common/upload-flow.js')
+        expect(vi.mocked(estimateUploadCost)).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.any(Number),
+          expect.objectContaining({ providerIds: [7n, 8n] })
+        )
+      })
+
+      it('passes dataSetIds to estimateUploadCost', async () => {
+        await runAdd({
+          filePath: testFile,
+          privateKey: 'test-private-key',
+          rpcUrl: 'wss://test.rpc.url',
+          dryRun: true,
+          dataSetIds: ['123', '456'],
+        })
+
+        const { estimateUploadCost } = await import('../../common/upload-flow.js')
+        expect(vi.mocked(estimateUploadCost)).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.any(Number),
+          expect.objectContaining({ dataSetIds: [123n, 456n] })
+        )
+      })
+
+      it('passes withCDN to estimateUploadCost based on egressProvider', async () => {
+        await runAdd({
+          filePath: testFile,
+          privateKey: 'test-private-key',
+          rpcUrl: 'wss://test.rpc.url',
+          dryRun: true,
+          egressProvider: 'none',
+        })
+
+        const { estimateUploadCost } = await import('../../common/upload-flow.js')
+        expect(vi.mocked(estimateUploadCost)).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.any(Number),
+          expect.objectContaining({ withCDN: false })
+        )
+      })
     })
   })
 

--- a/src/test/unit/import.test.ts
+++ b/src/test/unit/import.test.ts
@@ -20,7 +20,7 @@ import * as raw from 'multiformats/codecs/raw'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runCarImport, runCarImportFromCli } from '../../import/import.js'
-import type { ImportOptions } from '../../import/types.js'
+import type { ImportDryRunResult, ImportOptions, ImportResult } from '../../import/types.js'
 
 // Test constants
 const ZERO_CID = 'bafkqaaa' // Zero CID used when CAR has no roots
@@ -48,6 +48,19 @@ vi.mock('../../common/upload-flow.js', () => ({
   }),
   displayUploadResults: vi.fn(),
   performAutoFunding: vi.fn(),
+  estimateUploadCost: vi.fn().mockResolvedValue({
+    requestedCopies: 2,
+    newDataSetCount: 0,
+    costs: {
+      rates: { perEpoch: 100n, perMonth: 3000n },
+      fees: { total: 500n },
+      lockups: { total: 90000n },
+      depositNeeded: 0n,
+      needsFwssMaxApproval: false,
+      ready: true,
+    },
+  }),
+  displayDryRunEstimate: vi.fn(),
 }))
 vi.mock('../../core/payments/index.js', async () => {
   const actual = await vi.importActual<typeof import('../../core/payments/index.js')>('../../core/payments/index.js')
@@ -235,7 +248,7 @@ describe('CAR Import', () => {
         privateKey: testPrivateKey,
       }
 
-      const result = await runCarImport(options)
+      const result = (await runCarImport(options)) as ImportResult
 
       expect(result.rootCid).toBe(cid.toString())
       expect(result.filePath).toBe(carPath)
@@ -256,7 +269,7 @@ describe('CAR Import', () => {
         privateKey: testPrivateKey,
       }
 
-      const result = await runCarImport(options)
+      const result = (await runCarImport(options)) as ImportResult
 
       expect(result.rootCid).toBe(ZERO_CID) // Zero CID
       expect(result.filePath).toBe(carPath)
@@ -533,7 +546,7 @@ describe('CAR Import', () => {
         privateKey: testPrivateKey,
       }
 
-      const result = await runCarImport(options)
+      const result = (await runCarImport(options)) as ImportResult
 
       expect(result).toMatchObject({
         filePath: carPath,
@@ -547,6 +560,114 @@ describe('CAR Import', () => {
       expect(result.copies[0]?.role).toBe('primary')
       expect(result.copies[0]?.providerId).toBe(1n)
       expect(result.failedAttempts).toHaveLength(0)
+    })
+  })
+
+  describe('dry-run', () => {
+    it('returns ImportDryRunResult and skips upload, funding, and payment validation', async () => {
+      const carPath = join(testDir, 'dry-run.car')
+      await createTestCarFile(carPath, [], [{ content: 'dry-run content' }])
+
+      const result = (await runCarImport({
+        filePath: carPath,
+        privateKey: testPrivateKey,
+        rpcUrl: 'wss://test.rpc.url',
+        dryRun: true,
+      })) as ImportDryRunResult
+
+      expect(result).toMatchObject({
+        dryRun: true,
+        filePath: carPath,
+        fileSize: expect.any(Number),
+        requestedCopies: 2,
+        newDataSetCount: 0,
+        costs: expect.objectContaining({ ready: true }),
+      })
+
+      const { performUpload, performAutoFunding, validatePaymentSetup } = await import('../../common/upload-flow.js')
+      expect(vi.mocked(performUpload)).not.toHaveBeenCalled()
+      expect(vi.mocked(performAutoFunding)).not.toHaveBeenCalled()
+      expect(vi.mocked(validatePaymentSetup)).not.toHaveBeenCalled()
+    })
+
+    it('passes copies to estimateUploadCost', async () => {
+      const carPath = join(testDir, 'dry-run-copies.car')
+      await createTestCarFile(carPath, [], [{ content: 'copies content' }])
+
+      await runCarImport({
+        filePath: carPath,
+        privateKey: testPrivateKey,
+        rpcUrl: 'wss://test.rpc.url',
+        dryRun: true,
+        copies: 3,
+      })
+
+      const { estimateUploadCost } = await import('../../common/upload-flow.js')
+      expect(vi.mocked(estimateUploadCost)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Number),
+        expect.objectContaining({ copies: 3 })
+      )
+    })
+
+    it('passes providerIds to estimateUploadCost', async () => {
+      const carPath = join(testDir, 'dry-run-providers.car')
+      await createTestCarFile(carPath, [], [{ content: 'providers content' }])
+
+      await runCarImport({
+        filePath: carPath,
+        privateKey: testPrivateKey,
+        rpcUrl: 'wss://test.rpc.url',
+        dryRun: true,
+        providerIds: ['7', '8'],
+      })
+
+      const { estimateUploadCost } = await import('../../common/upload-flow.js')
+      expect(vi.mocked(estimateUploadCost)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Number),
+        expect.objectContaining({ providerIds: [7n, 8n] })
+      )
+    })
+
+    it('passes dataSetIds to estimateUploadCost', async () => {
+      const carPath = join(testDir, 'dry-run-datasets.car')
+      await createTestCarFile(carPath, [], [{ content: 'datasets content' }])
+
+      await runCarImport({
+        filePath: carPath,
+        privateKey: testPrivateKey,
+        rpcUrl: 'wss://test.rpc.url',
+        dryRun: true,
+        dataSetIds: ['123', '456'],
+      })
+
+      const { estimateUploadCost } = await import('../../common/upload-flow.js')
+      expect(vi.mocked(estimateUploadCost)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Number),
+        expect.objectContaining({ dataSetIds: [123n, 456n] })
+      )
+    })
+
+    it('passes withCDN: false to estimateUploadCost when egressProvider is none', async () => {
+      const carPath = join(testDir, 'dry-run-egress.car')
+      await createTestCarFile(carPath, [], [{ content: 'egress content' }])
+
+      await runCarImport({
+        filePath: carPath,
+        privateKey: testPrivateKey,
+        rpcUrl: 'wss://test.rpc.url',
+        dryRun: true,
+        egressProvider: 'none',
+      })
+
+      const { estimateUploadCost } = await import('../../common/upload-flow.js')
+      expect(vi.mocked(estimateUploadCost)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Number),
+        expect.objectContaining({ withCDN: false })
+      )
     })
   })
 })

--- a/src/test/unit/import.test.ts
+++ b/src/test/unit/import.test.ts
@@ -204,6 +204,14 @@ async function createTestCarFile(
   return { cids }
 }
 
+async function createCarWithRoot(carPath: string): Promise<CID> {
+  const { cids } = await createTestCarFile(carPath, [], [{ content: 'test content' }])
+  const cid = cids[0]
+  if (!cid) throw new Error('No CID generated')
+  await createTestCarFile(carPath, [cid], [{ content: 'test content', cid }])
+  return cid
+}
+
 describe('CAR Import', () => {
   const testDir = './test-import-cars'
   const testPrivateKey = '0x0000000000000000000000000000000000000000000000000000000000000001'
@@ -232,23 +240,9 @@ describe('CAR Import', () => {
   describe('CAR File Validation', () => {
     it('should validate a proper CAR file with single root', async () => {
       const carPath = join(testDir, 'valid.car')
-      const { cids } = await createTestCarFile(
-        carPath,
-        [], // Will use first block's CID as root
-        [{ content: 'test content' }]
-      )
-      const cid = cids[0]
-      if (!cid) throw new Error('No CID generated')
+      const cid = await createCarWithRoot(carPath)
 
-      // Update CAR with proper root
-      await createTestCarFile(carPath, [cid], [{ content: 'test content', cid }])
-
-      const options: ImportOptions = {
-        filePath: carPath,
-        privateKey: testPrivateKey,
-      }
-
-      const result = (await runCarImport(options)) as ImportResult
+      const result = (await runCarImport({ filePath: carPath, privateKey: testPrivateKey })) as ImportResult
 
       expect(result.rootCid).toBe(cid.toString())
       expect(result.filePath).toBe(carPath)
@@ -533,20 +527,9 @@ describe('CAR Import', () => {
   describe('Upload Result', () => {
     it('should return complete import result with copies', async () => {
       const carPath = join(testDir, 'result.car')
-      const { cids } = await createTestCarFile(carPath, [], [{ content: 'test content' }])
+      const cid = await createCarWithRoot(carPath)
 
-      const cid = cids[0]
-      if (!cid) throw new Error('No CID generated')
-
-      // Recreate with proper root
-      await createTestCarFile(carPath, [cid], [{ content: 'test content', cid }])
-
-      const options: ImportOptions = {
-        filePath: carPath,
-        privateKey: testPrivateKey,
-      }
-
-      const result = (await runCarImport(options)) as ImportResult
+      const result = (await runCarImport({ filePath: carPath, privateKey: testPrivateKey })) as ImportResult
 
       expect(result).toMatchObject({
         filePath: carPath,

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -271,12 +271,19 @@ export function addNetworkOptions(command: Command): Command {
  * Used by `add` and `import` commands.
  */
 export function addUploadOptions(command: Command): Command {
-  return command.addOption(
-    new Option(
-      '--skip-ipni-verification',
-      'Skip IPNI advertisement verification after upload (automatic for devnet)'
-    ).env('SKIP_IPNI_VERIFICATION')
-  )
+  return command
+    .addOption(
+      new Option(
+        '--skip-ipni-verification',
+        'Skip IPNI advertisement verification after upload (automatic for devnet)'
+      ).env('SKIP_IPNI_VERIFICATION')
+    )
+    .addOption(
+      new Option(
+        '--dry-run',
+        'Estimate upload cost and required deposit, then exit without uploading or moving funds'
+      ).conflicts('autoFund')
+    )
 }
 
 /**


### PR DESCRIPTION
Closes #591

### What
Adds `--dry-run` to both `add` and `import`. Packs the CAR (add) or validates the file (import) as usual, then estimates cost across all requested copies using `calculateMultiContextCosts()` and exits without uploading or moving funds. Also fixes a pre-existing bug in `autoFund` where missing `WITH_IPFS_INDEXING` metadata caused all contexts to resolve as new data sets, inflating deposit estimates.

### Verification
- `pnpm test` - 634 unit tests pass
- `filecoin-pin add <file> --dry-run` prints cost breakdown, no upload
- `filecoin-pin import <car> --dry-run` same
- `--dry-run --auto-fund` rejected by Commander with a conflict error

<img width="697" height="566" alt="image" src="https://github.com/user-attachments/assets/26a9cc27-a72a-4aca-8853-7aa6ed0c8ee1" />


### Notes
`--dry-run` skips the early WarmStorage allowance-approval check in `add`, which would otherwise submit an on-chain transaction before the dry-run exits.

`calculateMultiContextCosts()` was chosen over calling `getUploadCosts()` once per copy because `getUploadCosts()` independently re-derives account-level debt, runway, and buffer on every call. `calculateMultiContextCosts()` sums per-context lockup and fees while computing the account-level terms exactly once, giving a correct aggregate.

The current upload path's payment check (`validatePaymentCapacity` / `calculatePieceUploadRequirements`) still uses a single-context, copies-unaware estimator that hardcodes `isNewDataSet: false`. A follow-up could replace it with `calculateMultiContextCosts()` or `prepare()` directly for consistent, accurate pre-upload estimates.