### PR TITLE
feat: add migrate state store and CLI parsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ test-car-output/
 test-e2e-cars/
 test-simple-car-output/
 coverage
+
+# Local scratch artifacts
+.lavish/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@ test-car-output/
 test-e2e-cars/
 test-simple-car-output/
 coverage
-
-# Local scratch artifacts
-.lavish/

--- a/documentation/glossary.md
+++ b/documentation/glossary.md
@@ -110,6 +110,10 @@ See [Management Console affordance in the README](../README.md#-management-conso
 
 This is the primary smart contract used when interacting with the warm storage functionality offered in [Filecoin Onchain Cloud](#filecoin-onchain-cloud).  It acts as both a "service" contract and a "validator" contract for payment management and settlements, ensuring the warm storage service is actually delivered before payments are released to the [Service Provider](#service-provider).
 
+## GC Window
+
+The time a [Service Provider](#service-provider)'s [Curio](#curio) instance keeps a [Parked Piece](#parked-piece) before garbage-collecting it (roughly 2 hours by default, provider-configurable, not discoverable on chain). The `migrate` command schedules its batched `addPieces` commits to land before its per-provider estimate of this window expires, and lowers the estimate when it observes a GC rejection.
+
 ## IPFS Root CID
 
 The CID for the root of a merkle DAG that is usually encoding a file or directory as UnixFS.  Since each `filecoin-pin add` creates a [CAR](#car), regardless if passed a file or directory, there is a single root corresponding to root of the Merkle DAG made out of encoding the file or directory as UnixFS. Typically this will be presented in base32, beginning with `bafy` and be 59 characters long. See [Relationship between Piece CID and IPFS Root CID](#relationship-between-piece-cid-and-ipfs-root-cid) for how this relates to the [Piece CID](#piece-cid).
@@ -136,6 +140,14 @@ Key | Purpose | Scope
 `withIPFSIndexing` | Set to empty string to signal the [SP](#service-provider) to index and advertise the data to [IPNI](#ipni) | Data Set
 `ipfsRootCid` | Stored on each Piece to link the [Piece CID](#piece-cid) back to the [IPFS Root CID](#ipfs-root-cid).  While this is a convention that Filecoin Pin follows, there is nothing onchain enforcing a correct link between `ipfsRootCid` and `pieceCid`. | Piece
 `name` | Original basename of the source path (file or directory). Auto-derived during `add` so the human-readable label survives even though the [UnixFS profile](#unixfs-v1-2025-profile) does not wrap single files in a parent directory. User-supplied piece metadata wins over the auto-derived value; an explicit empty string is treated as an opt-out. Consumers that need to know whether the source was a file or a directory inspect the [IPFS Root CID](#ipfs-root-cid) (codec + UnixFS `Data.Type`), matching the IPFS Pinning Service `name` convention. | Piece
+
+## Member CAR
+
+A single source [CID](#cid)'s verified [CAR](#car), downloaded from a trustless gateway by the `migrate` command and staged on disk. Members are bin-packed into one multi-root CAR that becomes a [Piece](#piece); the member file is deleted once the packed piece records it. See [How migrate works](migrate.md).
+
+## Parked Piece
+
+A [Piece](#piece) stored on a [Service Provider](#service-provider) but not yet committed on chain via `addPieces`. Parking starts the provider's [GC Window](#gc-window) clock: a piece parked past the window is garbage-collected and must be stored again.
 
 ## unixfs-v1-2025 profile
 
@@ -238,6 +250,10 @@ Session keys require specific permissions (such as CREATE_DATA_SET and ADD_PIECE
 Note that the filecoin-pin CLI's `--session-key` flag (and `SESSION_KEY` environment variable) expect the session key's **private key** — the `SESSION_KEY` value printed by `filecoin-pin session create` or `filecoin-pin session generate` — not the session address. The (public) session address is only used when authorizing or revoking: `filecoin-pin session authorize <session-address>` and `filecoin-pin session revoke <session-address>`.
 
 
+
+## Staging Budget
+
+The byte budget the `migrate` command grants its staging directory (free space at startup, capped by `--max-staged-bytes`). Everything staged counts against it: [Member CARs](#member-car), in-flight downloads, assembling pieces, and packed pieces not yet committed. A full budget blocks downloads until commits evict pieces, so a disk smaller than the migration cycles instead of failing. See [How migrate works](migrate.md).
 
 ## Standard IPFS Tooling
 

--- a/documentation/migrate.md
+++ b/documentation/migrate.md
@@ -52,4 +52,4 @@ Egress defaults to `none` for migrate: bulk archives will not pay [FilBeam](glos
 
 ## What the exit code means
 
-`0` means every CID in the list is committed on chain at the requested number of copies. Anything short of that (failed downloads, over-cap CIDs, unresolved commits, missing copies) exits `1`, and the summary JSON on stdout says exactly which CIDs need attention. Re-running is always safe.
+`0` means every CID in the list is committed on chain at the requested number of copies. Anything short of that (failed downloads, over-cap CIDs, unresolved commits, missing copies) exits `1`, and the summary printed at the end says exactly which CIDs need attention (the full record lives in `migrate.db`). Re-running is always safe.

--- a/documentation/migrate.md
+++ b/documentation/migrate.md
@@ -1,0 +1,55 @@
+# How migrate works
+
+`filecoin-pin migrate <cid-list-file>` moves a list of IPFS CIDs onto [Filecoin Onchain Cloud](glossary.md#filecoin-onchain-cloud). You give it a text file with one [CID](glossary.md#cid) per line; it downloads each one from a trustless gateway, packs them into large [pieces](glossary.md#piece), uploads those pieces to [storage providers](glossary.md#storage-provider), and commits them on chain in batches. Every step is recorded in a local sqlite database, so a killed or crashed run resumes where it left off.
+
+This page explains the pipeline and the guarantees behind it. For flags and defaults, run `filecoin-pin migrate --help`.
+
+## Why not just run `add` in a loop
+
+Two reasons: cost and throughput. Each on-chain `addPieces` transaction can carry up to 40 pieces, and each piece can hold up to 1016 MiB. Uploading a 2 MiB CID as its own piece wastes both dimensions. Migrate packs many source CIDs into one ~1000 MiB multi-root [CAR](glossary.md#car) and commits up to 40 of those pieces per transaction, so a million small files does not mean a million transactions.
+
+## The pipeline
+
+Four stages run concurrently, connected by a disk budget:
+
+```
+download + verify --> pack --> upload --> commit --> evict
+        ^                                              |
+        +-------------- disk budget freed <------------+
+```
+
+1. **Download and verify.** Each CID is fetched from a trustless gateway as a CAR, once. In a single pass the bytes are written to a member file on disk while every block is hash-checked against its CID, the DAG is walked to confirm every reachable link is present, and the [CommP](glossary.md#commp) is computed. A truncated or corrupt gateway response fails that CID loudly instead of migrating incomplete data. The bytes that were verified are the bytes on disk, and later the bytes uploaded. Verification supports sha2-256 and sha2-512 multihashes (plus identity CIDs); a DAG hashed with anything else, such as blake2b, fails that CID with a `no hasher` error.
+2. **Pack.** When enough verified members accumulate to fill a piece (default target 1000 MiB), they are bin-packed and assembled into one multi-root CAR, streamed disk-to-disk. The assembled piece's CommP is computed during assembly. Member files are deleted only after the piece and its member list are recorded atomically. A CID too large to share a piece ships alone; a CID over the 1016 MiB cap cannot migrate on this path and is reported, not dropped silently.
+3. **Upload.** Each packed piece is stored on the primary provider over HTTP. Secondary copies pull provider-to-provider from the primary, so your bandwidth is spent once per piece regardless of `--copies`. A stored-but-uncommitted piece is "parked": [Curio](glossary.md#curio) garbage-collects parked pieces after a window (roughly 2 hours, provider-configurable, not discoverable), which is why commit timing matters.
+4. **Commit and evict.** Parked pieces are flushed through one `addPieces` transaction when the batch reaches 40, when the oldest parked piece nears the assumed GC window (the margin adapts to observed confirmation times), or when the source drains. Once a piece is committed on chain, its staged file is deleted, which frees disk budget and unblocks the download stage.
+
+## The disk budget
+
+At startup, migrate measures free space in its staging directory and takes a budget (capped by `--max-staged-bytes` if you set it). Everything staged counts against it: member files, in-flight downloads, the piece being assembled, and packed pieces not yet committed. When the budget is full, downloads block until eviction frees space.
+
+The budget is the whole flow-control mechanism. There is no rate probing and no schedule: a bounded pipeline runs at the speed of its slowest stage automatically, and it keeps adapting when the gateway throttles or a provider slows down. If your disk is smaller than your migration, the pipeline cycles through it; a full staging directory is the normal steady state, not a failure. A budget too small to assemble even one piece is refused up front with a clear error.
+
+## The GC window
+
+Committing every piece individually would be safe but wasteful; waiting for a full batch of 40 risks the provider garbage-collecting the oldest parked piece first. Migrate starts from a conservative window guess (60 minutes, `--assumed-window-minutes`) and flushes a partial batch whenever the oldest parked piece gets close. The costs are asymmetric (an early flush costs one extra transaction, a collected piece costs a full re-upload), so every tie breaks toward flushing sooner. When a commit is rejected because a piece was already collected, the window estimate is lowered from the evidence and the piece is re-uploaded. The estimate only ever moves down.
+
+## Resume
+
+State lives in `migrate.db` under the filecoin-pin data directory (`--db` overrides it). Kill the process at any point and re-run with the same CID list:
+
+- Downloaded members are verified against their recorded hash and reused; anything missing or corrupt is re-downloaded, and only that CID.
+- Packed pieces on disk are re-verified and re-enter the upload queue.
+- A commit whose outcome is unknown (the process died mid-transaction) is never blindly retried. Resume checks the transaction receipt first: if the `PiecesAdded` event is on chain, the piece is marked committed; if not, it re-queues. A blind retry could add the same piece to your [data set](glossary.md#data-set) twice, so rows that cannot be resolved either way stay flagged and the run exits non-zero.
+- Nothing staged is deleted until the piece it belongs to is committed for every copy that still needs the local bytes.
+
+Two runs against the same `migrate.db` at the same time are not supported.
+
+## Data sets and cost
+
+Migrate writes into its own [data sets](glossary.md#data-set), tagged with `migrate: true` [metadata](glossary.md#metadata), separate from the data sets `add` and `import` use. Pass `--data-set-id` to target an existing one instead.
+
+Egress defaults to `none` for migrate: bulk archives will not pay [FilBeam](glossary.md#filbeam-egress) CDN lockup unless you ask for it with `--egress-provider beam`. Storage costs are the same as any other upload; run `filecoin-pin payments status` before a large migration.
+
+## What the exit code means
+
+`0` means every CID in the list is committed on chain at the requested number of copies. Anything short of that (failed downloads, over-cap CIDs, unresolved commits, missing copies) exits `1`, and the summary JSON on stdout says exactly which CIDs need attention. Re-running is always safe.

--- a/src/migrate/car-url.ts
+++ b/src/migrate/car-url.ts
@@ -1,0 +1,21 @@
+/**
+ * Trustless-gateway CAR URL construction and the default gateway list. One
+ * definition, so every fetch in the pipeline requests the same shape.
+ */
+
+/** Gateways used when no `--gateway` is given. */
+export const DEFAULT_GATEWAYS = ['https://trustless-gateway.link']
+
+export const CAR_ACCEPT = 'application/vnd.ipld.car'
+
+/**
+ * Build the trustless-gateway CAR URL for a CID. The query string pins the
+ * variables the trustless-gateway spec exposes (full DAG scope, CAR v1
+ * framing, depth-first order, no duplicate blocks) so responses stay
+ * consistent across gateways; every block is still hash-verified and the DAG
+ * completeness-checked before the bytes count as migrated.
+ */
+export function buildCarUrl(gateway: string, cid: string): string {
+  const base = gateway.replace(/\/+$/, '')
+  return `${base}/ipfs/${cid}?format=car&dag-scope=all&car-version=1&car-order=dfs&car-dups=n`
+}

--- a/src/migrate/db.ts
+++ b/src/migrate/db.ts
@@ -1,0 +1,764 @@
+/**
+ * Migrate state store, backed by Node's built-in node:sqlite (no dependency).
+ *
+ * The database is the single source of truth for a migration run: each source
+ * CID's piece commitment and member file, the packed piece it landed in, and
+ * the per-provider upload lifecycle. A run resumes from here after any
+ * interruption. Rows are scoped per network and owner address so one
+ * `migrate.db` serves development runs against different networks and wallets
+ * without cross-talk.
+ *
+ * Concurrent runs against the same file are unsupported: WAL mode plus
+ * `busy_timeout` keep a second process from corrupting state, but two live
+ * runners would race the same work items.
+ */
+
+import { DatabaseSync } from 'node:sqlite'
+
+export type PieceStatus = 'pending' | 'done' | 'failed' | 'oversized'
+
+/**
+ * Failure taxonomy set alongside `pieces.error` so operators can triage by
+ * category rather than parsing free-form error strings.
+ */
+export type FailureCategory =
+  | 'source_gateway_429'
+  | 'source_gateway_5xx'
+  | 'source_gateway_network'
+  | 'source_gateway_timeout'
+  | 'car_incomplete'
+  | 'car_root_mismatch'
+  | 'commp_mismatch'
+  | 'oversized'
+  | 'staging_budget'
+  | 'other'
+
+/**
+ * Packed piece lifecycle. A sub-piece is a synthetic multi-root CAR that
+ * groups M source CIDs into one uploadable piece. `built` means the assembled
+ * CAR is on disk (under the staging directory) and its commitment matched;
+ * `failed` is set if assembly produced a different commitment than planned.
+ */
+export type SubPieceStatus = 'built' | 'failed'
+
+export interface SubPieceRow {
+  subPieceCid: string
+  assembledCarLength: number
+  assembledSha256: string | null
+  targetSizeBytes: number
+  /** Local CAR file for the assembled sub-piece. */
+  carPath: string | null
+  status: SubPieceStatus
+}
+
+export interface PieceRow {
+  cid: string
+  pieceCid: string | null
+  rawSize: number | null
+  gateway: string | null
+  url: string | null
+  /** Verified member CAR file on disk; null until the download completes. */
+  memberCarPath: string | null
+  /** sha256 of the member CAR bytes, for resume re-verification. */
+  memberSha256: string | null
+  status: PieceStatus
+  error: string | null
+}
+
+/**
+ * Direct-upload lifecycle, per (sub-piece, provider) pair: the migrate
+ * command stores the same CAR on every provider copy independently.
+ *
+ *   parked           the provider holds the bytes; nothing on-chain. Curio
+ *                    garbage-collects parked pieces after an undiscoverable
+ *                    window (~2h default), so parked_at drives the flush timer
+ *   add_unconfirmed  an addPieces batch containing this piece was attempted;
+ *                    outcome unknown. Never auto-reset into a blind re-add
+ *   committed        addPieces landed; data_set_id/piece_id/tx_hash are final
+ *   collected        the provider garbage-collected the parked piece before
+ *                    commit; the piece must be stored (or pulled) again
+ *   failed           store, pull, or commit failed for a non-GC reason
+ */
+export type UploadStatus = 'parked' | 'add_unconfirmed' | 'committed' | 'collected' | 'failed'
+
+export type UploadRole = 'primary' | 'secondary'
+
+export interface UploadRow {
+  subPieceCid: string
+  providerId: string
+  role: UploadRole
+  dataSetId: string | null
+  status: UploadStatus
+  /** ISO timestamp of store() completion: the moment the GC clock starts. */
+  parkedAt: string
+  txHash: string | null
+  pieceId: string | null
+  committedAt: string | null
+  /** Timestamp of the row's last state transition. */
+  updatedAt: string
+  error: string | null
+}
+
+export class MigrationDB {
+  #db: DatabaseSync
+  /** The sqlite file path this instance opened, so callers can echo it back. */
+  readonly path: string
+  /** Network + owner-address scope for every row this instance touches. */
+  readonly scope: string
+
+  constructor(path: string, scope: string) {
+    this.path = path
+    this.scope = scope
+    this.#db = new DatabaseSync(path)
+    // busy_timeout must come before any other exec: even setting WAL needs
+    // the write lock, and a sibling process holding it will error out the
+    // very first pragma without this. Without busy_timeout, the sqlite layer
+    // surfaces SQLITE_BUSY as `disk I/O error`.
+    this.#db.exec('PRAGMA busy_timeout = 5000')
+    this.#db.exec('PRAGMA journal_mode = WAL')
+    this.#migrate()
+  }
+
+  #migrate(): void {
+    // No ALTERs: schema is unreleased, so each new column joins the CREATE
+    // statement directly. sub_pieces / sub_piece_members hold the packed
+    // multi-root CAR groups (each one is a single uploadable piece).
+    this.#db.exec(`
+      CREATE TABLE IF NOT EXISTS pieces (
+        scope            TEXT NOT NULL,
+        cid              TEXT NOT NULL,
+        piece_cid        TEXT,
+        raw_size         INTEGER,
+        gateway          TEXT,
+        url              TEXT,
+        member_car_path  TEXT,
+        member_sha256    TEXT,
+        status           TEXT NOT NULL DEFAULT 'pending',
+        error            TEXT,
+        failure_category TEXT,
+        updated_at       TEXT NOT NULL,
+        PRIMARY KEY (scope, cid)
+      );
+      CREATE TABLE IF NOT EXISTS sub_pieces (
+        scope                 TEXT NOT NULL,
+        sub_piece_cid         TEXT NOT NULL,
+        assembled_car_length  INTEGER NOT NULL,
+        assembled_sha256      TEXT,
+        target_size_bytes     INTEGER NOT NULL,
+        car_path              TEXT NOT NULL,
+        status                TEXT NOT NULL DEFAULT 'built',
+        built_at              TEXT,
+        error                 TEXT,
+        created_at            TEXT NOT NULL,
+        PRIMARY KEY (scope, sub_piece_cid)
+      );
+      CREATE TABLE IF NOT EXISTS sub_piece_members (
+        scope             TEXT NOT NULL,
+        sub_piece_cid     TEXT NOT NULL,
+        member_cid        TEXT NOT NULL,
+        member_sort_order INTEGER NOT NULL,
+        member_sha256     TEXT,
+        member_raw_size   INTEGER,
+        PRIMARY KEY (scope, sub_piece_cid, member_cid),
+        FOREIGN KEY (scope, sub_piece_cid) REFERENCES sub_pieces(scope, sub_piece_cid),
+        FOREIGN KEY (scope, member_cid) REFERENCES pieces(scope, cid)
+      );
+      CREATE TABLE IF NOT EXISTS uploads (
+        scope         TEXT NOT NULL,
+        sub_piece_cid TEXT NOT NULL,
+        provider_id   TEXT NOT NULL,
+        role          TEXT NOT NULL,
+        data_set_id   TEXT,
+        status        TEXT NOT NULL DEFAULT 'parked',
+        parked_at     TEXT NOT NULL,
+        tx_hash       TEXT,
+        piece_id      TEXT,
+        committed_at  TEXT,
+        error         TEXT,
+        updated_at    TEXT NOT NULL,
+        PRIMARY KEY (scope, sub_piece_cid, provider_id),
+        FOREIGN KEY (scope, sub_piece_cid) REFERENCES sub_pieces(scope, sub_piece_cid)
+      );
+      CREATE TABLE IF NOT EXISTS provider_windows (
+        scope             TEXT NOT NULL,
+        provider_id       TEXT NOT NULL,
+        assumed_window_ms INTEGER NOT NULL,
+        updated_at        TEXT NOT NULL,
+        PRIMARY KEY (scope, provider_id)
+      );
+    `)
+  }
+
+  /** Register CIDs for processing. Existing rows are left untouched (resumable). */
+  addCids(cids: string[]): void {
+    const stmt = this.#db.prepare(
+      `INSERT INTO pieces (scope, cid, status, updated_at) VALUES (?, ?, 'pending', ?)
+       ON CONFLICT(scope, cid) DO NOTHING`
+    )
+    const now = new Date().toISOString()
+    for (const cid of cids) {
+      stmt.run(this.scope, cid, now)
+    }
+  }
+
+  /** CIDs not yet downloaded and verified. Failed CIDs re-enter the queue. */
+  pendingCids(): string[] {
+    const rows = this.#db
+      .prepare(`SELECT cid FROM pieces WHERE scope = ? AND status IN ('pending', 'failed') ORDER BY cid`)
+      .all(this.scope)
+    return rows.map((r) => (r as { cid: string }).cid)
+  }
+
+  /** Record a verified member download: commP, sizes, and the on-disk CAR file. */
+  recordPieceSuccess(
+    cid: string,
+    info: {
+      pieceCid: string
+      rawSize: number
+      gateway: string
+      url: string
+      memberCarPath: string
+      memberSha256: string
+    }
+  ): void {
+    this.#db
+      .prepare(
+        `UPDATE pieces SET piece_cid=?, raw_size=?, gateway=?, url=?,
+                            member_car_path=?, member_sha256=?,
+                            status='done', error=NULL, failure_category=NULL, updated_at=?
+         WHERE scope=? AND cid=?`
+      )
+      .run(
+        info.pieceCid,
+        info.rawSize,
+        info.gateway,
+        info.url,
+        info.memberCarPath,
+        info.memberSha256,
+        new Date().toISOString(),
+        this.scope,
+        cid
+      )
+  }
+
+  recordPieceFailure(cid: string, error: string, category: FailureCategory = 'other'): void {
+    this.#db
+      .prepare(`UPDATE pieces SET status='failed', error=?, failure_category=?, updated_at=? WHERE scope=? AND cid=?`)
+      .run(error, category, new Date().toISOString(), this.scope, cid)
+  }
+
+  /**
+   * Return a `done` piece to `pending`, clearing its member-file columns. The
+   * startup sweep uses this when the recorded member CAR is missing or does
+   * not match its recorded sha256: only that CID re-downloads.
+   */
+  resetPieceToPending(cid: string): void {
+    this.#db
+      .prepare(
+        `UPDATE pieces SET status='pending', member_car_path=NULL, member_sha256=NULL,
+                            piece_cid=NULL, raw_size=NULL, error=NULL, failure_category=NULL, updated_at=?
+         WHERE scope=? AND cid=?`
+      )
+      .run(new Date().toISOString(), this.scope, cid)
+  }
+
+  counts(): { pending: number; done: number; failed: number; oversized: number; total: number } {
+    const row = this.#db
+      .prepare(
+        `SELECT
+           SUM(status='pending')    AS pending,
+           SUM(status='done')       AS done,
+           SUM(status='failed')     AS failed,
+           SUM(status='oversized')  AS oversized,
+           COUNT(*)                 AS total
+         FROM pieces WHERE scope = ?`
+      )
+      .get(this.scope) as Record<string, number | null>
+    return {
+      pending: Number(row.pending ?? 0),
+      done: Number(row.done ?? 0),
+      failed: Number(row.failed ?? 0),
+      oversized: Number(row.oversized ?? 0),
+      total: Number(row.total ?? 0),
+    }
+  }
+
+  failures(): Array<{ cid: string; error: string; category: FailureCategory }> {
+    const rows = this.#db
+      .prepare(`SELECT cid, error, failure_category FROM pieces WHERE scope = ? AND status='failed' ORDER BY cid`)
+      .all(this.scope)
+    return rows.map((r) => {
+      const row = r as Record<string, unknown>
+      return {
+        cid: String(row.cid),
+        error: String(row.error ?? ''),
+        category: (row.failure_category as FailureCategory | undefined) ?? 'other',
+      }
+    })
+  }
+
+  /**
+   * Insert a sub-piece row in `built` status together with its member rows in
+   * one transaction: a crash between the two writes must never strand a
+   * sub-piece with locked members and no recovery pass.
+   */
+  recordBuiltSubPiece(args: {
+    subPieceCid: string
+    assembledCarLength: number
+    targetSizeBytes: number
+    carPath: string
+    assembledSha256: string
+    members: Array<{ cid: string; rawSize: number | null; sha256: string | null }>
+  }): void {
+    const now = new Date().toISOString()
+    const insertSub = this.#db.prepare(
+      `INSERT INTO sub_pieces (scope, sub_piece_cid, assembled_car_length, target_size_bytes,
+                                status, car_path, assembled_sha256, built_at, created_at)
+       VALUES (?, ?, ?, ?, 'built', ?, ?, ?, ?)`
+    )
+    const insertMember = this.#db.prepare(
+      `INSERT INTO sub_piece_members (scope, sub_piece_cid, member_cid, member_sort_order,
+                                       member_sha256, member_raw_size)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    this.#db.exec('BEGIN')
+    try {
+      insertSub.run(
+        this.scope,
+        args.subPieceCid,
+        args.assembledCarLength,
+        args.targetSizeBytes,
+        args.carPath,
+        args.assembledSha256,
+        now,
+        now
+      )
+      args.members.forEach((m, i) => {
+        insertMember.run(this.scope, args.subPieceCid, m.cid, i, m.sha256, m.rawSize)
+      })
+      // The members' bytes now live in the recorded piece; clearing their
+      // member-file columns in the same transaction keeps the startup sweep
+      // from treating the soon-deleted files as missing and re-queueing
+      // already-packed downloads.
+      const clearMember = this.#db.prepare(
+        `UPDATE pieces SET member_car_path = NULL, member_sha256 = NULL, updated_at = ?
+         WHERE scope = ? AND cid = ?`
+      )
+      for (const m of args.members) {
+        clearMember.run(now, this.scope, m.cid)
+      }
+      this.#db.exec('COMMIT')
+    } catch (err) {
+      this.#db.exec('ROLLBACK')
+      throw err
+    }
+  }
+
+  /**
+   * Remove a staged piece whose CAR file failed re-verification, freeing its
+   * member CIDs to re-download. One transaction deletes the piece, its
+   * member list, and any upload rows, then returns the affected source CIDs
+   * so the caller can reset them to pending. Refuses a piece whose primary
+   * copy is already committed: that piece is on chain and its local file no
+   * longer matters.
+   */
+  deleteSubPieceForRebuild(subPieceCid: string): string[] {
+    // Live provider-side state blocks a rebuild: a committed primary is
+    // final, an add_unconfirmed row is an unresolved breadcrumb whose
+    // deletion could turn into a duplicate on-chain add, and a parked copy
+    // can still commit from the provider's bytes without the local file.
+    // Reconciliation resolves those states first; the rebuild waits for a
+    // run where none remain.
+    const live = this.#db
+      .prepare(
+        `SELECT status FROM uploads
+         WHERE scope = ? AND sub_piece_cid = ?
+           AND (status IN ('parked', 'add_unconfirmed') OR (role = 'primary' AND status = 'committed'))
+         LIMIT 1`
+      )
+      .get(this.scope, subPieceCid) as { status: string } | undefined
+    if (live != null) {
+      throw new Error(`refusing to rebuild ${subPieceCid}: it has a live upload in status '${live.status}'`)
+    }
+    const members = this.subPieceMemberCids(subPieceCid)
+    this.#db.exec('BEGIN')
+    try {
+      this.#db.prepare(`DELETE FROM uploads WHERE scope = ? AND sub_piece_cid = ?`).run(this.scope, subPieceCid)
+      this.#db
+        .prepare(`DELETE FROM sub_piece_members WHERE scope = ? AND sub_piece_cid = ?`)
+        .run(this.scope, subPieceCid)
+      this.#db.prepare(`DELETE FROM sub_pieces WHERE scope = ? AND sub_piece_cid = ?`).run(this.scope, subPieceCid)
+      this.#db.exec('COMMIT')
+    } catch (err) {
+      this.#db.exec('ROLLBACK')
+      throw err
+    }
+    return members
+  }
+
+  /**
+   * Mark CIDs whose CAR exceeds the per-piece upload cap. Terminal: they
+   * leave the free pool and the retry queue, and only appear in reporting.
+   */
+  markOversized(cids: string[]): void {
+    const stmt = this.#db.prepare(
+      `UPDATE pieces SET status='oversized', failure_category='oversized',
+                          member_car_path=NULL, member_sha256=NULL, updated_at=?
+       WHERE scope=? AND cid=?`
+    )
+    const now = new Date().toISOString()
+    for (const cid of cids) stmt.run(now, this.scope, cid)
+  }
+
+  /** Look up a sub-piece by its packed PieceCID v2. Null when no row exists. */
+  subPieceByCid(subPieceCid: string): SubPieceRow | null {
+    const row = this.#db
+      .prepare(
+        `SELECT sub_piece_cid, assembled_car_length, assembled_sha256, target_size_bytes,
+                car_path, status FROM sub_pieces WHERE scope = ? AND sub_piece_cid = ? LIMIT 1`
+      )
+      .get(this.scope, subPieceCid) as Record<string, unknown> | undefined
+    if (row == null) return null
+    return toSubPieceRow(row)
+  }
+
+  /** Sub-pieces in the given status. */
+  subPiecesByStatus(status: SubPieceStatus): SubPieceRow[] {
+    const rows = this.#db
+      .prepare(
+        `SELECT sub_piece_cid, assembled_car_length, assembled_sha256, target_size_bytes,
+                car_path, status FROM sub_pieces WHERE scope = ? AND status = ? ORDER BY sub_piece_cid`
+      )
+      .all(this.scope, status)
+    return rows.map(toSubPieceRow)
+  }
+
+  /**
+   * Ordered member CIDs of a sub-piece (sort order set at pack time): the
+   * order the piece commitment was computed against.
+   */
+  subPieceMemberCids(subPieceCid: string): string[] {
+    const rows = this.#db
+      .prepare(
+        `SELECT member_cid FROM sub_piece_members
+         WHERE scope = ? AND sub_piece_cid = ? ORDER BY member_sort_order`
+      )
+      .all(this.scope, subPieceCid)
+    return rows.map((r) => String((r as { member_cid: string }).member_cid))
+  }
+
+  /**
+   * Verified members not yet packed into a sub-piece. Membership in any
+   * sub-piece excludes a piece; composition is set at INSERT and never
+   * mutates.
+   */
+  donePiecesFreeForPacking(): PieceRow[] {
+    const rows = this.#db
+      .prepare(
+        `SELECT p.cid, p.piece_cid, p.raw_size, p.gateway, p.url,
+                p.member_car_path, p.member_sha256, p.status, p.error
+         FROM pieces p
+         WHERE p.scope = ? AND p.status='done'
+           AND p.cid NOT IN (SELECT member_cid FROM sub_piece_members WHERE scope = ?)
+         ORDER BY p.cid`
+      )
+      .all(this.scope, this.scope)
+    return rows.map(toPieceRow)
+  }
+
+  /** Total bytes of verified members not yet packed (pack trigger + budget resync). */
+  freeMemberBytes(): number {
+    const row = this.#db
+      .prepare(
+        `SELECT COALESCE(SUM(p.raw_size), 0) AS n
+         FROM pieces p
+         WHERE p.scope = ? AND p.status='done'
+           AND p.cid NOT IN (SELECT member_cid FROM sub_piece_members WHERE scope = ?)`
+      )
+      .get(this.scope, this.scope) as { n: number }
+    return Number(row.n)
+  }
+
+  /** Every `done` piece with a recorded member file, for the startup sweep. */
+  donePiecesWithMembers(): Array<{ cid: string; memberCarPath: string; memberSha256: string | null }> {
+    const rows = this.#db
+      .prepare(
+        `SELECT cid, member_car_path, member_sha256
+         FROM pieces
+         WHERE scope = ? AND status='done' AND member_car_path IS NOT NULL
+           AND cid NOT IN (SELECT member_cid FROM sub_piece_members WHERE scope = ?)`
+      )
+      .all(this.scope, this.scope)
+    return rows.map((r) => {
+      const row = r as Record<string, unknown>
+      return {
+        cid: String(row.cid),
+        memberCarPath: String(row.member_car_path),
+        memberSha256: row.member_sha256 == null ? null : String(row.member_sha256),
+      }
+    })
+  }
+
+  // ---- direct-upload state (uploads / provider_windows) ----
+
+  /** Built, file-backed sub-pieces with no live upload row for this provider. */
+  subPiecesNeedingUpload(providerId: string): SubPieceRow[] {
+    const rows = this.#db
+      .prepare(
+        `SELECT sp.sub_piece_cid, sp.assembled_car_length, sp.assembled_sha256,
+                sp.target_size_bytes, sp.car_path, sp.status
+         FROM sub_pieces sp
+         WHERE sp.scope = ? AND sp.status = 'built'
+           AND NOT EXISTS (
+             SELECT 1 FROM uploads u
+             WHERE u.scope = sp.scope
+               AND u.sub_piece_cid = sp.sub_piece_cid
+               AND u.provider_id = ?
+               AND u.status IN ('parked', 'add_unconfirmed', 'committed', 'failed')
+           )
+         ORDER BY sp.created_at, sp.rowid`
+      )
+      .all(this.scope, providerId)
+    return rows.map(toSubPieceRow)
+  }
+
+  /**
+   * Built sub-pieces whose primary copy is live but that lack any row for
+   * the given secondary provider. A crash between the primary store and the
+   * secondary pull leaves exactly this shape; the retry pass repairs it.
+   */
+  subPiecesMissingSecondary(primaryProviderId: string, secondaryProviderId: string): string[] {
+    const rows = this.#db
+      .prepare(
+        `SELECT sp.sub_piece_cid
+         FROM sub_pieces sp
+         WHERE sp.scope = ? AND sp.status = 'built'
+           AND EXISTS (
+             SELECT 1 FROM uploads u
+             WHERE u.scope = sp.scope AND u.sub_piece_cid = sp.sub_piece_cid
+               AND u.provider_id = ? AND u.status IN ('parked', 'add_unconfirmed', 'committed')
+           )
+           AND NOT EXISTS (
+             SELECT 1 FROM uploads u
+             WHERE u.scope = sp.scope AND u.sub_piece_cid = sp.sub_piece_cid
+               AND u.provider_id = ?
+           )
+         ORDER BY sp.created_at, sp.rowid`
+      )
+      .all(this.scope, primaryProviderId, secondaryProviderId)
+    return rows.map((r) => String((r as { sub_piece_cid: string }).sub_piece_cid))
+  }
+
+  /** Record a successful store(): the provider holds the bytes, GC clock starts. */
+  recordUploadParked(subPieceCid: string, providerId: string, role: UploadRole, dataSetId: string | null): void {
+    const now = new Date().toISOString()
+    this.#db
+      .prepare(
+        `INSERT INTO uploads (scope, sub_piece_cid, provider_id, role, data_set_id, status, parked_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, 'parked', ?, ?)
+         ON CONFLICT (scope, sub_piece_cid, provider_id) DO UPDATE SET
+           role = excluded.role, data_set_id = excluded.data_set_id,
+           status = 'parked', parked_at = excluded.parked_at,
+           tx_hash = NULL, piece_id = NULL, committed_at = NULL, error = NULL,
+           updated_at = excluded.updated_at`
+      )
+      .run(this.scope, subPieceCid, providerId, role, dataSetId, now, now)
+  }
+
+  /** Parked uploads for one provider, oldest parked first (the flush batch). */
+  parkedUploads(providerId: string): UploadRow[] {
+    return this.uploadsByStatus(providerId, 'parked')
+  }
+
+  /**
+   * One transactional UPDATE applied to each (sub_piece_cid, provider_id) in
+   * the batch. `set` is a compile-time constant fragment, never caller input.
+   */
+  #updateUploadsBatch(subPieceCids: string[], providerId: string, set: string, params: unknown[]): void {
+    const now = new Date().toISOString()
+    const stmt = this.#db.prepare(
+      `UPDATE uploads SET ${set}, updated_at = ? WHERE scope = ? AND sub_piece_cid = ? AND provider_id = ?`
+    )
+    this.#db.exec('BEGIN')
+    try {
+      for (const cid of subPieceCids) stmt.run(...(params as string[]), now, this.scope, cid, providerId)
+      this.#db.exec('COMMIT')
+    } catch (err) {
+      this.#db.exec('ROLLBACK')
+      throw err
+    }
+  }
+
+  /**
+   * Durable breadcrumb set immediately before the addPieces attempt, so a
+   * crash mid-commit is never auto-resolved into a blind re-add.
+   */
+  markUploadsAddUnconfirmed(subPieceCids: string[], providerId: string): void {
+    this.#updateUploadsBatch(subPieceCids, providerId, `status = 'add_unconfirmed'`, [])
+  }
+
+  markUploadTxSubmitted(subPieceCids: string[], providerId: string, txHash: string): void {
+    this.#updateUploadsBatch(subPieceCids, providerId, 'tx_hash = ?', [txHash])
+  }
+
+  markUploadCommitted(
+    subPieceCid: string,
+    providerId: string,
+    info: { dataSetId: string; pieceId: string; txHash: string | null }
+  ): void {
+    const now = new Date().toISOString()
+    this.#db
+      .prepare(
+        `UPDATE uploads SET status = 'committed', data_set_id = ?, piece_id = ?, tx_hash = ?,
+           committed_at = ?, error = NULL, updated_at = ?
+         WHERE scope = ? AND sub_piece_cid = ? AND provider_id = ?`
+      )
+      .run(info.dataSetId, info.pieceId, info.txHash, now, now, this.scope, subPieceCid, providerId)
+  }
+
+  /**
+   * Return add_unconfirmed rows to parked after a re-verify confirmed the
+   * provider still holds the bytes. Leaves parked_at untouched (the GC clock
+   * started at store() time and a failed commit does not reset it) but clears
+   * the stale commit coordinates: the next flush writes fresh ones, and a
+   * leftover tx_hash from the failed attempt would mislead a later resume.
+   */
+  revertUploadsToParked(subPieceCids: string[], providerId: string): void {
+    this.#updateUploadsBatch(
+      subPieceCids,
+      providerId,
+      `status = 'parked', tx_hash = NULL, piece_id = NULL, committed_at = NULL`,
+      []
+    )
+  }
+
+  /** The provider garbage-collected the parked piece; the CAR must be stored again. */
+  markUploadCollected(subPieceCid: string, providerId: string): void {
+    this.#db
+      .prepare(
+        `UPDATE uploads SET status = 'collected', updated_at = ?
+         WHERE scope = ? AND sub_piece_cid = ? AND provider_id = ?`
+      )
+      .run(new Date().toISOString(), this.scope, subPieceCid, providerId)
+  }
+
+  /**
+   * Upsert, not update: a secondary whose pull fails has no uploads row yet,
+   * so the failure record is the first thing written for that (piece, provider).
+   */
+  markUploadFailed(subPieceCid: string, providerId: string, role: UploadRole, error: string): void {
+    const now = new Date().toISOString()
+    this.#db
+      .prepare(
+        `INSERT INTO uploads (scope, sub_piece_cid, provider_id, role, status, parked_at, error, updated_at)
+         VALUES (?, ?, ?, ?, 'failed', ?, ?, ?)
+         ON CONFLICT (scope, sub_piece_cid, provider_id) DO UPDATE SET
+           status = 'failed', error = excluded.error, updated_at = excluded.updated_at`
+      )
+      .run(this.scope, subPieceCid, providerId, role, now, error, now)
+  }
+
+  uploadsByStatus(providerId: string, status: UploadStatus): UploadRow[] {
+    const rows = this.#db
+      .prepare(
+        `SELECT sub_piece_cid, provider_id, role, data_set_id, status, parked_at,
+                tx_hash, piece_id, committed_at, updated_at, error
+         FROM uploads WHERE scope = ? AND provider_id = ? AND status = ? ORDER BY parked_at`
+      )
+      .all(this.scope, providerId, status)
+    return rows.map(toUploadRow)
+  }
+
+  /**
+   * Sub-piece CARs safe to evict: the primary copy is committed on chain.
+   * The local file exists to (re-)store the primary; secondary copies pull
+   * provider-to-provider from the primary, whose possession is proven on
+   * chain, so a pending or failed secondary does not hold the file hostage.
+   */
+  carPathsEvictable(): string[] {
+    const rows = this.#db
+      .prepare(
+        `SELECT sp.car_path FROM sub_pieces sp
+         WHERE sp.scope = ?
+           AND EXISTS (
+             SELECT 1 FROM uploads u
+             WHERE u.scope = sp.scope AND u.sub_piece_cid = sp.sub_piece_cid
+               AND u.role = 'primary' AND u.status = 'committed'
+           )`
+      )
+      .all(this.scope)
+    return rows.map((r) => (r as { car_path: string }).car_path)
+  }
+
+  /**
+   * Per-provider GC-window estimate. Reads fall back to the caller's default;
+   * writes only ever lower the stored value (a successful run proves nothing
+   * about the window being longer).
+   */
+  providerWindowMs(providerId: string, defaultMs: number): number {
+    const row = this.#db
+      .prepare(`SELECT assumed_window_ms FROM provider_windows WHERE scope = ? AND provider_id = ?`)
+      .get(this.scope, providerId) as { assumed_window_ms: number } | undefined
+    return row == null ? defaultMs : Math.min(row.assumed_window_ms, defaultMs)
+  }
+
+  lowerProviderWindow(providerId: string, windowMs: number): void {
+    this.#db
+      .prepare(
+        `INSERT INTO provider_windows (scope, provider_id, assumed_window_ms, updated_at)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT (scope, provider_id) DO UPDATE SET
+           assumed_window_ms = MIN(provider_windows.assumed_window_ms, excluded.assumed_window_ms),
+           updated_at = excluded.updated_at`
+      )
+      .run(this.scope, providerId, windowMs, new Date().toISOString())
+  }
+
+  close(): void {
+    this.#db.close()
+  }
+}
+
+function toSubPieceRow(r: unknown): SubPieceRow {
+  const row = r as Record<string, unknown>
+  return {
+    subPieceCid: String(row.sub_piece_cid),
+    assembledCarLength: Number(row.assembled_car_length),
+    assembledSha256: row.assembled_sha256 == null ? null : String(row.assembled_sha256),
+    targetSizeBytes: Number(row.target_size_bytes),
+    carPath: row.car_path == null ? null : String(row.car_path),
+    status: row.status as SubPieceStatus,
+  }
+}
+
+function toUploadRow(r: unknown): UploadRow {
+  const row = r as Record<string, unknown>
+  return {
+    subPieceCid: String(row.sub_piece_cid),
+    providerId: String(row.provider_id),
+    role: row.role as UploadRole,
+    dataSetId: row.data_set_id == null ? null : String(row.data_set_id),
+    status: row.status as UploadStatus,
+    parkedAt: String(row.parked_at),
+    txHash: row.tx_hash == null ? null : String(row.tx_hash),
+    pieceId: row.piece_id == null ? null : String(row.piece_id),
+    committedAt: row.committed_at == null ? null : String(row.committed_at),
+    updatedAt: String(row.updated_at ?? row.parked_at),
+    error: row.error == null ? null : String(row.error),
+  }
+}
+
+function toPieceRow(r: unknown): PieceRow {
+  const row = r as Record<string, unknown>
+  return {
+    cid: String(row.cid),
+    pieceCid: row.piece_cid == null ? null : String(row.piece_cid),
+    rawSize: row.raw_size == null ? null : Number(row.raw_size),
+    gateway: row.gateway == null ? null : String(row.gateway),
+    url: row.url == null ? null : String(row.url),
+    memberCarPath: row.member_car_path == null ? null : String(row.member_car_path),
+    memberSha256: row.member_sha256 == null ? null : String(row.member_sha256),
+    status: row.status as PieceStatus,
+    error: row.error == null ? null : String(row.error),
+  }
+}

--- a/src/migrate/db.ts
+++ b/src/migrate/db.ts
@@ -28,6 +28,7 @@ export type FailureCategory =
   | 'source_gateway_timeout'
   | 'car_incomplete'
   | 'car_root_mismatch'
+  | 'car_block_mismatch'
   | 'commp_mismatch'
   | 'oversized'
   | 'staging_budget'
@@ -163,6 +164,10 @@ export class MigrationDB {
         FOREIGN KEY (scope, sub_piece_cid) REFERENCES sub_pieces(scope, sub_piece_cid),
         FOREIGN KEY (scope, member_cid) REFERENCES pieces(scope, cid)
       );
+      -- A member belongs to at most one sub-piece: double-packing a source
+      -- CID must fail at the store, not survive as silent corruption.
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_sub_piece_members_member
+        ON sub_piece_members (scope, member_cid);
       CREATE TABLE IF NOT EXISTS uploads (
         scope         TEXT NOT NULL,
         sub_piece_cid TEXT NOT NULL,
@@ -357,14 +362,15 @@ export class MigrationDB {
   /**
    * Remove a staged piece whose CAR file failed re-verification, freeing its
    * member CIDs to re-download. One transaction deletes the piece, its
-   * member list, and any upload rows, then returns the affected source CIDs
-   * so the caller can reset them to pending. Refuses a piece whose primary
-   * copy is already committed: that piece is on chain and its local file no
-   * longer matters.
+   * member list, and any upload rows, and resets the member CIDs to
+   * `pending`; the returned CIDs are for logging. Refuses a piece any of
+   * whose copies is already committed: that piece is on chain and its local
+   * file no longer matters.
    */
   deleteSubPieceForRebuild(subPieceCid: string): string[] {
-    // Live provider-side state blocks a rebuild: a committed primary is
-    // final, an add_unconfirmed row is an unresolved breadcrumb whose
+    // Live provider-side state blocks a rebuild: a committed copy (either
+    // role) is on chain and deleting its row would let later flow re-add the
+    // same piece, an add_unconfirmed row is an unresolved breadcrumb whose
     // deletion could turn into a duplicate on-chain add, and a parked copy
     // can still commit from the provider's bytes without the local file.
     // Reconciliation resolves those states first; the rebuild waits for a
@@ -373,7 +379,7 @@ export class MigrationDB {
       .prepare(
         `SELECT status FROM uploads
          WHERE scope = ? AND sub_piece_cid = ?
-           AND (status IN ('parked', 'add_unconfirmed') OR (role = 'primary' AND status = 'committed'))
+           AND status IN ('parked', 'add_unconfirmed', 'committed')
          LIMIT 1`
       )
       .get(this.scope, subPieceCid) as { status: string } | undefined
@@ -381,6 +387,16 @@ export class MigrationDB {
       throw new Error(`refusing to rebuild ${subPieceCid}: it has a live upload in status '${live.status}'`)
     }
     const members = this.subPieceMemberCids(subPieceCid)
+    // Members reset to pending inside the same transaction: a crash between
+    // deleting the sub-piece and re-queueing its sources would otherwise
+    // leave `done` rows with no member file and no membership, which nothing
+    // re-queues.
+    const resetMember = this.#db.prepare(
+      `UPDATE pieces SET status='pending', member_car_path=NULL, member_sha256=NULL,
+                          piece_cid=NULL, raw_size=NULL, error=NULL, failure_category=NULL, updated_at=?
+       WHERE scope=? AND cid=?`
+    )
+    const now = new Date().toISOString()
     this.#db.exec('BEGIN')
     try {
       this.#db.prepare(`DELETE FROM uploads WHERE scope = ? AND sub_piece_cid = ?`).run(this.scope, subPieceCid)
@@ -388,6 +404,9 @@ export class MigrationDB {
         .prepare(`DELETE FROM sub_piece_members WHERE scope = ? AND sub_piece_cid = ?`)
         .run(this.scope, subPieceCid)
       this.#db.prepare(`DELETE FROM sub_pieces WHERE scope = ? AND sub_piece_cid = ?`).run(this.scope, subPieceCid)
+      for (const cid of members) {
+        resetMember.run(now, this.scope, cid)
+      }
       this.#db.exec('COMMIT')
     } catch (err) {
       this.#db.exec('ROLLBACK')
@@ -542,6 +561,7 @@ export class MigrationDB {
              SELECT 1 FROM uploads u
              WHERE u.scope = sp.scope AND u.sub_piece_cid = sp.sub_piece_cid
                AND u.provider_id = ?
+               AND u.status IN ('parked', 'add_unconfirmed', 'committed', 'failed')
            )
          ORDER BY sp.created_at, sp.rowid`
       )
@@ -560,7 +580,8 @@ export class MigrationDB {
            role = excluded.role, data_set_id = excluded.data_set_id,
            status = 'parked', parked_at = excluded.parked_at,
            tx_hash = NULL, piece_id = NULL, committed_at = NULL, error = NULL,
-           updated_at = excluded.updated_at`
+           updated_at = excluded.updated_at
+         WHERE uploads.status != 'committed'`
       )
       .run(this.scope, subPieceCid, providerId, role, dataSetId, now, now)
   }

--- a/src/migrate/metrics.ts
+++ b/src/migrate/metrics.ts
@@ -1,0 +1,24 @@
+/**
+ * Formatting and timing helpers for the migrate pipeline's logs and summary.
+ */
+
+/** Human-readable duration from milliseconds: ms under a second, else seconds. */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`
+  }
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+/** A single timed span. `stop()` returns elapsed milliseconds. */
+export class Timer {
+  #start: number
+
+  constructor() {
+    this.#start = performance.now()
+  }
+
+  stop(): number {
+    return performance.now() - this.#start
+  }
+}

--- a/src/migrate/util.ts
+++ b/src/migrate/util.ts
@@ -1,55 +1,8 @@
 /**
- * Small helpers for the migrate runner: size parsing and CID-list parsing.
- * Output goes through `src/utils/cli-logger.ts` like every other command.
+ * Migrate-specific input parsing. Generic flag parsers (sizes, positive
+ * integers) live in `src/utils/cli-helpers.ts`; output goes through
+ * `src/utils/cli-logger.ts` like every other command.
  */
-
-// Decimal spellings (kb, mb, ...) are accepted as binary aliases: staging
-// sizes are power-of-two territory and rejecting `32GB` helps nobody.
-const SIZE_UNITS: Record<string, bigint> = {
-  b: 1n,
-  k: 1024n,
-  kb: 1024n,
-  kib: 1024n,
-  m: 1024n ** 2n,
-  mb: 1024n ** 2n,
-  mib: 1024n ** 2n,
-  g: 1024n ** 3n,
-  gb: 1024n ** 3n,
-  gib: 1024n ** 3n,
-  t: 1024n ** 4n,
-  tb: 1024n ** 4n,
-  tib: 1024n ** 4n,
-}
-
-/**
- * Parse a size like "32GiB", "1MiB", or a raw byte count "34359738368".
- */
-export function parseSize(input: string): bigint {
-  const trimmed = input.trim().toLowerCase()
-  const match = trimmed.match(/^(\d+)\s*([a-z]*)$/)
-  if (match?.[1] == null) {
-    throw new Error(`invalid size: ${input}`)
-  }
-  const value = BigInt(match[1])
-  const unit = match[2] == null || match[2] === '' ? 'b' : match[2]
-  const multiplier = SIZE_UNITS[unit]
-  if (multiplier == null) {
-    throw new Error(`unknown size unit "${unit}" in ${input}`)
-  }
-  return value * multiplier
-}
-
-/** Parse a positive integer flag value; throws a clear error for missing or non-positive input. */
-export function parsePositiveInt(raw: string | undefined, flag: string): number {
-  if (raw == null) {
-    throw new Error(`${flag} requires a value`)
-  }
-  const n = Number.parseInt(raw, 10)
-  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0 || String(n) !== raw.trim()) {
-    throw new Error(`${flag} must be a positive integer (got ${JSON.stringify(raw)})`)
-  }
-  return n
-}
 
 /** Read a CID list file: one CID per line, blank lines and `#` comments ignored. */
 export function parseCidList(text: string): string[] {

--- a/src/migrate/util.ts
+++ b/src/migrate/util.ts
@@ -1,0 +1,59 @@
+/**
+ * Small helpers for the migrate runner: stderr logging, size parsing, a
+ * bounded concurrency pool, and CID-list parsing.
+ */
+
+/** Log to stderr so stdout stays reserved for machine-readable output. */
+export function log(...args: unknown[]): void {
+  console.error(...args)
+}
+
+const SIZE_UNITS: Record<string, bigint> = {
+  b: 1n,
+  k: 1024n,
+  kib: 1024n,
+  m: 1024n ** 2n,
+  mib: 1024n ** 2n,
+  g: 1024n ** 3n,
+  gib: 1024n ** 3n,
+  t: 1024n ** 4n,
+  tib: 1024n ** 4n,
+}
+
+/**
+ * Parse a size like "32GiB", "1MiB", or a raw byte count "34359738368".
+ */
+export function parseSize(input: string): bigint {
+  const trimmed = input.trim().toLowerCase()
+  const match = trimmed.match(/^(\d+)\s*([a-z]*)$/)
+  if (match?.[1] == null) {
+    throw new Error(`invalid size: ${input}`)
+  }
+  const value = BigInt(match[1])
+  const unit = match[2] == null || match[2] === '' ? 'b' : match[2]
+  const multiplier = SIZE_UNITS[unit]
+  if (multiplier == null) {
+    throw new Error(`unknown size unit "${unit}" in ${input}`)
+  }
+  return value * multiplier
+}
+
+/** Parse a positive integer flag value; throws a clear error for missing or non-positive input. */
+export function parsePositiveInt(raw: string | undefined, flag: string): number {
+  if (raw == null) {
+    throw new Error(`${flag} requires a value`)
+  }
+  const n = Number.parseInt(raw, 10)
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0 || String(n) !== raw.trim()) {
+    throw new Error(`${flag} must be a positive integer (got ${JSON.stringify(raw)})`)
+  }
+  return n
+}
+
+/** Read a CID list file: one CID per line, blank lines and `#` comments ignored. */
+export function parseCidList(text: string): string[] {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '' && !line.startsWith('#'))
+}

--- a/src/migrate/util.ts
+++ b/src/migrate/util.ts
@@ -1,12 +1,7 @@
 /**
- * Small helpers for the migrate runner: stderr logging, size parsing, and
- * CID-list parsing.
+ * Small helpers for the migrate runner: size parsing and CID-list parsing.
+ * Output goes through `src/utils/cli-logger.ts` like every other command.
  */
-
-/** Log to stderr so stdout stays reserved for machine-readable output. */
-export function log(...args: unknown[]): void {
-  console.error(...args)
-}
 
 // Decimal spellings (kb, mb, ...) are accepted as binary aliases: staging
 // sizes are power-of-two territory and rejecting `32GB` helps nobody.

--- a/src/migrate/util.ts
+++ b/src/migrate/util.ts
@@ -1,6 +1,6 @@
 /**
- * Small helpers for the migrate runner: stderr logging, size parsing, a
- * bounded concurrency pool, and CID-list parsing.
+ * Small helpers for the migrate runner: stderr logging, size parsing, and
+ * CID-list parsing.
  */
 
 /** Log to stderr so stdout stays reserved for machine-readable output. */
@@ -8,15 +8,21 @@ export function log(...args: unknown[]): void {
   console.error(...args)
 }
 
+// Decimal spellings (kb, mb, ...) are accepted as binary aliases: staging
+// sizes are power-of-two territory and rejecting `32GB` helps nobody.
 const SIZE_UNITS: Record<string, bigint> = {
   b: 1n,
   k: 1024n,
+  kb: 1024n,
   kib: 1024n,
   m: 1024n ** 2n,
+  mb: 1024n ** 2n,
   mib: 1024n ** 2n,
   g: 1024n ** 3n,
+  gb: 1024n ** 3n,
   gib: 1024n ** 3n,
   t: 1024n ** 4n,
+  tb: 1024n ** 4n,
   tib: 1024n ** 4n,
 }
 

--- a/src/test/unit/migrate-db.test.ts
+++ b/src/test/unit/migrate-db.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { MigrationDB } from '../../migrate/db.js'
+import { parseSize } from '../../migrate/util.js'
+
+const CID_A = 'bafkreialpha'
+const CID_B = 'bafkreibravo'
+const SUB_1 = 'bafkreisubone'
+const SUB_2 = 'bafkreisubtwo'
+const PRIMARY = 'provider-1'
+const SECONDARY = 'provider-2'
+
+function openDb(): MigrationDB {
+  return new MigrationDB(':memory:', 'test:0xabc')
+}
+
+/** One downloaded member packed into one built sub-piece. */
+function stageOne(db: MigrationDB, cid: string, subPieceCid: string): void {
+  db.addCids([cid])
+  db.recordPieceSuccess(cid, {
+    pieceCid: 'bafkzcibtest',
+    rawSize: 100,
+    gateway: 'https://gw.example',
+    url: `https://gw.example/ipfs/${cid}`,
+    memberCarPath: `/tmp/${cid}.car`,
+    memberSha256: 'aa'.repeat(32),
+  })
+  db.recordBuiltSubPiece({
+    subPieceCid,
+    assembledCarLength: 120,
+    targetSizeBytes: 1000,
+    carPath: `/tmp/${subPieceCid}.car`,
+    assembledSha256: 'bb'.repeat(32),
+    members: [{ cid, rawSize: 100, sha256: 'aa'.repeat(32) }],
+  })
+}
+
+describe('MigrationDB resume transitions', () => {
+  it('re-schedules a secondary copy after the provider collected it', () => {
+    const db = openDb()
+    stageOne(db, CID_A, SUB_1)
+    db.recordUploadParked(SUB_1, PRIMARY, 'primary', '1')
+    db.markUploadCommitted(SUB_1, PRIMARY, { dataSetId: '1', pieceId: '1', txHash: '0x01' })
+
+    db.recordUploadParked(SUB_1, SECONDARY, 'secondary', null)
+    db.markUploadCollected(SUB_1, SECONDARY)
+
+    expect(db.subPiecesMissingSecondary(PRIMARY, SECONDARY)).toEqual([SUB_1])
+  })
+
+  it('refuses a rebuild while a secondary copy is committed', () => {
+    const db = openDb()
+    stageOne(db, CID_A, SUB_1)
+    db.recordUploadParked(SUB_1, PRIMARY, 'primary', '1')
+    db.markUploadCollected(SUB_1, PRIMARY)
+    db.recordUploadParked(SUB_1, SECONDARY, 'secondary', '1')
+    db.markUploadCommitted(SUB_1, SECONDARY, { dataSetId: '1', pieceId: '2', txHash: '0x02' })
+
+    expect(() => db.deleteSubPieceForRebuild(SUB_1)).toThrow(/committed/)
+    expect(db.uploadsByStatus(SECONDARY, 'committed')).toHaveLength(1)
+  })
+
+  it('resets members to pending in the same transaction as a rebuild', () => {
+    const db = openDb()
+    stageOne(db, CID_A, SUB_1)
+
+    const members = db.deleteSubPieceForRebuild(SUB_1)
+
+    expect(members).toEqual([CID_A])
+    expect(db.pendingCids()).toEqual([CID_A])
+    expect(db.subPiecesByStatus('built')).toHaveLength(0)
+  })
+
+  it('does not demote a committed upload back to parked', () => {
+    const db = openDb()
+    stageOne(db, CID_A, SUB_1)
+    db.recordUploadParked(SUB_1, PRIMARY, 'primary', '1')
+    db.markUploadCommitted(SUB_1, PRIMARY, { dataSetId: '1', pieceId: '1', txHash: '0x01' })
+
+    db.recordUploadParked(SUB_1, PRIMARY, 'primary', '1')
+
+    const committed = db.uploadsByStatus(PRIMARY, 'committed')
+    expect(committed).toHaveLength(1)
+    expect(committed[0]?.txHash).toBe('0x01')
+    expect(db.uploadsByStatus(PRIMARY, 'parked')).toHaveLength(0)
+  })
+
+  it('rejects packing the same member into a second sub-piece', () => {
+    const db = openDb()
+    stageOne(db, CID_A, SUB_1)
+    db.addCids([CID_B])
+    db.recordPieceSuccess(CID_B, {
+      pieceCid: 'bafkzcibother',
+      rawSize: 50,
+      gateway: 'https://gw.example',
+      url: `https://gw.example/ipfs/${CID_B}`,
+      memberCarPath: `/tmp/${CID_B}.car`,
+      memberSha256: 'cc'.repeat(32),
+    })
+
+    expect(() =>
+      db.recordBuiltSubPiece({
+        subPieceCid: SUB_2,
+        assembledCarLength: 200,
+        targetSizeBytes: 1000,
+        carPath: `/tmp/${SUB_2}.car`,
+        assembledSha256: 'dd'.repeat(32),
+        members: [
+          { cid: CID_B, rawSize: 50, sha256: 'cc'.repeat(32) },
+          { cid: CID_A, rawSize: 100, sha256: 'aa'.repeat(32) },
+        ],
+      })
+    ).toThrow()
+    // The failed transaction must not half-commit: CID_B stays packable.
+    expect(db.subPiecesByStatus('built')).toHaveLength(1)
+    expect(db.donePiecesFreeForPacking().map((p) => p.cid)).toEqual([CID_B])
+  })
+})
+
+describe('parseSize decimal aliases', () => {
+  it('treats kb/mb/gb/tb as their binary equivalents', () => {
+    expect(parseSize('32GB')).toBe(32n * 1024n ** 3n)
+    expect(parseSize('32GiB')).toBe(32n * 1024n ** 3n)
+    expect(parseSize('1mb')).toBe(1024n ** 2n)
+    expect(parseSize('2tb')).toBe(2n * 1024n ** 4n)
+  })
+})

--- a/src/test/unit/migrate-db.test.ts
+++ b/src/test/unit/migrate-db.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { MigrationDB } from '../../migrate/db.js'
-import { parseSize } from '../../migrate/util.js'
+import { parseSize } from '../../utils/cli-helpers.js'
 
 const CID_A = 'bafkreialpha'
 const CID_B = 'bafkreibravo'

--- a/src/utils/cli-helpers.ts
+++ b/src/utils/cli-helpers.ts
@@ -141,3 +141,52 @@ function formatFileSizeBigInt(bytes: bigint): string {
 export function isInteractive(): boolean {
   return isTTY() && process.stdin.isTTY === true && process.env.CI !== 'true' && process.env.GITHUB_ACTIONS !== 'true'
 }
+
+// Decimal spellings (kb, mb, ...) are accepted as binary aliases: flag sizes
+// are power-of-two territory and rejecting `32GB` helps nobody.
+const SIZE_UNITS: Record<string, bigint> = {
+  b: 1n,
+  k: 1024n,
+  kb: 1024n,
+  kib: 1024n,
+  m: 1024n ** 2n,
+  mb: 1024n ** 2n,
+  mib: 1024n ** 2n,
+  g: 1024n ** 3n,
+  gb: 1024n ** 3n,
+  gib: 1024n ** 3n,
+  t: 1024n ** 4n,
+  tb: 1024n ** 4n,
+  tib: 1024n ** 4n,
+}
+
+/**
+ * Parse a size flag like "32GiB", "1MiB", or a raw byte count "34359738368".
+ * The inverse of `formatFileSize` above.
+ */
+export function parseSize(input: string): bigint {
+  const trimmed = input.trim().toLowerCase()
+  const match = trimmed.match(/^(\d+)\s*([a-z]*)$/)
+  if (match?.[1] == null) {
+    throw new Error(`invalid size: ${input}`)
+  }
+  const value = BigInt(match[1])
+  const unit = match[2] == null || match[2] === '' ? 'b' : match[2]
+  const multiplier = SIZE_UNITS[unit]
+  if (multiplier == null) {
+    throw new Error(`unknown size unit "${unit}" in ${input}`)
+  }
+  return value * multiplier
+}
+
+/** Parse a positive integer flag value; throws a clear error for missing or non-positive input. */
+export function parsePositiveInt(raw: string | undefined, flag: string): number {
+  if (raw == null) {
+    throw new Error(`${flag} requires a value`)
+  }
+  const n = Number.parseInt(raw, 10)
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0 || String(n) !== raw.trim()) {
+    throw new Error(`${flag} must be a positive integer (got ${JSON.stringify(raw)})`)
+  }
+  return n
+}


### PR DESCRIPTION
### What changed

Part 1 of 5 splitting #652 into reviewable slices. Adds the migrate command's SQLite resume state store (`migrate.db` schema and lifecycle transitions: source CIDs go pending, done, failed or oversized; packed pieces are built or failed; each per-provider upload goes parked, add_unconfirmed, committed, collected or failed), trustless-gateway CAR URL construction, the size/int flag parsers (shared in `src/utils/cli-helpers.ts` next to `formatFileSize`), and the CID-list parser. Uses `node:sqlite` (`DatabaseSync`, WAL), unflagged since Node 23.4.

Also carries [documentation/migrate.md](https://github.com/filecoin-project/filecoin-pin/blob/feat/migrate-1-state-store/documentation/migrate.md) and the migrate glossary entries: the design doc rides in the first slice so the pipeline, resume guarantees, and exit contract get agreement before the code that implements them. Start the review there.

No CLI wiring yet.. the command activates in part 5, so this is dead code until the stack lands. Code review focus: the schema and the state transitions, they are the resume model everything else leans on.

### How to verify

```
pnpm install && pnpm run build && pnpm test
```

### Notes / risks

Stack: merge order is 1 through 5; each PR's base is the previous branch. The original umbrella #652 is closed, this slice carries the design doc and the full pipeline description lives in [documentation/migrate.md](https://github.com/filecoin-project/filecoin-pin/blob/feat/migrate-1-state-store/documentation/migrate.md). A calibnet kill-and-resume validation (no duplicate adds) is still pending before #657 undrafts.
