### PR TITLE
fix: make payment preflight deposit-aware

### DIFF
--- a/src/core/payments/funding.ts
+++ b/src/core/payments/funding.ts
@@ -8,6 +8,7 @@ import {
   computeAdjustmentForExactDeposit,
   depositUSDFC,
   getPaymentStatus,
+  validateGasRequirement,
   validatePaymentRequirements,
   withdrawUSDFC,
 } from './index.js'
@@ -427,15 +428,17 @@ export async function planFilecoinPayFunding(options: PlanFilecoinPayFundingOpti
     allowWithdraw,
   })
 
-  // Planning, no-op, and withdrawal paths do not spend wallet USDFC. Only
-  // validate wallet funding when this plan will actually make a deposit.
-  if (plan.delta > 0n) {
-    const isCalibnet = status.chainId === calibration.id
-    const validation = validatePaymentRequirements(status.filBalance, status.walletUsdfcBalance, isCalibnet)
-    if (!validation.isValid) {
-      const help = validation.helpMessage ? ` ${validation.helpMessage}` : ''
-      throw new Error(`${validation.errorMessage}${help}`)
-    }
+  // Every plan may be followed by a transaction (allowance, deposit, or
+  // withdrawal), so always validate FIL for gas. Only a deposit spends wallet
+  // USDFC, so retain that check exclusively for positive deltas.
+  const isCalibnet = status.chainId === calibration.id
+  const validation =
+    plan.delta > 0n
+      ? validatePaymentRequirements(status.filBalance, status.walletUsdfcBalance, isCalibnet)
+      : validateGasRequirement(status.filBalance, isCalibnet)
+  if (!validation.isValid) {
+    const help = validation.helpMessage ? ` ${validation.helpMessage}` : ''
+    throw new Error(`${validation.errorMessage}${help}`)
   }
 
   const allowances = ensureAllowances

--- a/src/core/payments/funding.ts
+++ b/src/core/payments/funding.ts
@@ -370,7 +370,7 @@ export interface PlanFilecoinPayFundingOptions {
  * - Fetches current payment status and SDK account summary in parallel
  * - Fetches pricing if needed
  * - Calculates funding plan via `calculateFilecoinPayFundingPlan`
- * - Validates wallet funding only when the plan requires a deposit
+ * - Validates wallet funding whenever the plan will send a transaction
  * - Optionally ensures allowances are configured
  *
  * @param options - Planning options including synapse instance

--- a/src/core/payments/funding.ts
+++ b/src/core/payments/funding.ts
@@ -428,17 +428,21 @@ export async function planFilecoinPayFunding(options: PlanFilecoinPayFundingOpti
     allowWithdraw,
   })
 
-  // Every plan may be followed by a transaction (allowance, deposit, or
-  // withdrawal), so always validate FIL for gas. Only a deposit spends wallet
+  // Validate wallet funding only when the plan can send a transaction: a
+  // nonzero delta deposits or withdraws, and ensureAllowances may update
+  // allowances. A no-op plan without allowance changes is read-only, so it
+  // must not fail on insufficient FIL for gas. Only a deposit spends wallet
   // USDFC, so retain that check exclusively for positive deltas.
-  const isCalibnet = status.chainId === calibration.id
-  const validation =
-    plan.delta > 0n
-      ? validatePaymentRequirements(status.filBalance, status.walletUsdfcBalance, isCalibnet)
-      : validateGasRequirement(status.filBalance, isCalibnet)
-  if (!validation.isValid) {
-    const help = validation.helpMessage ? ` ${validation.helpMessage}` : ''
-    throw new Error(`${validation.errorMessage}${help}`)
+  if (plan.delta !== 0n || ensureAllowances) {
+    const isCalibnet = status.chainId === calibration.id
+    const validation =
+      plan.delta > 0n
+        ? validatePaymentRequirements(status.filBalance, status.walletUsdfcBalance, isCalibnet)
+        : validateGasRequirement(status.filBalance, isCalibnet)
+    if (!validation.isValid) {
+      const help = validation.helpMessage ? ` ${validation.helpMessage}` : ''
+      throw new Error(`${validation.errorMessage}${help}`)
+    }
   }
 
   const allowances = ensureAllowances
@@ -448,6 +452,8 @@ export async function planFilecoinPayFunding(options: PlanFilecoinPayFundingOpti
         currentAllowances: status.currentAllowances,
       }
 
+  // status is captured before any allowance update; when allowances.updated
+  // is true, read fresh allowance state from allowances.currentAllowances.
   return {
     plan,
     status,

--- a/src/core/payments/funding.ts
+++ b/src/core/payments/funding.ts
@@ -367,10 +367,10 @@ export interface PlanFilecoinPayFundingOptions {
  *
  * This async function handles the full workflow:
  * - Fetches current payment status and SDK account summary in parallel
- * - Optionally ensures allowances are configured
- * - Validates payment requirements (FIL for gas, USDFC availability)
  * - Fetches pricing if needed
  * - Calculates funding plan via `calculateFilecoinPayFundingPlan`
+ * - Validates wallet funding only when the plan requires a deposit
+ * - Optionally ensures allowances are configured
  *
  * @param options - Planning options including synapse instance
  * @returns Plan with status and allowance information
@@ -406,29 +406,7 @@ export async function planFilecoinPayFunding(options: PlanFilecoinPayFundingOpti
     throw new Error('A funding target is required')
   }
 
-  let allowanceStatus: {
-    updated: boolean
-    transactionHash?: string
-    currentAllowances: ServiceApprovalStatus
-  } | null = null
-
-  if (ensureAllowances) {
-    allowanceStatus = await checkAndSetAllowances(synapse)
-  }
-
   const [status, accountSummary] = await Promise.all([getPaymentStatus(synapse), synapse.payments.accountSummary({})])
-
-  const allowances = allowanceStatus ?? {
-    updated: false,
-    currentAllowances: status.currentAllowances,
-  }
-
-  const isCalibnet = status.chainId === calibration.id
-  const validation = validatePaymentRequirements(status.filBalance, status.walletUsdfcBalance, isCalibnet)
-  if (!validation.isValid) {
-    const help = validation.helpMessage ? ` ${validation.helpMessage}` : ''
-    throw new Error(`${validation.errorMessage}${help}`)
-  }
 
   let priceList = priceListOpt
   if (pieceSizeBytes != null && priceList == null) {
@@ -448,6 +426,24 @@ export async function planFilecoinPayFunding(options: PlanFilecoinPayFundingOpti
     mode,
     allowWithdraw,
   })
+
+  // Planning, no-op, and withdrawal paths do not spend wallet USDFC. Only
+  // validate wallet funding when this plan will actually make a deposit.
+  if (plan.delta > 0n) {
+    const isCalibnet = status.chainId === calibration.id
+    const validation = validatePaymentRequirements(status.filBalance, status.walletUsdfcBalance, isCalibnet)
+    if (!validation.isValid) {
+      const help = validation.helpMessage ? ` ${validation.helpMessage}` : ''
+      throw new Error(`${validation.errorMessage}${help}`)
+    }
+  }
+
+  const allowances = ensureAllowances
+    ? await checkAndSetAllowances(synapse)
+    : {
+        updated: false,
+        currentAllowances: status.currentAllowances,
+      }
 
   return {
     plan,

--- a/src/core/upload/index.ts
+++ b/src/core/upload/index.ts
@@ -10,8 +10,8 @@ import {
   checkUSDFCBalance,
   type PaymentCapacityCheck,
   setMaxAllowances,
+  validateGasRequirement,
   validatePaymentCapacity,
-  validatePaymentRequirements,
 } from '../payments/index.js'
 import { isSessionKeyMode } from '../synapse/index.js'
 import { recordUploadResult } from '../telemetry/index.js'
@@ -78,7 +78,7 @@ export interface UploadReadinessOptions {
 export interface UploadReadinessResult {
   /** Overall status of the readiness check. */
   status: 'ready' | 'blocked'
-  /** Gas + USDFC validation outcome. */
+  /** Gas validation outcome. */
   validation: {
     isValid: boolean
     errorMessage?: string
@@ -106,7 +106,7 @@ type CapacityStatus = 'sufficient' | 'warning' | 'insufficient'
  * Check readiness for uploading a CAR file.
  *
  * This performs the same validation chain previously used by the CLI/action:
- * 1. Ensure basic wallet requirements (FIL for gas, USDFC balance)
+ * 1. Ensure the wallet has enough FIL for gas
  * 2. Confirm or configure WarmStorage allowances
  * 3. Validate that the current deposit can cover the upload
  *
@@ -130,7 +130,9 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
   const filStatus = await checkFILBalance(synapse)
   const walletUsdfcBalance = await checkUSDFCBalance(synapse)
 
-  const validation = validatePaymentRequirements(filStatus.balance, walletUsdfcBalance, filStatus.isCalibnet)
+  // Upload readiness never deposits wallet USDFC. Deposited funds are checked
+  // below by validatePaymentCapacity, so only gas belongs in this wallet gate.
+  const validation = validateGasRequirement(filStatus.balance, filStatus.isCalibnet)
   if (!validation.isValid) {
     return {
       status: 'blocked',

--- a/src/core/upload/index.ts
+++ b/src/core/upload/index.ts
@@ -8,6 +8,8 @@ import {
   checkAllowances,
   checkFILBalance,
   checkUSDFCBalance,
+  getDepositedBalance,
+  getUsdfcAcquisitionHelpMessage,
   type PaymentCapacityCheck,
   setMaxAllowances,
   validateGasRequirement,
@@ -78,7 +80,7 @@ export interface UploadReadinessOptions {
 export interface UploadReadinessResult {
   /** Overall status of the readiness check. */
   status: 'ready' | 'blocked'
-  /** Gas validation outcome. */
+  /** Wallet validation outcome (gas, or no USDFC anywhere). */
   validation: {
     isValid: boolean
     errorMessage?: string
@@ -107,8 +109,9 @@ type CapacityStatus = 'sufficient' | 'warning' | 'insufficient'
  *
  * This performs the same validation chain previously used by the CLI/action:
  * 1. Ensure the wallet has enough FIL for gas
- * 2. Confirm or configure WarmStorage allowances
- * 3. Validate that the current deposit can cover the upload
+ * 2. Ensure the account holds USDFC somewhere (wallet or deposit)
+ * 3. Confirm or configure WarmStorage allowances
+ * 4. Validate that the current deposit can cover the upload
  *
  * The function only mutates state when `autoConfigureAllowances` is enabled
  * (default), in which case it will call {@link setMaxAllowances} as needed.
@@ -127,8 +130,11 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
 
   onProgress?.({ type: 'checkingBalances' })
 
-  const filStatus = await checkFILBalance(synapse)
-  const walletUsdfcBalance = await checkUSDFCBalance(synapse)
+  const [filStatus, walletUsdfcBalance, depositedBalance] = await Promise.all([
+    checkFILBalance(synapse),
+    checkUSDFCBalance(synapse),
+    getDepositedBalance(synapse),
+  ])
 
   // Upload readiness never deposits wallet USDFC. Deposited funds are checked
   // below by validatePaymentCapacity, so only gas belongs in this wallet gate.
@@ -137,6 +143,28 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
     return {
       status: 'blocked',
       validation,
+      filStatus,
+      walletUsdfcBalance,
+      allowances: {
+        needsUpdate: false,
+        updated: false,
+      },
+      suggestions: [],
+    }
+  }
+
+  // A wallet with no USDFC anywhere (wallet or deposit) can never upload, no
+  // matter the file size. Block here, before any allowance transaction spends
+  // gas, and point the user at how to acquire USDFC. Accounts holding all
+  // their USDFC as deposits pass this gate and are checked on capacity below.
+  if (walletUsdfcBalance === 0n && depositedBalance === 0n) {
+    return {
+      status: 'blocked',
+      validation: {
+        isValid: false,
+        errorMessage: 'No USDFC tokens found',
+        helpMessage: getUsdfcAcquisitionHelpMessage(filStatus.isCalibnet),
+      },
       filStatus,
       walletUsdfcBalance,
       allowances: {
@@ -168,6 +196,11 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
   const capacityStatus = determineCapacityStatus(capacityCheck)
 
   if (capacityStatus === 'insufficient') {
+    // Suggesting a deposit is useless when the wallet holds no USDFC to
+    // deposit, so include how to acquire it alongside the deposit suggestion.
+    if (walletUsdfcBalance === 0n) {
+      capacityCheck.suggestions.push(getUsdfcAcquisitionHelpMessage(filStatus.isCalibnet))
+    }
     return {
       status: 'blocked',
       validation,

--- a/src/core/upload/index.ts
+++ b/src/core/upload/index.ts
@@ -12,8 +12,8 @@ import {
   getUsdfcAcquisitionHelpMessage,
   type PaymentCapacityCheck,
   setMaxAllowances,
-  validateGasRequirement,
   validatePaymentCapacity,
+  validatePaymentRequirements,
 } from '../payments/index.js'
 import { isSessionKeyMode } from '../synapse/index.js'
 import { recordUploadResult } from '../telemetry/index.js'
@@ -136,35 +136,20 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
     getDepositedBalance(synapse),
   ])
 
-  // Upload readiness never deposits wallet USDFC. Deposited funds are checked
-  // below by validatePaymentCapacity, so only gas belongs in this wallet gate.
-  const validation = validateGasRequirement(filStatus.balance, filStatus.isCalibnet)
+  // Validate against total USDFC (wallet + deposited): uploads pay from the
+  // deposit, so an account holding all its USDFC as deposits is funded, while
+  // an account with no USDFC anywhere can never upload and must be blocked
+  // here, before any allowance transaction spends gas. Whether the deposit
+  // covers this file is checked below by validatePaymentCapacity.
+  const validation = validatePaymentRequirements(
+    filStatus.balance,
+    walletUsdfcBalance + depositedBalance,
+    filStatus.isCalibnet
+  )
   if (!validation.isValid) {
     return {
       status: 'blocked',
       validation,
-      filStatus,
-      walletUsdfcBalance,
-      allowances: {
-        needsUpdate: false,
-        updated: false,
-      },
-      suggestions: [],
-    }
-  }
-
-  // A wallet with no USDFC anywhere (wallet or deposit) can never upload, no
-  // matter the file size. Block here, before any allowance transaction spends
-  // gas, and point the user at how to acquire USDFC. Accounts holding all
-  // their USDFC as deposits pass this gate and are checked on capacity below.
-  if (walletUsdfcBalance === 0n && depositedBalance === 0n) {
-    return {
-      status: 'blocked',
-      validation: {
-        isValid: false,
-        errorMessage: 'No USDFC tokens found',
-        helpMessage: getUsdfcAcquisitionHelpMessage(filStatus.isCalibnet),
-      },
       filStatus,
       walletUsdfcBalance,
       allowances: {
@@ -196,10 +181,14 @@ export async function checkUploadReadiness(options: UploadReadinessOptions): Pro
   const capacityStatus = determineCapacityStatus(capacityCheck)
 
   if (capacityStatus === 'insufficient') {
-    // Suggesting a deposit is useless when the wallet holds no USDFC to
-    // deposit, so include how to acquire it alongside the deposit suggestion.
-    if (walletUsdfcBalance === 0n) {
-      capacityCheck.suggestions.push(getUsdfcAcquisitionHelpMessage(filStatus.isCalibnet))
+    // Suggesting a deposit is useless when the wallet cannot cover the
+    // shortfall, so include how to acquire USDFC alongside the suggestion.
+    // Suggestions render one bullet per entry, so split multi-line help.
+    if (walletUsdfcBalance < (capacityCheck.issues.insufficientDeposit ?? 0n)) {
+      const helpLines = getUsdfcAcquisitionHelpMessage(filStatus.isCalibnet)
+        .split('\n')
+        .map((line) => line.trim())
+      capacityCheck.suggestions.push(...helpLines)
     }
     return {
       status: 'blocked',

--- a/src/payments/status.ts
+++ b/src/payments/status.ts
@@ -103,7 +103,9 @@ export async function showPaymentStatus(options: StatusOptions): Promise<void> {
       log.indent(pc.yellow(`⚠ ${gasCheck.errorMessage}`))
       log.indent(pc.yellow(`  ${gasCheck.helpMessage}`))
     }
-    if (walletUsdfcBalance === 0n) {
+    // Acquisition links only help when there is no USDFC anywhere; a wallet
+    // holding its USDFC as deposits is the expected healthy state.
+    if (walletUsdfcBalance === 0n && funds === 0n) {
       const helpLines = `⚠ No USDFC in wallet — ${getUsdfcAcquisitionHelpMessage(filStatus.isCalibnet)}`.split('\n')
       for (const line of helpLines) {
         log.indent(pc.yellow(line))

--- a/src/test/unit/payments-funding.test.ts
+++ b/src/test/unit/payments-funding.test.ts
@@ -284,13 +284,31 @@ describe('planFilecoinPayFunding', () => {
   it('rejects a deposit plan when wallet USDFC is zero', async () => {
     const status = makeStatus({ filecoinPayBalance: 0n, wallet: 0n })
     vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+    const allowanceSpy = vi.spyOn(paymentsIndex, 'checkAndSetAllowances')
 
     await expect(
       planFilecoinPayFunding({
         synapse: makeSynapseStub() as any,
         targetDeposit: ONE_USDFC,
+        ensureAllowances: true,
       })
     ).rejects.toThrow('No USDFC tokens found')
+
+    expect(allowanceSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a withdrawal plan when FIL balance is zero', async () => {
+    const deposited = 10n * ONE_USDFC
+    const status = makeStatus({ filecoinPayBalance: deposited, wallet: 0n, filBalance: 0n })
+    const summary = makeSummary({ filecoinPayBalance: deposited })
+    vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+
+    await expect(
+      planFilecoinPayFunding({
+        synapse: makeSynapseStub(summary) as any,
+        targetDeposit: 5n * ONE_USDFC,
+      })
+    ).rejects.toThrow('Insufficient FIL for gas fees')
   })
 
   it('allows an allowance-only update when wallet USDFC is zero', async () => {
@@ -334,6 +352,23 @@ describe('planFilecoinPayFunding', () => {
     ).rejects.toThrow('Insufficient FIL for gas fees (balance: 0.0000 tFIL')
 
     expect(allowanceSpy).not.toHaveBeenCalled()
+  })
+
+  it('allows a read-only no-op plan when FIL balance is zero', async () => {
+    // `payments fund --amount X` at the current deposit computes a plan and
+    // sends nothing, so insufficient FIL for gas must not block the report.
+    const deposited = 10n * ONE_USDFC
+    const status = makeStatus({ filecoinPayBalance: deposited, wallet: 0n, filBalance: 0n })
+    const summary = makeSummary({ filecoinPayBalance: deposited })
+    vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+
+    const { plan } = await planFilecoinPayFunding({
+      synapse: makeSynapseStub(summary) as any,
+      targetDeposit: deposited,
+    })
+
+    expect(plan.action).toBe('none')
+    expect(plan.delta).toBe(0n)
   })
 
   it('throws when both runway and deposit targets are provided', async () => {

--- a/src/test/unit/payments-funding.test.ts
+++ b/src/test/unit/payments-funding.test.ts
@@ -248,6 +248,75 @@ describe('planFilecoinPayFunding', () => {
     expect(plan.projected.runway.state).toBe('no-spend')
   })
 
+  it('allows a no-op plan when all USDFC is already deposited', async () => {
+    const deposited = 10n * ONE_USDFC
+    const status = makeStatus({ filecoinPayBalance: deposited, wallet: 0n })
+    const summary = makeSummary({ filecoinPayBalance: deposited })
+    const validationSpy = vi.spyOn(paymentsIndex, 'validatePaymentRequirements')
+    vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+
+    const { plan } = await planFilecoinPayFunding({
+      synapse: makeSynapseStub(summary) as any,
+      targetDeposit: deposited,
+    })
+
+    expect(plan.action).toBe('none')
+    expect(validationSpy).not.toHaveBeenCalled()
+  })
+
+  it('allows a withdrawal plan when wallet USDFC is zero', async () => {
+    const deposited = 10n * ONE_USDFC
+    const status = makeStatus({ filecoinPayBalance: deposited, wallet: 0n })
+    const summary = makeSummary({ filecoinPayBalance: deposited })
+    const validationSpy = vi.spyOn(paymentsIndex, 'validatePaymentRequirements')
+    vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+
+    const { plan } = await planFilecoinPayFunding({
+      synapse: makeSynapseStub(summary) as any,
+      targetDeposit: 5n * ONE_USDFC,
+    })
+
+    expect(plan.action).toBe('withdraw')
+    expect(plan.delta).toBe(-5n * ONE_USDFC)
+    expect(validationSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a deposit plan when wallet USDFC is zero', async () => {
+    const status = makeStatus({ filecoinPayBalance: 0n, wallet: 0n })
+    vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+
+    await expect(
+      planFilecoinPayFunding({
+        synapse: makeSynapseStub() as any,
+        targetDeposit: ONE_USDFC,
+      })
+    ).rejects.toThrow('No USDFC tokens found')
+  })
+
+  it('allows an allowance-only update when wallet USDFC is zero', async () => {
+    const deposited = 10n * ONE_USDFC
+    const status = makeStatus({ filecoinPayBalance: deposited, wallet: 0n })
+    const summary = makeSummary({ filecoinPayBalance: deposited })
+    const validationSpy = vi.spyOn(paymentsIndex, 'validatePaymentRequirements')
+    vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+    const allowanceSpy = vi.spyOn(paymentsIndex, 'checkAndSetAllowances').mockResolvedValue({
+      updated: true,
+      transactionHash: '0xallowance',
+      currentAllowances: status.currentAllowances,
+    })
+
+    const { plan, allowances } = await planFilecoinPayFunding({
+      synapse: makeSynapseStub(summary) as any,
+      targetDeposit: deposited,
+      ensureAllowances: true,
+    })
+
+    expect(plan.action).toBe('none')
+    expect(allowances.updated).toBe(true)
+    expect(allowanceSpy).toHaveBeenCalledOnce()
+    expect(validationSpy).not.toHaveBeenCalled()
+  })
+
   it('throws when both runway and deposit targets are provided', async () => {
     const status = makeStatus({ filecoinPayBalance: 0n, wallet: 1_000n })
     vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)

--- a/src/test/unit/payments-funding.test.ts
+++ b/src/test/unit/payments-funding.test.ts
@@ -317,6 +317,25 @@ describe('planFilecoinPayFunding', () => {
     expect(validationSpy).not.toHaveBeenCalled()
   })
 
+  it('checks FIL gas before an allowance-only no-op plan', async () => {
+    const deposited = 10n * ONE_USDFC
+    const status = makeStatus({ filecoinPayBalance: deposited, wallet: 0n, filBalance: 0n })
+    const summary = makeSummary({ filecoinPayBalance: deposited })
+    const allowanceSpy = vi.spyOn(paymentsIndex, 'checkAndSetAllowances')
+
+    vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)
+
+    await expect(
+      planFilecoinPayFunding({
+        synapse: makeSynapseStub(summary) as any,
+        targetDeposit: deposited,
+        ensureAllowances: true,
+      })
+    ).rejects.toThrow('Insufficient FIL for gas fees (balance: 0.0000 tFIL')
+
+    expect(allowanceSpy).not.toHaveBeenCalled()
+  })
+
   it('throws when both runway and deposit targets are provided', async () => {
     const status = makeStatus({ filecoinPayBalance: 0n, wallet: 1_000n })
     vi.spyOn(paymentsIndex, 'getPaymentStatus').mockResolvedValue(status)

--- a/src/test/unit/payments-status.test.ts
+++ b/src/test/unit/payments-status.test.ts
@@ -1,6 +1,47 @@
 import { TIME_CONSTANTS } from '@filoz/synapse-sdk'
+import { parseEther } from 'viem'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { deriveAccountStatus, formatFundedUntil } from '../../payments/status.js'
+
+const mocks = vi.hoisted(() => ({
+  accountSummary: vi.fn(),
+  cancel: vi.fn(),
+  checkFILBalance: vi.fn(),
+  checkUSDFCBalance: vi.fn(),
+  log: { line: vi.fn(), indent: vi.fn(), flush: vi.fn() },
+}))
+
+vi.mock('../../core/synapse/index.js', () => ({
+  initializeSynapse: vi.fn(async () => ({
+    chain: { name: 'mainnet' },
+    payments: { accountSummary: mocks.accountSummary },
+  })),
+  getClientAddress: vi.fn(() => '0x1234'),
+}))
+vi.mock('../../utils/cli-auth.js', () => ({
+  parseCLIAuth: vi.fn(() => ({})),
+  getCLILogger: vi.fn(() => ({})),
+}))
+vi.mock('../../utils/cli-helpers.js', () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  cancel: mocks.cancel,
+  createSpinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() })),
+  formatFileSize: vi.fn(() => '0 B'),
+}))
+vi.mock('../../utils/cli-logger.js', () => ({
+  log: mocks.log,
+}))
+vi.mock('../../core/payments/index.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../core/payments/index.js')>()),
+  checkFILBalance: mocks.checkFILBalance,
+  checkUSDFCBalance: mocks.checkUSDFCBalance,
+}))
+vi.mock('../../core/data-set/index.js', () => ({
+  listDataSets: vi.fn(async () => []),
+  calculateActualStorage: vi.fn(async () => ({ totalBytes: 0n, timedOut: false, warnings: [] })),
+}))
+
+import { deriveAccountStatus, formatFundedUntil, showPaymentStatus } from '../../payments/status.js'
 
 const EPOCHS_14_DAYS = TIME_CONSTANTS.EPOCHS_PER_DAY * 14n
 
@@ -73,5 +114,55 @@ describe('formatFundedUntil', () => {
       const result = formatFundedUntil(runway, 1n)
       expect(result).toContain('(1 days)')
     })
+  })
+})
+
+describe('showPaymentStatus with zero wallet USDFC', () => {
+  function summary(funds: bigint) {
+    return {
+      runwayInEpochs: TIME_CONSTANTS.EPOCHS_PER_DAY * 365n,
+      debt: 0n,
+      lockupRatePerEpoch: 1n,
+      funds,
+      availableFunds: funds,
+      totalLockup: 0n,
+      totalRateBasedLockup: 0n,
+      totalFixedLockup: 0n,
+    }
+  }
+
+  function loggedLines(): string[] {
+    return [...mocks.log.line.mock.calls, ...mocks.log.indent.mock.calls].map((call) => String(call[0]))
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.checkFILBalance.mockResolvedValue({
+      balance: parseEther('1'),
+      isCalibnet: false,
+      hasSufficientGas: true,
+    })
+    mocks.checkUSDFCBalance.mockResolvedValue(0n)
+  })
+
+  it('completes without cancelling when all USDFC is held as deposits', async () => {
+    // The #616 account shape: wallet USDFC 0, everything deposited.
+    mocks.accountSummary.mockResolvedValue(summary(parseEther('36.7')))
+
+    await showPaymentStatus({})
+
+    expect(mocks.cancel).not.toHaveBeenCalled()
+    expect(loggedLines().some((line) => line.includes('No USDFC in wallet'))).toBe(false)
+  })
+
+  it('shows acquisition links only when there is no USDFC anywhere', async () => {
+    mocks.accountSummary.mockResolvedValue(summary(0n))
+
+    await showPaymentStatus({})
+
+    expect(mocks.cancel).not.toHaveBeenCalled()
+    const lines = loggedLines()
+    expect(lines.some((line) => line.includes('No USDFC in wallet'))).toBe(true)
+    expect(lines.some((line) => line.includes('Bridge USDFC to Filecoin mainnet'))).toBe(true)
   })
 })

--- a/src/test/unit/upload-readiness.test.ts
+++ b/src/test/unit/upload-readiness.test.ts
@@ -1,0 +1,74 @@
+import { parseEther } from 'viem'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  checkAllowances: vi.fn(),
+  checkFILBalance: vi.fn(),
+  checkUSDFCBalance: vi.fn(),
+  setMaxAllowances: vi.fn(),
+  validatePaymentCapacity: vi.fn(),
+}))
+
+vi.mock('../../core/payments/index.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../core/payments/index.js')>()),
+  checkAllowances: mocks.checkAllowances,
+  checkFILBalance: mocks.checkFILBalance,
+  checkUSDFCBalance: mocks.checkUSDFCBalance,
+  setMaxAllowances: mocks.setMaxAllowances,
+  validatePaymentCapacity: mocks.validatePaymentCapacity,
+}))
+
+vi.mock('../../core/synapse/index.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../core/synapse/index.js')>()),
+  isSessionKeyMode: vi.fn(() => false),
+}))
+
+import { checkUploadReadiness } from '../../core/upload/index.js'
+
+describe('checkUploadReadiness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.checkFILBalance.mockResolvedValue({
+      balance: parseEther('1'),
+      isCalibnet: false,
+      hasSufficientGas: true,
+    })
+    mocks.checkUSDFCBalance.mockResolvedValue(0n)
+    mocks.checkAllowances.mockResolvedValue({ needsUpdate: false, currentAllowances: {} })
+    mocks.validatePaymentCapacity.mockResolvedValue({
+      canUpload: true,
+      storageTiB: 0.001,
+      required: {
+        rateAllowance: 1n,
+        lockupAllowance: 1n,
+        storageCapacityTiB: 0.001,
+      },
+      issues: {},
+      suggestions: [],
+    })
+  })
+
+  it('allows uploads when wallet USDFC is zero but deposited capacity is sufficient', async () => {
+    const result = await checkUploadReadiness({ synapse: {} as any, fileSize: 1024 })
+
+    expect(result.status).toBe('ready')
+    expect(result.validation).toEqual({ isValid: true })
+    expect(result.walletUsdfcBalance).toBe(0n)
+    expect(mocks.validatePaymentCapacity).toHaveBeenCalledWith({}, 1024)
+  })
+
+  it('still blocks before capacity checks when wallet FIL is insufficient for gas', async () => {
+    mocks.checkFILBalance.mockResolvedValue({
+      balance: 0n,
+      isCalibnet: false,
+      hasSufficientGas: false,
+    })
+
+    const result = await checkUploadReadiness({ synapse: {} as any, fileSize: 1024 })
+
+    expect(result.status).toBe('blocked')
+    expect(result.validation.errorMessage).toContain('Insufficient FIL for gas fees')
+    expect(mocks.checkAllowances).not.toHaveBeenCalled()
+    expect(mocks.validatePaymentCapacity).not.toHaveBeenCalled()
+  })
+})

--- a/src/test/unit/upload-readiness.test.ts
+++ b/src/test/unit/upload-readiness.test.ts
@@ -119,8 +119,9 @@ describe('checkUploadReadiness', () => {
     expect(result.validation.helpMessage).toContain('Get test USDFC')
   })
 
-  it('appends USDFC acquisition help when the deposit is insufficient and the wallet holds no USDFC', async () => {
-    mocks.checkUSDFCBalance.mockResolvedValue(0n)
+  it('appends USDFC acquisition help when the wallet cannot cover the deposit shortfall', async () => {
+    // Wallet holds some USDFC, but less than the 0.04 shortfall below.
+    mocks.checkUSDFCBalance.mockResolvedValue(parseEther('0.001'))
     mocks.getDepositedBalance.mockResolvedValue(parseEther('0.01'))
     mocks.validatePaymentCapacity.mockResolvedValue({
       canUpload: false,
@@ -137,13 +138,18 @@ describe('checkUploadReadiness', () => {
     const result = await checkUploadReadiness({ synapse: {} as any, fileSize: 1024 })
 
     expect(result.status).toBe('blocked')
-    expect(result.suggestions[0]).toBe('Deposit at least 0.04 USDFC')
-    expect(result.suggestions[1]).toContain('Bridge USDFC to Filecoin mainnet')
+    const allSuggestions = result.suggestions.join('\n')
+    expect(allSuggestions).toContain('Deposit at least 0.04 USDFC')
+    expect(allSuggestions).toContain('Bridge USDFC to Filecoin mainnet')
+    // Each suggestion renders as one bullet, so entries must be single-line
+    for (const suggestion of result.suggestions) {
+      expect(suggestion).not.toContain('\n')
+    }
     // displayPaymentIssues prints capacity.suggestions, so the help must land there too
     expect(result.capacity?.suggestions).toEqual(result.suggestions)
   })
 
-  it('does not append acquisition help when the wallet holds USDFC to deposit', async () => {
+  it('does not append acquisition help when the wallet can cover the shortfall', async () => {
     mocks.checkUSDFCBalance.mockResolvedValue(parseEther('5'))
     mocks.getDepositedBalance.mockResolvedValue(parseEther('0.01'))
     mocks.validatePaymentCapacity.mockResolvedValue({

--- a/src/test/unit/upload-readiness.test.ts
+++ b/src/test/unit/upload-readiness.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   checkAllowances: vi.fn(),
   checkFILBalance: vi.fn(),
   checkUSDFCBalance: vi.fn(),
+  getDepositedBalance: vi.fn(),
   setMaxAllowances: vi.fn(),
   validatePaymentCapacity: vi.fn(),
 }))
@@ -14,6 +15,7 @@ vi.mock('../../core/payments/index.js', async (importOriginal) => ({
   checkAllowances: mocks.checkAllowances,
   checkFILBalance: mocks.checkFILBalance,
   checkUSDFCBalance: mocks.checkUSDFCBalance,
+  getDepositedBalance: mocks.getDepositedBalance,
   setMaxAllowances: mocks.setMaxAllowances,
   validatePaymentCapacity: mocks.validatePaymentCapacity,
 }))
@@ -34,6 +36,7 @@ describe('checkUploadReadiness', () => {
       hasSufficientGas: true,
     })
     mocks.checkUSDFCBalance.mockResolvedValue(0n)
+    mocks.getDepositedBalance.mockResolvedValue(parseEther('10'))
     mocks.checkAllowances.mockResolvedValue({ needsUpdate: false, currentAllowances: {} })
     mocks.validatePaymentCapacity.mockResolvedValue({
       canUpload: true,
@@ -70,5 +73,94 @@ describe('checkUploadReadiness', () => {
     expect(result.validation.errorMessage).toContain('Insufficient FIL for gas fees')
     expect(mocks.checkAllowances).not.toHaveBeenCalled()
     expect(mocks.validatePaymentCapacity).not.toHaveBeenCalled()
+  })
+
+  it('blocks a completely unfunded account before any allowance transaction', async () => {
+    mocks.checkUSDFCBalance.mockResolvedValue(0n)
+    mocks.getDepositedBalance.mockResolvedValue(0n)
+
+    const result = await checkUploadReadiness({ synapse: {} as any, fileSize: 1024 })
+
+    expect(result.status).toBe('blocked')
+    expect(result.validation.errorMessage).toBe('No USDFC tokens found')
+    expect(result.validation.helpMessage).toContain('Bridge USDFC to Filecoin mainnet')
+    expect(mocks.checkAllowances).not.toHaveBeenCalled()
+    expect(mocks.setMaxAllowances).not.toHaveBeenCalled()
+    expect(mocks.validatePaymentCapacity).not.toHaveBeenCalled()
+  })
+
+  it('detects a completely unfunded account during the zero-size pre-flight check', async () => {
+    // The `add` command runs a fileSize: 0 pre-flight to fail fast before
+    // packing the CAR. A zero-size capacity check passes vacuously (nothing
+    // to pay for), so the unfunded-account gate must catch this case.
+    mocks.checkUSDFCBalance.mockResolvedValue(0n)
+    mocks.getDepositedBalance.mockResolvedValue(0n)
+
+    const result = await checkUploadReadiness({ synapse: {} as any, fileSize: 0 })
+
+    expect(result.status).toBe('blocked')
+    expect(result.validation.errorMessage).toBe('No USDFC tokens found')
+    expect(mocks.setMaxAllowances).not.toHaveBeenCalled()
+    expect(mocks.validatePaymentCapacity).not.toHaveBeenCalled()
+  })
+
+  it('uses the calibnet acquisition help for unfunded accounts on calibnet', async () => {
+    mocks.checkFILBalance.mockResolvedValue({
+      balance: parseEther('1'),
+      isCalibnet: true,
+      hasSufficientGas: true,
+    })
+    mocks.checkUSDFCBalance.mockResolvedValue(0n)
+    mocks.getDepositedBalance.mockResolvedValue(0n)
+
+    const result = await checkUploadReadiness({ synapse: {} as any, fileSize: 1024 })
+
+    expect(result.status).toBe('blocked')
+    expect(result.validation.helpMessage).toContain('Get test USDFC')
+  })
+
+  it('appends USDFC acquisition help when the deposit is insufficient and the wallet holds no USDFC', async () => {
+    mocks.checkUSDFCBalance.mockResolvedValue(0n)
+    mocks.getDepositedBalance.mockResolvedValue(parseEther('0.01'))
+    mocks.validatePaymentCapacity.mockResolvedValue({
+      canUpload: false,
+      storageTiB: 0.1,
+      required: {
+        rateAllowance: 1n,
+        lockupAllowance: parseEther('0.05'),
+        storageCapacityTiB: 0.1,
+      },
+      issues: { insufficientDeposit: parseEther('0.04') },
+      suggestions: ['Deposit at least 0.04 USDFC'],
+    })
+
+    const result = await checkUploadReadiness({ synapse: {} as any, fileSize: 1024 })
+
+    expect(result.status).toBe('blocked')
+    expect(result.suggestions[0]).toBe('Deposit at least 0.04 USDFC')
+    expect(result.suggestions[1]).toContain('Bridge USDFC to Filecoin mainnet')
+    // displayPaymentIssues prints capacity.suggestions, so the help must land there too
+    expect(result.capacity?.suggestions).toEqual(result.suggestions)
+  })
+
+  it('does not append acquisition help when the wallet holds USDFC to deposit', async () => {
+    mocks.checkUSDFCBalance.mockResolvedValue(parseEther('5'))
+    mocks.getDepositedBalance.mockResolvedValue(parseEther('0.01'))
+    mocks.validatePaymentCapacity.mockResolvedValue({
+      canUpload: false,
+      storageTiB: 0.1,
+      required: {
+        rateAllowance: 1n,
+        lockupAllowance: parseEther('0.05'),
+        storageCapacityTiB: 0.1,
+      },
+      issues: { insufficientDeposit: parseEther('0.04') },
+      suggestions: ['Deposit at least 0.04 USDFC'],
+    })
+
+    const result = await checkUploadReadiness({ synapse: {} as any, fileSize: 1024 })
+
+    expect(result.status).toBe('blocked')
+    expect(result.suggestions).toEqual(['Deposit at least 0.04 USDFC'])
   })
 })


### PR DESCRIPTION
Builds on #628 by @beck-8, whose commits are included here with authorship preserved, and adds the fixes that came out of its review.

## From #628

Upload preflight rejected wallets holding all their USDFC as deposits (#616). The preflight now validates gas only up front and lets the deposit-aware capacity check answer whether the account can pay for the upload. Funding plans keep gas validation before any transaction.

## Added in this PR

- **Fail fast for fully unfunded accounts.** A wallet with no USDFC anywhere (wallet or deposit) can never upload, so `checkUploadReadiness` blocks it with acquisition help before any allowance transaction spends gas. This also restores the `add` zero-size pre-flight, which otherwise passes vacuously and packs the whole CAR before failing.
- **Acquisition help when there is nothing to deposit.** When capacity is insufficient and the wallet holds no USDFC, the "Deposit at least X USDFC" suggestion now comes with links for acquiring USDFC.
- **`payments status` links gated on deposits.** Acquisition links only print when there is no USDFC anywhere. An account holding all its USDFC as deposits, the healthy state the tooling encourages, gets a clean status.
- **Regression tests** for each case above, including the first tests covering `showPaymentStatus`. All were verified to fail against the pre-fix code.

Closes #616
Supersedes #628
