### PR TITLE
docs: pin upload-action examples to @master, recommend specific version or SHA for production

### DIFF
--- a/upload-action/README.md
+++ b/upload-action/README.md
@@ -32,7 +32,7 @@ If `path` points to a regular file whose name ends in `.car`, the action skips i
 
 ```yaml
 - name: Upload pre-built CAR to Filecoin
-  uses: filecoin-project/filecoin-pin/upload-action@v0
+  uses: filecoin-project/filecoin-pin/upload-action@v1
   with:
     path: build.car
     walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
@@ -46,7 +46,7 @@ For most users, automatic provider selection is recommended. However, for advanc
 
 ```yaml
 - name: Upload to Filecoin
-  uses: filecoin-project/filecoin-pin/upload-action@v0
+  uses: filecoin-project/filecoin-pin/upload-action@v1
   env:
     PROVIDER_IDS: "1,2"  # Target specific providers by their numeric on-chain IDs
   with:
@@ -64,7 +64,7 @@ To append an upload to one or more existing Synapse datasets instead of creating
 
 ```yaml
 - name: Upload to Filecoin
-  uses: filecoin-project/filecoin-pin/upload-action@v0
+  uses: filecoin-project/filecoin-pin/upload-action@v1
   with:
     path: dist
     walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
@@ -75,7 +75,7 @@ When omitted, the SDK selects or creates a dataset automatically (recommended). 
 
 ## Security Checklist
 
-- ✅ Pin action by version tag or commit SHA (`@v0`, `@v0.9.1`, or `@<sha>`)
+- ✅ Pin action by version tag or commit SHA (`@v1`, `@v1.1.0`, or `@<sha>`)
 - ✅ Grant `actions: read` for artifact reuse (cache fallback)
 - ✅ Grant `checks: write` for PR check status
 - ✅ Grant `pull-requests: write` for PR comments
@@ -99,9 +99,12 @@ When omitted, the SDK selects or creates a dataset automatically (recommended). 
 
 Use semantic version tags from [filecoin-pin releases](https://github.com/filecoin-project/filecoin-pin/releases):
 
-- **`@v0`** - Latest v0.x.x (recommended)
-- **`@v0.9.1`** - Specific version (production)
+- **`@v1`** - Latest v1.x.x (recommended)
+- **`@v1.1.0`** - Specific version (production)
 - **`@<commit-sha>`** - Maximum supply-chain security
+
+> [!IMPORTANT]
+> The `@v0` line is no longer supported and not receiving security patches. Users should mMigrate any workflows still pinned to `@v0` or `@v0.x.x`.
 
 The action checks npm for a newer `filecoin-pin` release at the start of each run and posts a GitHub Actions notice when one is available.
 

--- a/upload-action/README.md
+++ b/upload-action/README.md
@@ -32,7 +32,8 @@ If `path` points to a regular file whose name ends in `.car`, the action skips i
 
 ```yaml
 - name: Upload pre-built CAR to Filecoin
-  uses: filecoin-project/filecoin-pin/upload-action@v1
+  # For production, pin to a specific version (e.g. @v1.1.0) or commit SHA instead of @master.
+  uses: filecoin-project/filecoin-pin/upload-action@master
   with:
     path: build.car
     walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
@@ -46,7 +47,8 @@ For most users, automatic provider selection is recommended. However, for advanc
 
 ```yaml
 - name: Upload to Filecoin
-  uses: filecoin-project/filecoin-pin/upload-action@v1
+  # For production, pin to a specific version (e.g. @v1.1.0) or commit SHA instead of @master.
+  uses: filecoin-project/filecoin-pin/upload-action@master
   env:
     PROVIDER_IDS: "1,2"  # Target specific providers by their numeric on-chain IDs
   with:
@@ -64,7 +66,8 @@ To append an upload to one or more existing Synapse datasets instead of creating
 
 ```yaml
 - name: Upload to Filecoin
-  uses: filecoin-project/filecoin-pin/upload-action@v1
+  # For production, pin to a specific version (e.g. @v1.1.0) or commit SHA instead of @master.
+  uses: filecoin-project/filecoin-pin/upload-action@master
   with:
     path: dist
     walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
@@ -75,7 +78,7 @@ When omitted, the SDK selects or creates a dataset automatically (recommended). 
 
 ## Security Checklist
 
-- ✅ Pin action by version tag or commit SHA (`@v1`, `@v1.1.0`, or `@<sha>`)
+- ✅ Pin action by specific version tag (`@v1.1.0`) or commit SHA (`@<sha>`) for production workflows. `@master` is acceptable for tracking latest but accepts whatever maintainers push between releases.
 - ✅ Grant `actions: read` for artifact reuse (cache fallback)
 - ✅ Grant `checks: write` for PR check status
 - ✅ Grant `pull-requests: write` for PR comments
@@ -97,14 +100,14 @@ When omitted, the SDK selects or creates a dataset automatically (recommended). 
 
 ## Versioning and Updates
 
-Use semantic version tags from [filecoin-pin releases](https://github.com/filecoin-project/filecoin-pin/releases):
+Pin the action to one of:
 
-- **`@v1`** - Latest v1.x.x (recommended)
-- **`@v1.1.0`** - Specific version (production)
-- **`@<commit-sha>`** - Maximum supply-chain security
+- **`@v1.1.0`** (or any specific [release tag](https://github.com/filecoin-project/filecoin-pin/releases)). Recommended for production.
+- **`@<commit-sha>`**. Maximum supply-chain security; updates require an intentional commit.
+- **`@master`**. Tracks the latest commit on master. Convenient, and what [filecoin-pin-website's CI](https://github.com/filecoin-project/filecoin-pin-website/blob/main/.github/workflows/filecoin-pin-upload.yml) currently uses, but it accepts whatever maintainers push, so avoid it in security-sensitive workflows.
 
-> [!IMPORTANT]
-> The `@v0` line is no longer supported and not receiving security patches. Users should migrate any workflows still pinned to `@v0` or `@v0.x.x`.
+> [!NOTE]
+> Floating major-version tags (e.g. `@v1`) are not currently maintained. Pin to a specific version, commit SHA, or `@master`.
 
 The action checks npm for a newer `filecoin-pin` release at the start of each run and posts a GitHub Actions notice when one is available.
 

--- a/upload-action/README.md
+++ b/upload-action/README.md
@@ -104,7 +104,7 @@ Use semantic version tags from [filecoin-pin releases](https://github.com/fileco
 - **`@<commit-sha>`** - Maximum supply-chain security
 
 > [!IMPORTANT]
-> The `@v0` line is no longer supported and not receiving security patches. Users should mMigrate any workflows still pinned to `@v0` or `@v0.x.x`.
+> The `@v0` line is no longer supported and not receiving security patches. Users should migrate any workflows still pinned to `@v0` or `@v0.x.x`.
 
 The action checks npm for a newer `filecoin-pin` release at the start of each run and posts a GitHub Actions notice when one is available.
 

--- a/upload-action/examples/single-workflow/build-and-upload.yml
+++ b/upload-action/examples/single-workflow/build-and-upload.yml
@@ -31,7 +31,8 @@ jobs:
 
       # Upload to Filecoin - the action will build CAR and upload in a single flow
       - name: Upload to Filecoin
-        uses: filecoin-project/filecoin-pin/upload-action@v1
+        # For production, pin to a specific version (e.g. @v1.1.0) or commit SHA instead of @master.
+        uses: filecoin-project/filecoin-pin/upload-action@master
         with:
           walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
           path: dist

--- a/upload-action/examples/single-workflow/build-and-upload.yml
+++ b/upload-action/examples/single-workflow/build-and-upload.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Upload to Filecoin - the action will build CAR and upload in a single flow
       - name: Upload to Filecoin
-        uses: filecoin-project/filecoin-pin/upload-action@v0
+        uses: filecoin-project/filecoin-pin/upload-action@v1
         with:
           walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}
           path: dist

--- a/upload-action/examples/two-workflow-pattern/upload-to-filecoin.yml
+++ b/upload-action/examples/two-workflow-pattern/upload-to-filecoin.yml
@@ -37,7 +37,7 @@ jobs:
       # Upload to Filecoin using the downloaded build artifacts
       # The action will create a CAR file from the downloaded artifacts and upload to Filecoin
       - name: Upload to Filecoin
-        uses: filecoin-project/filecoin-pin/upload-action@v0
+        uses: filecoin-project/filecoin-pin/upload-action@v1
         with:
           path: dist  # Path to the downloaded build artifacts
           walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}

--- a/upload-action/examples/two-workflow-pattern/upload-to-filecoin.yml
+++ b/upload-action/examples/two-workflow-pattern/upload-to-filecoin.yml
@@ -37,7 +37,8 @@ jobs:
       # Upload to Filecoin using the downloaded build artifacts
       # The action will create a CAR file from the downloaded artifacts and upload to Filecoin
       - name: Upload to Filecoin
-        uses: filecoin-project/filecoin-pin/upload-action@v1
+        # For production, pin to a specific version (e.g. @v1.1.0) or commit SHA instead of @master.
+        uses: filecoin-project/filecoin-pin/upload-action@master
         with:
           path: dist  # Path to the downloaded build artifacts
           walletPrivateKey: ${{ secrets.FILECOIN_WALLET_KEY }}


### PR DESCRIPTION
## Summary

Updates the upload-action README examples and example workflows to pin to `@master`, matching what [filecoin-pin-website's CI](https://github.com/filecoin-project/filecoin-pin-website/blob/main/.github/workflows/filecoin-pin-upload.yml) actually uses. Each `@master` pin has an inline comment pointing readers to a specific version or commit SHA for production.

Background: the prior README examples (and this branch's first commit) used `@v0` / `@v1`, but no floating major-version ref exists on the repo today, so those pins fail to resolve. Caught in review by @rjan90.

## Changes

- README code examples (3 of them) and both example workflows: `@v1` → `@master` with a leading comment recommending specific version / SHA pins for production.
- README **Versioning and Updates** section: restructured to lead with specific version tag (production), then commit SHA (max supply-chain security), then `@master` (with a clear caveat). Added a NOTE that floating major-version tags like `@v1` are not currently maintained.
- README **Security Checklist**: rewritten to match the new ordering.

## Follow-ups (not in this PR)

- If we want the floating-major-tag UX (`@v1`) at some point, file a follow-up to either (a) manually create and maintain `v1`, or (b) automate it via the release-please job.

## Test plan

- [ ] Visual: render the README on the branch and confirm the **Versioning and Updates** section reads clearly
- [ ] Verify the two example workflow YAMLs still parse (no incidental indentation drift)
- [ ] Sanity-check that `@master` actually resolves for the action (it should; that's what filecoin-pin-website already uses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)