### PR TITLE
fix(cli): clarify that --session-key expects a session key private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,10 @@ npm install -g filecoin-pin
 #    Private key:   export PRIVATE_KEY=0x...
 #                   (or pass --private-key <key> to each command)
 #    Session key:   export WALLET_ADDRESS=0x... SESSION_KEY=0x...
-#                   (or pass --wallet-address <addr> --session-key <key> to each command)
+#                   WALLET_ADDRESS is the owner wallet address; SESSION_KEY is the
+#                   session key PRIVATE key (not the session address), as printed by
+#                   `filecoin-pin session create` or `filecoin-pin session generate`
+#                   (or pass --wallet-address <addr> --session-key <private-key> to each command)
 #    Revoke later:  filecoin-pin session revoke <session-address>
 
 # 1. Configure payment permissions (one-time setup)
@@ -254,7 +257,7 @@ filecoin-pin add myfile.txt
 * `-v`, `--verbose`: Verbose output
 * `--private-key`: Ethereum-style (`0x`) private key (wallet and signer), funded with USDFC
 * `--wallet-address`: Session key mode: owner wallet address
-* `--session-key`: Session key mode: scoped signing key registered to the wallet
+* `--session-key`: Session key mode: the session key's **private key** (printed as `SESSION_KEY` by `filecoin-pin session create` / `session generate`), not the session address
 * `--network`: Filecoin network to use: `mainnet`, `calibration`, or `devnet` (default: `mainnet`). Mutually exclusive with `--rpc-url`.
 * `--rpc-url`: Filecoin RPC endpoint. Filecoin Pin probes its `eth_chainId` to derive the chain. Mutually exclusive with `--network`.
 

--- a/documentation/glossary.md
+++ b/documentation/glossary.md
@@ -235,6 +235,8 @@ A session key acts as a credential that permits a scoped-down set of tasks on be
 
 Session keys require specific permissions (such as CREATE_DATA_SET and ADD_PIECES) and have expiration timestamps.  The filecoin-pin-website session key is scoped to allowing the creation of [data sets](#data-set) and [pieces](#piece), but prevents transferring of funds for example. Wallet owners can also revoke session key permissions before expiration.
 
+Note that the filecoin-pin CLI's `--session-key` flag (and `SESSION_KEY` environment variable) expect the session key's **private key** — the `SESSION_KEY` value printed by `filecoin-pin session create` or `filecoin-pin session generate` — not the session address. The (public) session address is only used when authorizing or revoking: `filecoin-pin session authorize <session-address>` and `filecoin-pin session revoke <session-address>`.
+
 
 
 ## Standard IPFS Tooling

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -142,7 +142,7 @@ const PERMISSION_NAMES: Record<string, string> = {
  * Reject malformed session key material before it reaches the SDK, whose own
  * error ("invalid private key, expected hex or 32 bytes") never names the flag.
  */
-function assertSessionKeyPrivateKey(value: string): void {
+export function assertSessionKeyPrivateKey(value: string): asserts value is Hex {
   if (/^0x[0-9a-fA-F]{64}$/.test(value)) return
   const detail = /^(0x)?[0-9a-fA-F]{40}$/.test(value)
     ? 'this looks like an address, but the session key private key (0x-prefixed, 64 hex characters) is required'

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -138,6 +138,23 @@ const PERMISSION_NAMES: Record<string, string> = {
   [SchedulePieceRemovalsPermission]: 'SchedulePieceRemovals',
 }
 
+/**
+ * Reject malformed session key material before it reaches the SDK. Without
+ * this, viem fails with "invalid private key, expected hex or 32 bytes" —
+ * which never names `--session-key` and gives no clue that the flag expects
+ * the session key's private key rather than its address.
+ */
+function assertSessionKeyPrivateKey(value: string): void {
+  if (/^0x[0-9a-fA-F]{64}$/.test(value)) return
+  const detail = /^(0x)?[0-9a-fA-F]{40}$/.test(value)
+    ? 'this looks like an address, but the session key private key (0x-prefixed, 64 hex characters) is required'
+    : 'expected the session key private key (0x-prefixed, 64 hex characters)'
+  throw new Error(
+    `Invalid --session-key / SESSION_KEY: ${detail}. ` +
+      'Use the SESSION_KEY value printed by "filecoin-pin session create" or "filecoin-pin session generate".'
+  )
+}
+
 function checkSessionKeyPermissions(key: SessionKey<'Secp256k1'>, ownerAddress: string): void {
   const missing = DefaultFwssPermissions.filter((p) => !key.hasPermission(p))
   if (missing.length === 0) return
@@ -196,6 +213,7 @@ export async function initializeSynapse(config: SynapseSetupConfig, logger?: Log
   } else if (isSessionKeyConfig(config)) {
     const walletAddress = getAddress(config.walletAddress)
     account = walletAddress
+    assertSessionKeyPrivateKey(config.sessionKey)
     sessionKey = fromSecp256k1({
       privateKey: config.sessionKey,
       root: walletAddress,

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -139,10 +139,8 @@ const PERMISSION_NAMES: Record<string, string> = {
 }
 
 /**
- * Reject malformed session key material before it reaches the SDK. Without
- * this, viem fails with "invalid private key, expected hex or 32 bytes" —
- * which never names `--session-key` and gives no clue that the flag expects
- * the session key's private key rather than its address.
+ * Reject malformed session key material before it reaches the SDK, whose own
+ * error ("invalid private key, expected hex or 32 bytes") never names the flag.
  */
 function assertSessionKeyPrivateKey(value: string): void {
   if (/^0x[0-9a-fA-F]{64}$/.test(value)) return
@@ -187,6 +185,12 @@ function checkSessionKeyPermissions(key: SessionKey<'Secp256k1'>, ownerAddress: 
  * @returns Initialized Synapse instance
  */
 export async function initializeSynapse(config: SynapseSetupConfig, logger?: Logger): Promise<Synapse> {
+  // Validate key material before any network I/O (the RPC chain probe below)
+  // so a malformed --session-key fails fast even when the RPC endpoint is down.
+  if (isSessionKeyConfig(config)) {
+    assertSessionKeyPrivateKey(config.sessionKey)
+  }
+
   let chain: Chain
   let rpcUrl: string | undefined
   let transport: HttpTransport | WebSocketTransport | undefined
@@ -213,13 +217,19 @@ export async function initializeSynapse(config: SynapseSetupConfig, logger?: Log
   } else if (isSessionKeyConfig(config)) {
     const walletAddress = getAddress(config.walletAddress)
     account = walletAddress
-    assertSessionKeyPrivateKey(config.sessionKey)
-    sessionKey = fromSecp256k1({
-      privateKey: config.sessionKey,
-      root: walletAddress,
-      chain,
-      ...(transport ? { transport } : {}),
-    })
+    try {
+      sessionKey = fromSecp256k1({
+        privateKey: config.sessionKey,
+        root: walletAddress,
+        chain,
+        ...(transport ? { transport } : {}),
+      })
+    } catch (error) {
+      // The format gate in assertSessionKeyPrivateKey can't catch key material
+      // outside the secp256k1 scalar range (e.g. all zeros).
+      const reason = error instanceof Error ? error.message : String(error)
+      throw new Error(`Invalid --session-key / SESSION_KEY: ${reason}`, { cause: error })
+    }
     await sessionKey.syncExpirations()
     checkSessionKeyPermissions(sessionKey, walletAddress)
     logger?.info({ event: 'synapse.init', mode: 'session-key' }, 'Initializing Synapse (session key)')

--- a/src/filecoin-pinning-server.ts
+++ b/src/filecoin-pinning-server.ts
@@ -3,7 +3,7 @@ import { CID } from 'multiformats/cid'
 import type { Logger } from 'pino'
 import { isAddress, isHex } from 'viem'
 import type { Chain, Config } from './core/synapse/index.js'
-import { initializeSynapse, type SynapseSetupConfig } from './core/synapse/index.js'
+import { assertSessionKeyPrivateKey, initializeSynapse, type SynapseSetupConfig } from './core/synapse/index.js'
 import { FilecoinPinStore, type PinOptions } from './filecoin-pin-store.js'
 import type { ServiceInfo } from './server.js'
 
@@ -100,12 +100,7 @@ function buildSynapseConfig(config: Config): SynapseSetupConfig {
     if (!isAddress(config.walletAddress)) {
       throw new Error('Wallet address must be an ethereum address')
     }
-    if (!isHex(config.sessionKey)) {
-      throw new Error('Session key must be 0x-prefixed hexadecimal')
-    }
-    if (config.sessionKey.length !== 66) {
-      throw new Error('Session key must be 32 bytes')
-    }
+    assertSessionKeyPrivateKey(config.sessionKey)
     return {
       ...base,
       walletAddress: config.walletAddress,

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,7 +76,7 @@ export async function startServer(): Promise<void> {
     if (errorMessage.includes('No authentication')) {
       console.error('\n❌ Error: Authentication is required to start the pinning server')
       console.error('   Private key:   --private-key <key>  or  PRIVATE_KEY=0x...')
-      console.error('   Session key:   --wallet-address <addr> --session-key <key>')
+      console.error('   Session key:   --wallet-address <addr> --session-key <private-key>')
       console.error('                  or  WALLET_ADDRESS=0x... SESSION_KEY=0x...\n')
     } else if (errorMessage.includes('No access token')) {
       console.error('\n❌ Error: An access token is required to start the pinning server')

--- a/src/test/unit/filecoin-pinning-server.unit.test.ts
+++ b/src/test/unit/filecoin-pinning-server.unit.test.ts
@@ -161,7 +161,7 @@ describe('createFilecoinPinningServer auth selection', () => {
     const logger = createLogger(config)
 
     await expect(createFilecoinPinningServer(config, logger, SERVICE_INFO)).rejects.toThrow(
-      'Session key must be 0x-prefixed hexadecimal'
+      'Invalid --session-key / SESSION_KEY'
     )
   })
 
@@ -177,7 +177,25 @@ describe('createFilecoinPinningServer auth selection', () => {
     const logger = createLogger(config)
 
     await expect(createFilecoinPinningServer(config, logger, SERVICE_INFO)).rejects.toThrow(
-      'Session key must be 32 bytes'
+      'Invalid --session-key / SESSION_KEY'
+    )
+  })
+
+  it('should name the flag and flag the address mix-up when sessionKey looks like a session address', async () => {
+    const config = {
+      ...createConfig(),
+      carStoragePath: TEST_OUTPUT_DIR,
+      port: 0,
+      privateKey: undefined,
+      walletAddress: '0x0000000000000000000000000000000000000002',
+      // A 40-hex-char value shaped like an address, not a 32-byte private key
+      // — the mistake this validator exists to catch on the daemon path too.
+      sessionKey: '0x1234567890123456789012345678901234567890',
+    }
+    const logger = createLogger(config)
+
+    await expect(createFilecoinPinningServer(config, logger, SERVICE_INFO)).rejects.toThrow(
+      /Invalid --session-key \/ SESSION_KEY: this looks like an address/
     )
   })
 

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -118,6 +118,30 @@ describe('synapse-service', () => {
 
       await expect(initializeSynapse(config, logger)).rejects.toThrow('Missing: --wallet-address / WALLET_ADDRESS')
     })
+
+    it('should throw a flag-specific error when sessionKey is not a hex private key', async () => {
+      const config = {
+        walletAddress: '0x0000000000000000000000000000000000000002',
+        sessionKey: 'not-a-private-key',
+        rpcUrl: 'wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1',
+      } as any
+
+      await expect(initializeSynapse(config, logger)).rejects.toThrow(
+        'Invalid --session-key / SESSION_KEY: expected the session key private key'
+      )
+    })
+
+    it('should explain when the session address is passed as sessionKey', async () => {
+      const config = {
+        walletAddress: '0x0000000000000000000000000000000000000002',
+        sessionKey: '0x1234567890123456789012345678901234567890',
+        rpcUrl: 'wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1',
+      } as any
+
+      await expect(initializeSynapse(config, logger)).rejects.toThrow(
+        'this looks like an address, but the session key private key'
+      )
+    })
   })
 
   describe('initializeSynapse chain resolution', () => {

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -142,6 +142,39 @@ describe('synapse-service', () => {
         'this looks like an address, but the session key private key'
       )
     })
+
+    it('should name --session-key when the SDK rejects a well-formed key (e.g. out of curve range)', async () => {
+      const { fromSecp256k1 } = await import('@filoz/synapse-core/session-key')
+      vi.mocked(fromSecp256k1).mockImplementationOnce(() => {
+        // Mirrors viem's privateKeyToAccount error for a zero scalar
+        throw new Error('expected valid private key: 1 <= n < 1157920892…, got 0')
+      })
+
+      const config = {
+        walletAddress: '0x0000000000000000000000000000000000000002',
+        sessionKey: `0x${'0'.repeat(64)}`,
+        rpcUrl: 'wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1',
+      } as any
+
+      await expect(initializeSynapse(config, logger)).rejects.toThrow(
+        'Invalid --session-key / SESSION_KEY: expected valid private key'
+      )
+    })
+
+    it('should report a malformed sessionKey before probing the RPC endpoint', async () => {
+      const { resolveChainFromRpc } = await import('../../core/synapse/resolve-chain-from-rpc.js')
+
+      const config = {
+        walletAddress: '0x0000000000000000000000000000000000000002',
+        sessionKey: 'not-a-private-key',
+        rpcUrl: 'wss://unreachable.example.com/rpc/v1',
+      } as any
+
+      await expect(initializeSynapse(config, logger)).rejects.toThrow(
+        'Invalid --session-key / SESSION_KEY: expected the session key private key'
+      )
+      expect(resolveChainFromRpc).not.toHaveBeenCalled()
+    })
   })
 
   describe('initializeSynapse chain resolution', () => {

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -41,8 +41,10 @@ export function rpcUrlOption(description: string): Option {
 export function addSigningAuthOptions(command: Command): Command {
   return command
     .addOption(privateKeyOption('Private key for standard auth'))
-    .addOption(new Option('--wallet-address <address>', 'Wallet address for session key auth').env('WALLET_ADDRESS'))
-    .addOption(sessionKeyOption('Session key for session key auth'))
+    .addOption(
+      new Option('--wallet-address <address>', 'Owner wallet address for session key auth').env('WALLET_ADDRESS')
+    )
+    .addOption(sessionKeyOption('Session key private key for session key auth (not the session address)'))
 }
 
 /**


### PR DESCRIPTION
Fixes #612

`--session-key` expects the session key's **private key**, but nothing in the help text, docs, or error output said so — passing the session address (or any other wrong value) failed deep inside the SDK with viem's bare `invalid private key, expected hex or 32 bytes, got string`.

## Changes

**Clear, early errors** (`src/core/synapse/index.ts`)
- Validate the session key format at the top of `initializeSynapse()`, before any network I/O (including the `--rpc-url` chain probe). Wrong values now fail fast with an error naming `--session-key / SESSION_KEY` and pointing at `session create` / `session generate` as the source of the correct value.
- When the value looks like an address (40 hex chars), say so explicitly: *"this looks like an address, but the session key private key (0x-prefixed, 64 hex characters) is required"*.
- Wrap `fromSecp256k1()` so well-formed keys the SDK still rejects (e.g. out of secp256k1 scalar range) also surface with the flag named.

**Help text** (`src/utils/cli-options.ts`)
- `--session-key`: "Session key private key for session key auth (not the session address)"
- `--wallet-address`: "Owner wallet address for session key auth"

**Docs**
- README: Basic Usage and the argument list now state `SESSION_KEY` is the session key *private key* printed by `filecoin-pin session create` / `session generate`.
- Glossary: Session Key entry notes the CLI flag takes the private key; the session *address* is only used by `session authorize` / `session revoke`.

The `SESSION_KEY` env var name is intentionally kept (rather than the `SESSION_KEY_PRIVATE_KEY` suggested in the issue): `session create` / `session generate` already print `SESSION_KEY=0x...` for direct export, so renaming would break that consistency. All wording now makes the private-key expectation explicit instead.

## Before / after

```text
# before
Add failed: invalid private key, expected hex or 32 bytes, got string

# after (session address passed by mistake)
Add failed: Invalid --session-key / SESSION_KEY: this looks like an address, but the
session key private key (0x-prefixed, 64 hex characters) is required. Use the
SESSION_KEY value printed by "filecoin-pin session create" or "filecoin-pin session generate".
```

## Testing

- 4 new unit tests: garbage value, address passed as key, SDK-rejected well-formed key, and validation ordering ahead of the RPC probe.
- Verified end-to-end against the built CLI (real SDK, no mocks) for all three error paths.
