### PR TITLE
fix: make payment preflight deposit-aware

### DIFF
--- a/src/core/payments/funding.ts
+++ b/src/core/payments/funding.ts
@@ -8,6 +8,7 @@ import {
   computeAdjustmentForExactDeposit,
   depositUSDFC,
   getPaymentStatus,
+  validateGasRequirement,
   validatePaymentRequirements,
   withdrawUSDFC,
 } from './index.js'
@@ -427,15 +428,17 @@ export async function planFilecoinPayFunding(options: PlanFilecoinPayFundingOpti
     allowWithdraw,
   })
 
-  // Planning, no-op, and withdrawal paths do not spend wallet USDFC. Only
-  // validate wallet funding when this plan will actually make a deposit.
-  if (plan.delta > 0n) {
-    const isCalibnet = status.chainId === calibration.id
-    const validation = validatePaymentRequirements(status.filBalance, status.walletUsdfcBalance, isCalibnet)
-    if (!validation.isValid) {
-      const help = validation.helpMessage ? ` ${validation.helpMessage}` : ''
-      throw new Error(`${validation.errorMessage}${help}`)
-    }
+  // Every plan may be followed by a transaction (allowance, deposit, or
+  // withdrawal), so always validate FIL for gas. Only a deposit spends wallet
+  // USDFC, so retain that check exclusively for positive deltas.
+  const isCalibnet = status.chainId === calibration.id
+  const validation =
+    plan.delta > 0n
+      ? validatePaymentRequirements(status.filBalance, status.walletUsdfcBalance, isCalibnet)
+      : validateGasRequirement(status.filBalance, isCalibnet)
+  if (!validation.isValid) {
+    const help = validation.helpMessage ? ` ${validation.helpMessage}` : ''
+    throw new Error(`${validation.errorMessage}${help}`)
   }
 
   const allowances = ensureAllowances

--- a/src/core/payments/funding.ts
+++ b/src/core/payments/funding.ts
@@ -367,10 +367,10 @@ export interface PlanFilecoinPayFundingOptions {
  *
  * This async function handles the full workflow:
  * - Fetches current payment status and SDK account summary in parallel
- * - Optionally ensures allowances are configured
- * - Validates payment requirements (FIL for gas, USDFC availability)
  * - Fetches pricing if needed
  * - Calculates funding plan via `calculateFilecoinPayFundingPlan`
+ * - Validates wallet funding only when the plan requires a deposit
+ * - Optionally ensures allowances are configured
  *
  * @param options - Planning options including synapse instance
  * @returns Plan with status and allowance information
@@ -406,29 +406,7 @@ export async function planFilecoinPayFunding(options: PlanFilecoinPayFundingOpti
     throw new Error('A funding target is required')
   }
 
-  let allowanceStatus: {
-    updated: boolean
-    transactionHash?: string
-    currentAllowances: ServiceApprovalStatus
-  } | null = null
-
-  if (ensureAllowances) {
-    allowanceStatus = await checkAndSetAllowances(synapse)
-  }
-
   const [status, accountSummary] = await Promise.all([getPaymentStatus(synapse), synapse.payments.accountSummary({})])
-
-  const allowances = allowanceStatus ?? {
-    updated: false,
-    currentAllowances: status.currentAllowances,
-  }
-
-  const isCalibnet = status.chainId === calibration.id
-  const validation = validatePaymentRequirements(status.filBalance, status.walletUsdfcBalance, isCalibnet)
-  if (!validation.isValid) {
-    const help = validation.helpMessage ? ` ${validation.helpMessage}` : ''
-    throw new Error(`${validation.errorMessage}${help}`)
-  }
 
   let priceList = priceListOpt
   if (pieceSizeBytes != null && priceList == null) {
@@ -448,6 +426,24 @@ export async function planFilecoinPayFunding(options: PlanFilecoinPayFundingOpti
     mode,
     allowWithdraw,
   })
+
+  // Planning, no-op, and withdrawal paths do not spend wallet USDFC. Only
+  // validate wallet funding when this plan will actually make a deposit.
+  if (plan.delta > 0n) {
+    const isCalibnet = status.chainId === calibration.id
+    const validation = validatePaymentRequirements(status.filBalance, status.walletUsdfcBalance, isCalibnet)
+    if (!validation.isValid) {
+      const help = validation.helpMessage ? ` ${validation.helpMessage}` : ''
+      throw new Error(`${validation.errorMessage}${help}`)
+    }
+  }
+
+  const allowances = ensureAllowances
+    ? await checkAndSetAllowances(synapse)
+    : {
+        updated: false,
+        currentAllowances: status.currentAllowances,
+      }
 
   return {
     plan,

--- a/src/core/upload/index.ts
+++ b/src/core/upload/index.ts
@@ -10,8 +10,8 @@ import {
   checkUSDFCBalance,
   type PaymentCapacityCheck,
   setMaxAllowances,
+  validateGasRequirement,
   validatePaymentCapacity,
-  validatePaymentRequirements,
 } from '../payments/index.js'
 import { isSessionKeyMode } from '../synapse/index.js'
 import { recordUploadResult } from '../telemetry/index.js'
@@ -78,7 +78,7 @@ export interface UploadReadinessOptions {
 export interface UploadReadinessResult {
   /** Overall status of the readiness check. */
   status: 'ready' | 'blocked'
-  /** Gas + USDFC validation outcome. */
+  /** Gas validation outcome. */
   validation: {
     isValid: boolean
     errorMessage?: string
@@ -106,7 +106,7 @@ type CapacityStatus = 'sufficient' | 'warning' | 'insufficient'
  * Check readiness for uploading a CAR file.
  *
  * This performs the same validation chain previously used by the CLI/action:
- * 1. Ensure basic wallet requirements (FIL for gas, USDFC balance)
+ * 1. Ensure the wallet has enough FIL for gas
  * 2. Confirm or configure WarmStorage allowances
  * 3. Validate that the current deposit can cover the upload
  *
@@ -130,7 +130,9 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
   const filStatus = await checkFILBalance(synapse)
   const walletUsdfcBalance = await checkUSDFCBalance(synapse)
 
-  const validation = validatePaymentRequirements(filStatus.balance, walletUsdfcBalance, filStatus.isCalibnet)
+  // Upload readiness never deposits wallet USDFC. Deposited funds are checked
+  // below by validatePaymentCapacity, so only gas belongs in this wallet gate.
+  const validation = validateGasRequirement(filStatus.balance, filStatus.isCalibnet)
   if (!validation.isValid) {
     return {
       status: 'blocked',

--- a/src/test/unit/payments-funding.test.ts
+++ b/src/test/unit/payments-funding.test.ts
@@ -248,6 +248,75 @@ describe('planFilecoinPayFunding', () => {
     expect(plan.projected.runway.state).toBe('no-spend')
   })
 
+  it('allows a no-op plan when all USDFC is already deposited', async () => {
+    const deposited = 10n * ONE_USDFC
+    const status = makeStatus({ filecoinPayBalance: deposited, wallet: 0n })
+    const summary = makeSummary({ filecoinPayBalance: deposited })
+    const validationSpy = vi.spyOn(paymentsIndex, 'validatePaymentRequirements')
+    vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+
+    const { plan } = await planFilecoinPayFunding({
+      synapse: makeSynapseStub(summary) as any,
+      targetDeposit: deposited,
+    })
+
+    expect(plan.action).toBe('none')
+    expect(validationSpy).not.toHaveBeenCalled()
+  })
+
+  it('allows a withdrawal plan when wallet USDFC is zero', async () => {
+    const deposited = 10n * ONE_USDFC
+    const status = makeStatus({ filecoinPayBalance: deposited, wallet: 0n })
+    const summary = makeSummary({ filecoinPayBalance: deposited })
+    const validationSpy = vi.spyOn(paymentsIndex, 'validatePaymentRequirements')
+    vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+
+    const { plan } = await planFilecoinPayFunding({
+      synapse: makeSynapseStub(summary) as any,
+      targetDeposit: 5n * ONE_USDFC,
+    })
+
+    expect(plan.action).toBe('withdraw')
+    expect(plan.delta).toBe(-5n * ONE_USDFC)
+    expect(validationSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a deposit plan when wallet USDFC is zero', async () => {
+    const status = makeStatus({ filecoinPayBalance: 0n, wallet: 0n })
+    vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+
+    await expect(
+      planFilecoinPayFunding({
+        synapse: makeSynapseStub() as any,
+        targetDeposit: ONE_USDFC,
+      })
+    ).rejects.toThrow('No USDFC tokens found')
+  })
+
+  it('allows an allowance-only update when wallet USDFC is zero', async () => {
+    const deposited = 10n * ONE_USDFC
+    const status = makeStatus({ filecoinPayBalance: deposited, wallet: 0n })
+    const summary = makeSummary({ filecoinPayBalance: deposited })
+    const validationSpy = vi.spyOn(paymentsIndex, 'validatePaymentRequirements')
+    vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+    const allowanceSpy = vi.spyOn(paymentsIndex, 'checkAndSetAllowances').mockResolvedValue({
+      updated: true,
+      transactionHash: '0xallowance',
+      currentAllowances: status.currentAllowances,
+    })
+
+    const { plan, allowances } = await planFilecoinPayFunding({
+      synapse: makeSynapseStub(summary) as any,
+      targetDeposit: deposited,
+      ensureAllowances: true,
+    })
+
+    expect(plan.action).toBe('none')
+    expect(allowances.updated).toBe(true)
+    expect(allowanceSpy).toHaveBeenCalledOnce()
+    expect(validationSpy).not.toHaveBeenCalled()
+  })
+
   it('throws when both runway and deposit targets are provided', async () => {
     const status = makeStatus({ filecoinPayBalance: 0n, wallet: 1_000n })
     vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)

--- a/src/test/unit/payments-funding.test.ts
+++ b/src/test/unit/payments-funding.test.ts
@@ -317,6 +317,25 @@ describe('planFilecoinPayFunding', () => {
     expect(validationSpy).not.toHaveBeenCalled()
   })
 
+  it('checks FIL gas before an allowance-only no-op plan', async () => {
+    const deposited = 10n * ONE_USDFC
+    const status = makeStatus({ filecoinPayBalance: deposited, wallet: 0n, filBalance: 0n })
+    const summary = makeSummary({ filecoinPayBalance: deposited })
+    const allowanceSpy = vi.spyOn(paymentsIndex, 'checkAndSetAllowances')
+
+    vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+
+    await expect(
+      planFilecoinPayFunding({
+        synapse: makeSynapseStub(summary) as any,
+        targetDeposit: deposited,
+        ensureAllowances: true,
+      })
+    ).rejects.toThrow('Insufficient FIL for gas fees (balance: 0.0000 tFIL')
+
+    expect(allowanceSpy).not.toHaveBeenCalled()
+  })
+
   it('throws when both runway and deposit targets are provided', async () => {
     const status = makeStatus({ filecoinPayBalance: 0n, wallet: 1_000n })
     vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)

--- a/src/test/unit/upload-readiness.test.ts
+++ b/src/test/unit/upload-readiness.test.ts
@@ -1,0 +1,74 @@
+import { parseEther } from 'viem'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  checkAllowances: vi.fn(),
+  checkFILBalance: vi.fn(),
+  checkUSDFCBalance: vi.fn(),
+  setMaxAllowances: vi.fn(),
+  validatePaymentCapacity: vi.fn(),
+}))
+
+vi.mock('../../core/payments/index.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../core/payments/index.js')>()),
+  checkAllowances: mocks.checkAllowances,
+  checkFILBalance: mocks.checkFILBalance,
+  checkUSDFCBalance: mocks.checkUSDFCBalance,
+  setMaxAllowances: mocks.setMaxAllowances,
+  validatePaymentCapacity: mocks.validatePaymentCapacity,
+}))
+
+vi.mock('../../core/synapse/index.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../core/synapse/index.js')>()),
+  isSessionKeyMode: vi.fn(() => false),
+}))
+
+import { checkUploadReadiness } from '../../core/upload/index.js'
+
+describe('checkUploadReadiness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.checkFILBalance.mockResolvedValue({
+      balance: parseEther('1'),
+      isCalibnet: false,
+      hasSufficientGas: true,
+    })
+    mocks.checkUSDFCBalance.mockResolvedValue(0n)
+    mocks.checkAllowances.mockResolvedValue({ needsUpdate: false, currentAllowances: {} })
+    mocks.validatePaymentCapacity.mockResolvedValue({
+      canUpload: true,
+      storageTiB: 0.001,
+      required: {
+        rateAllowance: 1n,
+        lockupAllowance: 1n,
+        storageCapacityTiB: 0.001,
+      },
+      issues: {},
+      suggestions: [],
+    })
+  })
+
+  it('allows uploads when wallet USDFC is zero but deposited capacity is sufficient', async () => {
+    const result = await checkUploadReadiness({ synapse: {} as any, fileSize: 1024 })
+
+    expect(result.status).toBe('ready')
+    expect(result.validation).toEqual({ isValid: true })
+    expect(result.walletUsdfcBalance).toBe(0n)
+    expect(mocks.validatePaymentCapacity).toHaveBeenCalledWith({}, 1024)
+  })
+
+  it('still blocks before capacity checks when wallet FIL is insufficient for gas', async () => {
+    mocks.checkFILBalance.mockResolvedValue({
+      balance: 0n,
+      isCalibnet: false,
+      hasSufficientGas: false,
+    })
+
+    const result = await checkUploadReadiness({ synapse: {} as any, fileSize: 1024 })
+
+    expect(result.status).toBe('blocked')
+    expect(result.validation.errorMessage).toContain('Insufficient FIL for gas fees')
+    expect(mocks.checkAllowances).not.toHaveBeenCalled()
+    expect(mocks.validatePaymentCapacity).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- allow upload readiness checks to use deposited Filecoin Pay funds when wallet USDFC is zero
- calculate funding plans before deciding whether wallet USDFC is required
- preserve FIL gas validation for deposit, withdrawal, and allowance transaction paths
- avoid configuring allowances before a funding plan has passed wallet validation

## Testing

- `pnpm run build`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test:unit` (685 passed, 11 skipped)

Closes #616
