### PR TITLE
feat: add migrate gateway fetch and CAR verify

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,8 @@
     "@helia/unixfs": "^7.0.4",
     "@helia/utils": "^2.5.2",
     "@ipld/car": "^5.4.2",
+    "@ipld/dag-cbor": "^10.0.1",
+    "@ipld/dag-pb": "^4.1.7",
     "@libp2p/identify": "^4.1.2",
     "@libp2p/tcp": "^11.0.17",
     "@multiformats/multiaddr": "^13.0.1",
@@ -157,7 +159,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.5",
-    "@ipld/dag-cbor": "^10.0.1",
     "@types/node": "^26.1.1",
     "@types/semver": "^7.7.1",
     "@vitest/browser-playwright": "^4.0.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,12 @@ importers:
       '@ipld/car':
         specifier: ^5.4.2
         version: 5.4.6
+      '@ipld/dag-cbor':
+        specifier: ^10.0.1
+        version: 10.0.1
+      '@ipld/dag-pb':
+        specifier: ^4.1.7
+        version: 4.1.7
       '@libp2p/identify':
         specifier: ^4.1.2
         version: 4.1.8
@@ -102,9 +108,6 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.5
         version: 2.4.5
-      '@ipld/dag-cbor':
-        specifier: ^10.0.1
-        version: 10.0.1
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1

--- a/src/migrate/gateway.ts
+++ b/src/migrate/gateway.ts
@@ -1,0 +1,114 @@
+/**
+ * Trustless gateway access.
+ *
+ * Each CID is fetched as a CAR via the IPFS Trustless Gateway spec
+ * (`?format=car&dag-scope=all`). The response is untrusted: `verify-car.ts`
+ * hash-checks every block and walks the DAG for completeness before the
+ * bytes count as migrated.
+ */
+
+import { buildCarUrl, CAR_ACCEPT } from './car-url.js'
+import type { FailureCategory } from './db.js'
+
+/**
+ * Error subclass thrown by `fetchCar` so callers can categorize failures by
+ * kind instead of pattern-matching the error message.
+ */
+export class GatewayError extends Error {
+  status?: number
+  category: FailureCategory
+  constructor(message: string, opts: { status?: number | undefined; category: FailureCategory }) {
+    super(message)
+    this.name = 'GatewayError'
+    if (opts.status != null) {
+      this.status = opts.status
+    }
+    this.category = opts.category
+  }
+}
+
+function categoryForStatus(status: number): FailureCategory {
+  if (status === 429) return 'source_gateway_429'
+  if (status >= 500 && status < 600) return 'source_gateway_5xx'
+  return 'other'
+}
+
+function categoryForFetchError(err: unknown): FailureCategory {
+  // node:fetch wraps transport errors in a TypeError whose `cause` carries the
+  // node:net / dns / undici code. The signal-aborted case surfaces as a
+  // DOMException with name='AbortError'. Walk the chain rather than grep the
+  // message string.
+  const seen = new Set<unknown>()
+  let cur: unknown = err
+  while (cur != null && !seen.has(cur)) {
+    seen.add(cur)
+    const name = (cur as { name?: string }).name
+    if (name === 'AbortError' || name === 'TimeoutError') return 'source_gateway_timeout'
+    const code = (cur as { code?: string }).code
+    if (
+      code === 'ETIMEDOUT' ||
+      code === 'UND_ERR_CONNECT_TIMEOUT' ||
+      code === 'UND_ERR_HEADERS_TIMEOUT' ||
+      code === 'UND_ERR_BODY_TIMEOUT'
+    )
+      return 'source_gateway_timeout'
+    if (
+      code === 'ECONNREFUSED' ||
+      code === 'ECONNRESET' ||
+      code === 'EHOSTUNREACH' ||
+      code === 'ENETUNREACH' ||
+      code === 'ENOTFOUND' ||
+      code === 'EAI_AGAIN' ||
+      code === 'UND_ERR_SOCKET'
+    )
+      return 'source_gateway_network'
+    cur = (cur as { cause?: unknown }).cause
+  }
+  return 'source_gateway_network'
+}
+
+/** Fetch a CID as a CAR stream. Throws on non-2xx or a non-CAR content-type. */
+export async function fetchCar(
+  gateway: string,
+  cid: string,
+  signal?: AbortSignal
+): Promise<{ url: string; body: ReadableStream<Uint8Array> }> {
+  const url = buildCarUrl(gateway, cid)
+  let res: Response
+  try {
+    res = await fetch(url, { headers: { accept: CAR_ACCEPT }, signal: signal ?? null })
+  } catch (err) {
+    throw new GatewayError(
+      `gateway ${gateway} fetch failed for ${cid}: ${err instanceof Error ? err.message : String(err)}`,
+      { category: categoryForFetchError(err) }
+    )
+  }
+  if (!res.ok) {
+    res.body?.cancel().catch(() => {
+      // the stream may already be closed; either way it is released
+    })
+    throw new GatewayError(`gateway ${gateway} returned HTTP ${res.status} for ${cid}`, {
+      status: res.status,
+      category: categoryForStatus(res.status),
+    })
+  }
+  const contentType = res.headers.get('content-type') ?? ''
+  if (!contentType.includes('application/vnd.ipld.car')) {
+    // A file-mode gateway ignores ?format=car and returns the reassembled
+    // file. That is unusable for CID preservation, so reject it loudly.
+    res.body?.cancel().catch(() => {
+      // release the unusable body
+    })
+    throw new GatewayError(
+      `gateway ${gateway} is not trustless: got content-type "${contentType}" instead of a CAR for ${cid}`,
+      { status: res.status, category: 'other' }
+    )
+  }
+  if (res.body == null) {
+    throw new GatewayError(`gateway ${gateway} returned an empty body for ${cid}`, {
+      status: res.status,
+      category: 'other',
+    })
+  }
+  return { url, body: res.body }
+}

--- a/src/migrate/verify-car.ts
+++ b/src/migrate/verify-car.ts
@@ -1,0 +1,315 @@
+/**
+ * Single-pass member download: stream a CID's CAR from a trustless gateway to
+ * a file on disk while verifying it and computing its piece commitment.
+ *
+ * One pass over the bytes does all of:
+ *   - write through to `<memberDir>/<cid>.car` (via a temp file + atomic
+ *     rename, so a partial download is never mistaken for a verified member)
+ *   - hash every block against its CID multihash
+ *   - decode every block's links and, once the stream ends, walk the DAG from
+ *     the root to confirm every reachable link is present (a truncated
+ *     gateway response parses cleanly but fails this walk)
+ *   - compute the piece commitment (CommP) and a sha256 over the exact bytes
+ *
+ * The bytes verified here are the bytes on disk, and later the bytes packed
+ * and uploaded: there is no second fetch anywhere in the pipeline.
+ */
+
+import { createHash } from 'node:crypto'
+import { createWriteStream } from 'node:fs'
+import { rename, unlink } from 'node:fs/promises'
+import { join } from 'node:path'
+import { hasher } from '@filoz/synapse-core/piece'
+import { CarBlockIterator } from '@ipld/car'
+import * as dagCbor from '@ipld/dag-cbor'
+import * as dagPb from '@ipld/dag-pb'
+import { base64 } from 'multiformats/bases/base64'
+import { createUnsafe } from 'multiformats/block'
+import type { BlockView } from 'multiformats/block/interface'
+import { CID } from 'multiformats/cid'
+import * as json from 'multiformats/codecs/json'
+import * as raw from 'multiformats/codecs/raw'
+import { sha256, sha512 } from 'multiformats/hashes/sha2'
+import type { FailureCategory } from './db.js'
+import { fetchCar, GatewayError } from './gateway.js'
+import { log } from './util.js'
+
+/**
+ * Error thrown by the verify path, carrying a failure category alongside the
+ * message, mirroring `GatewayError`.
+ */
+export class VerifyCarError extends Error {
+  category: FailureCategory
+  constructor(message: string, category: FailureCategory) {
+    super(message)
+    this.name = 'VerifyCarError'
+    this.category = category
+  }
+}
+
+/** Read a category off a thrown error, falling back to `other`. */
+export function categoryOf(err: unknown): FailureCategory {
+  if (err instanceof GatewayError) return err.category
+  if (err instanceof VerifyCarError) return err.category
+  return 'other'
+}
+
+const IDENTITY_MULTIHASH_CODE = 0x0
+const SHA2_256_CODE = 0x12
+const SHA2_512_CODE = 0x13
+
+const HASHERS: Record<number, { digest(b: Uint8Array): { digest: Uint8Array } | Promise<{ digest: Uint8Array }> }> = {
+  [SHA2_256_CODE]: sha256,
+  [SHA2_512_CODE]: sha512,
+}
+
+/**
+ * Codecs a trustless UnixFS/IPLD CAR carries. An unknown codec fails the
+ * verification rather than silently skipping a block's links: skipped links
+ * would defeat the completeness walk.
+ */
+const CODECS: Record<number, { code: number; decode(bytes: Uint8Array): unknown }> = {
+  [dagPb.code]: dagPb,
+  [dagCbor.code]: dagCbor,
+  [raw.code]: raw,
+  [json.code]: json,
+}
+
+/** Exact key: the multihash bytes, so CIDv0/v1 forms of a block collapse. */
+function blockKey(cid: CID): string {
+  return base64.encode(cid.multihash.bytes)
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+async function digestMatches(cid: CID, bytes: Uint8Array): Promise<boolean> {
+  const code = cid.multihash.code
+  if (code === IDENTITY_MULTIHASH_CODE) return bytesEqual(bytes, cid.multihash.digest)
+  const h = HASHERS[code]
+  if (h == null) {
+    throw new VerifyCarError(`no hasher for multihash code 0x${code.toString(16)}; cannot verify block ${cid}`, 'other')
+  }
+  const { digest } = await h.digest(bytes)
+  return bytesEqual(digest, cid.multihash.digest)
+}
+
+function linksOf(cid: CID, bytes: Uint8Array): CID[] {
+  const codec = CODECS[cid.code]
+  if (codec == null) {
+    throw new VerifyCarError(`no codec for 0x${cid.code.toString(16)} in block ${cid}`, 'other')
+  }
+  const block = createUnsafe({ cid, bytes, codec }) as BlockView
+  const links: CID[] = []
+  for (const [, linked] of block.links()) {
+    links.push(linked as CID)
+  }
+  return links
+}
+
+export interface VerifiedCar {
+  /** PieceCID v2 over the exact CAR bytes. */
+  pieceCid: string
+  /** CAR byte length. */
+  rawSize: number
+  /** sha256 of the same bytes, for resume re-verification. */
+  sha256: string
+  roots: CID[]
+  blockCount: number
+}
+
+export interface VerifyCarOptions {
+  /**
+   * Called with each chunk's byte length as it is written. Throwing aborts
+   * the verification with that error: the disk-budget gate uses this to cut
+   * off a download that would overrun the staging budget.
+   */
+  onBytes?: ((delta: number) => void) | undefined
+  /**
+   * Root the completeness walk starts from. Without it the first declared
+   * root is walked, which is not enough when the caller requested a specific
+   * CID: a response could declare an unrelated-but-complete first root and
+   * an incomplete requested one.
+   */
+  expectedRoot?: CID | undefined
+}
+
+/**
+ * Stream a CAR through the piece hasher, a sha256 tap, block verification,
+ * and the sink in one pass, then walk the DAG from the first root and reject
+ * any reachable link the CAR does not contain.
+ */
+export async function verifyCarStream(
+  body: ReadableStream<Uint8Array>,
+  sink: { write(chunk: Uint8Array): Promise<void>; end(): Promise<void> },
+  opts: VerifyCarOptions = {}
+): Promise<VerifiedCar> {
+  const pieceHasher = hasher()
+  const sha = createHash('sha256')
+  let rawSize = 0
+
+  async function* tap(): AsyncIterable<Uint8Array> {
+    for await (const chunk of body as unknown as AsyncIterable<Uint8Array>) {
+      opts.onBytes?.(chunk.length)
+      pieceHasher.write(chunk)
+      sha.update(chunk)
+      rawSize += chunk.length
+      await sink.write(chunk)
+      yield chunk
+    }
+  }
+
+  /** Present blocks and their outgoing links, keyed by multihash bytes. */
+  const links = new Map<string, CID[]>()
+  let blockCount = 0
+
+  const reader = await CarBlockIterator.fromIterable(tap())
+  for await (const block of reader) {
+    const cid = block.cid
+    if (!(await digestMatches(cid, block.bytes))) {
+      throw new VerifyCarError(`block ${cid.toString()} does not match its multihash`, 'car_root_mismatch')
+    }
+    links.set(blockKey(cid), linksOf(cid, block.bytes))
+    blockCount++
+  }
+  const roots = await reader.getRoots()
+  await sink.end()
+
+  // Completeness: every link reachable from the root must be present. A
+  // response that ended early at a block boundary parses cleanly and fails
+  // exactly here.
+  const root = opts.expectedRoot ?? roots[0]
+  if (root == null) {
+    throw new VerifyCarError('CAR declares no roots', 'car_incomplete')
+  }
+  const seen = new Set<string>()
+  const stack: CID[] = [root]
+  while (stack.length > 0) {
+    const cid = stack.pop()
+    if (cid == null) break
+    const key = blockKey(cid)
+    if (seen.has(key)) continue
+    seen.add(key)
+    if (cid.multihash.code === IDENTITY_MULTIHASH_CODE) {
+      // Identity blocks carry their bytes in the digest and are not written
+      // to the CAR; their links still count toward completeness.
+      stack.push(...linksOf(cid, cid.multihash.digest))
+      continue
+    }
+    const outgoing = links.get(key)
+    if (outgoing == null) {
+      throw new VerifyCarError(
+        `CAR is incomplete: block ${cid.toString()} is reachable from the root but missing`,
+        'car_incomplete'
+      )
+    }
+    stack.push(...outgoing)
+  }
+
+  return { pieceCid: pieceHasher.finalize().toString(), rawSize, sha256: sha.digest('hex'), roots, blockCount }
+}
+
+/** File-backed sink for `verifyCarStream`; unlinks the partial file on failure. */
+export function createFileSink(filePath: string): { write(chunk: Uint8Array): Promise<void>; end(): Promise<void> } {
+  const stream = createWriteStream(filePath)
+  let firstError: Error | null = null
+  stream.on('error', (err) => {
+    if (firstError == null) firstError = err
+  })
+  return {
+    write(chunk) {
+      if (firstError != null) return Promise.reject(firstError)
+      return new Promise<void>((resolve, reject) => {
+        const ok = stream.write(chunk, (err) => {
+          if (err) reject(err)
+          else if (ok) resolve()
+        })
+        if (!ok) stream.once('drain', resolve)
+      })
+    },
+    async end() {
+      if (firstError != null) throw firstError
+      await new Promise<void>((resolve, reject) => {
+        stream.end((err?: Error | null) => (err ? reject(err) : resolve()))
+      })
+    },
+  }
+}
+
+export interface StagedMember {
+  cid: string
+  pieceCid: string
+  rawSize: number
+  gateway: string
+  url: string
+  memberCarPath: string
+  memberSha256: string
+}
+
+/** The fetch surface `stageMember` drives; injectable for network-free tests. */
+export type CarFetcher = (gateway: string, cid: string) => Promise<{ url: string; body: ReadableStream<Uint8Array> }>
+
+/**
+ * Download one CID from the first working gateway, verify it, and land it as
+ * `<memberDir>/<cid>.car` via a temp file and atomic rename. Tries gateways
+ * in order; the first whose CAR verifies wins.
+ */
+export async function stageMember(
+  cid: string,
+  gateways: string[],
+  memberDir: string,
+  opts: VerifyCarOptions = {},
+  fetcher: CarFetcher = fetchCar
+): Promise<StagedMember> {
+  const expected = CID.parse(cid)
+  const finalPath = join(memberDir, `${cid}.car`)
+  const errors: string[] = []
+  const categories: FailureCategory[] = []
+
+  for (const gateway of gateways) {
+    const tmpPath = join(memberDir, `${cid}.car.tmp-${process.pid}`)
+    try {
+      const { url, body } = await fetcher(gateway, cid)
+      const sink = createFileSink(tmpPath)
+      // The completeness walk must start from the CID the caller asked for,
+      // not whatever root the response happens to declare first.
+      const verified = await verifyCarStream(body, sink, { ...opts, expectedRoot: expected })
+      if (!verified.roots.some((r) => r.equals(expected) || r.toString() === cid)) {
+        throw new VerifyCarError(
+          `CAR root mismatch: expected ${cid}, CAR declares [${verified.roots.map((r) => r.toString()).join(', ')}]`,
+          'car_root_mismatch'
+        )
+      }
+      await rename(tmpPath, finalPath)
+      log(`  ok ${cid} (${verified.rawSize} bytes, ${verified.blockCount} block(s) verified) via ${gateway}`)
+      return {
+        cid,
+        pieceCid: verified.pieceCid,
+        rawSize: verified.rawSize,
+        gateway,
+        url,
+        memberCarPath: finalPath,
+        memberSha256: verified.sha256,
+      }
+    } catch (err) {
+      await unlink(tmpPath).catch(() => undefined)
+      const message = err instanceof Error ? err.message : String(err)
+      errors.push(`${gateway}: ${message}`)
+      categories.push(categoryOf(err))
+      log(`  ! ${cid} via ${gateway} failed: ${message}`)
+      // A budget cutoff is not a gateway problem; do not burn the other
+      // gateways on it.
+      if (categoryOf(err) === 'staging_budget') {
+        throw err
+      }
+    }
+  }
+
+  const aggregated = categories.find((c) => c !== 'other') ?? 'other'
+  throw new VerifyCarError(`all gateways failed for ${cid}\n    ${errors.join('\n    ')}`, aggregated)
+}

--- a/src/migrate/verify-car.ts
+++ b/src/migrate/verify-car.ts
@@ -32,7 +32,7 @@ import * as raw from 'multiformats/codecs/raw'
 import { sha256, sha512 } from 'multiformats/hashes/sha2'
 import type { FailureCategory } from './db.js'
 import { fetchCar, GatewayError } from './gateway.js'
-import { log } from './util.js'
+import { log } from '../utils/cli-logger.js'
 
 /**
  * Error thrown by the verify path, carrying a failure category alongside the
@@ -325,7 +325,7 @@ export async function stageMember(
         )
       }
       await rename(tmpPath, finalPath)
-      log(`  ok ${cid} (${verified.rawSize} bytes, ${verified.blockCount} block(s) verified) via ${gateway}`)
+      log.message(`  ok ${cid} (${verified.rawSize} bytes, ${verified.blockCount} block(s) verified) via ${gateway}`)
       return {
         cid,
         pieceCid: verified.pieceCid,
@@ -345,7 +345,7 @@ export async function stageMember(
       const message = err instanceof Error ? err.message : String(err)
       errors.push(`${gateway}: ${message}`)
       categories.push(categoryOf(err))
-      log(`  ! ${cid} via ${gateway} failed: ${message}`)
+      log.message(`  ! ${cid} via ${gateway} failed: ${message}`)
       // A budget cutoff is not a gateway problem; do not burn the other
       // gateways on it.
       if (categoryOf(err) === 'staging_budget') {

--- a/src/migrate/verify-car.ts
+++ b/src/migrate/verify-car.ts
@@ -164,17 +164,22 @@ export async function verifyCarStream(
     }
   }
 
-  /** Present blocks and their outgoing links, keyed by multihash bytes. */
-  const links = new Map<string, CID[]>()
+  /**
+   * Present blocks and their outgoing links, keyed by multihash bytes. The
+   * codec the CAR entry declared is kept alongside: links were decoded with
+   * it, so a walk that reaches the same multihash under a different codec
+   * must not trust them (see the codec check below).
+   */
+  const links = new Map<string, { code: number; links: CID[] }>()
   let blockCount = 0
 
   const reader = await CarBlockIterator.fromIterable(tap())
   for await (const block of reader) {
     const cid = block.cid
     if (!(await digestMatches(cid, block.bytes))) {
-      throw new VerifyCarError(`block ${cid.toString()} does not match its multihash`, 'car_root_mismatch')
+      throw new VerifyCarError(`block ${cid.toString()} does not match its multihash`, 'car_block_mismatch')
     }
-    links.set(blockKey(cid), linksOf(cid, block.bytes))
+    links.set(blockKey(cid), { code: cid.code, links: linksOf(cid, block.bytes) })
     blockCount++
   }
   const roots = await reader.getRoots()
@@ -201,21 +206,39 @@ export async function verifyCarStream(
       stack.push(...linksOf(cid, cid.multihash.digest))
       continue
     }
-    const outgoing = links.get(key)
-    if (outgoing == null) {
+    const entry = links.get(key)
+    if (entry == null) {
       throw new VerifyCarError(
         `CAR is incomplete: block ${cid.toString()} is reachable from the root but missing`,
         'car_incomplete'
       )
     }
-    stack.push(...outgoing)
+    // A block that arrived under a different codec than the walk reached it
+    // by had its links decoded with the wrong decoder. Accepting it would
+    // let a gateway relabel the root bytes as `raw` (no links) and pass the
+    // completeness walk on a truncated DAG.
+    if (entry.code !== cid.code) {
+      throw new VerifyCarError(
+        `block ${cid.toString()} arrived with codec 0x${entry.code.toString(16)} but is referenced ` +
+          `with codec 0x${cid.code.toString(16)}`,
+        'car_block_mismatch'
+      )
+    }
+    stack.push(...entry.links)
   }
 
   return { pieceCid: pieceHasher.finalize().toString(), rawSize, sha256: sha.digest('hex'), roots, blockCount }
 }
 
+export interface FileSink {
+  write(chunk: Uint8Array): Promise<void>
+  end(): Promise<void>
+  /** Release the descriptor after a failure so the temp file can unlink (Windows holds EBUSY otherwise). */
+  destroy(): void
+}
+
 /** File-backed sink for `verifyCarStream`; unlinks the partial file on failure. */
-export function createFileSink(filePath: string): { write(chunk: Uint8Array): Promise<void>; end(): Promise<void> } {
+export function createFileSink(filePath: string): FileSink {
   const stream = createWriteStream(filePath)
   let firstError: Error | null = null
   stream.on('error', (err) => {
@@ -225,11 +248,16 @@ export function createFileSink(filePath: string): { write(chunk: Uint8Array): Pr
     write(chunk) {
       if (firstError != null) return Promise.reject(firstError)
       return new Promise<void>((resolve, reject) => {
+        // A buffered write resolves immediately; a flush failure lands in
+        // `firstError` via the error listener and fails the next write or
+        // end(). Only backpressure defers, and then to `drain`, not to the
+        // flush callback: waiting out the flush per chunk would serialize
+        // the whole download on disk latency.
         const ok = stream.write(chunk, (err) => {
           if (err) reject(err)
-          else if (ok) resolve()
         })
-        if (!ok) stream.once('drain', resolve)
+        if (ok) resolve()
+        else stream.once('drain', resolve)
       })
     },
     async end() {
@@ -237,6 +265,10 @@ export function createFileSink(filePath: string): { write(chunk: Uint8Array): Pr
       await new Promise<void>((resolve, reject) => {
         stream.end((err?: Error | null) => (err ? reject(err) : resolve()))
       })
+      if (firstError != null) throw firstError
+    },
+    destroy() {
+      stream.destroy()
     },
   }
 }
@@ -273,13 +305,20 @@ export async function stageMember(
 
   for (const gateway of gateways) {
     const tmpPath = join(memberDir, `${cid}.car.tmp-${process.pid}`)
+    let body: ReadableStream<Uint8Array> | null = null
+    let sink: FileSink | null = null
     try {
-      const { url, body } = await fetcher(gateway, cid)
-      const sink = createFileSink(tmpPath)
+      const fetched = await fetcher(gateway, cid)
+      const url = fetched.url
+      body = fetched.body
+      sink = createFileSink(tmpPath)
       // The completeness walk must start from the CID the caller asked for,
       // not whatever root the response happens to declare first.
       const verified = await verifyCarStream(body, sink, { ...opts, expectedRoot: expected })
-      if (!verified.roots.some((r) => r.equals(expected) || r.toString() === cid)) {
+      // Roots compare by multihash: the trustless-gateway spec permits
+      // answering a CIDv0 request with the equivalent CIDv1 root, and the
+      // walk's codec check above already rejects a relabeled root.
+      if (!verified.roots.some((r) => blockKey(r) === blockKey(expected))) {
         throw new VerifyCarError(
           `CAR root mismatch: expected ${cid}, CAR declares [${verified.roots.map((r) => r.toString()).join(', ')}]`,
           'car_root_mismatch'
@@ -297,6 +336,11 @@ export async function stageMember(
         memberSha256: verified.sha256,
       }
     } catch (err) {
+      // Release the descriptor and the HTTP connection before the unlink:
+      // an open handle blocks deletion on Windows, and an unconsumed body
+      // holds the socket until GC.
+      sink?.destroy()
+      await body?.cancel().catch(() => undefined)
       await unlink(tmpPath).catch(() => undefined)
       const message = err instanceof Error ? err.message : String(err)
       errors.push(`${gateway}: ${message}`)

--- a/src/test/unit/migrate-verify-car.test.ts
+++ b/src/test/unit/migrate-verify-car.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { calculate } from '@filoz/synapse-core/piece'
 import { CarWriter } from '@ipld/car'
 import * as dagCbor from '@ipld/dag-cbor'
+import * as dagPb from '@ipld/dag-pb'
 import { CID } from 'multiformats/cid'
 import * as raw from 'multiformats/codecs/raw'
 import { sha256 } from 'multiformats/hashes/sha2'
@@ -196,6 +197,46 @@ describe('stageMember', () => {
         stageMember(other, ['fake://gw'], dir, {}, async () => ({ url: 'fake://gw/x', body: streamOf(car) }))
       ).rejects.toThrow(/all gateways failed/)
       await expect(readFile(join(dir, `${other}.car`))).rejects.toThrow()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a truncated DAG whose root block is relabeled with a linkless codec', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'fp-stage-relabel-'))
+    try {
+      // Attack shape: the dag-cbor root's bytes served under a `raw` CID with
+      // the same multihash, children omitted. Raw has no links, so a
+      // multihash-only completeness walk would accept the truncated DAG.
+      const { root } = await linkedDag()
+      const relabeled = { cid: CID.createV1(raw.code, root.cid.multihash), bytes: root.bytes }
+      const car = await buildCar(root.cid, [relabeled])
+
+      await expect(
+        stageMember(root.cid.toString(), ['fake://gw'], dir, {}, async () => ({
+          url: 'fake://gw/x',
+          body: streamOf(car),
+        }))
+      ).rejects.toThrow(/codec/)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts the equivalent CIDv1 root for a CIDv0 request', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'fp-stage-v0v1-'))
+    try {
+      const data = dagPb.encode({ Links: [] })
+      const digest = await sha256.digest(data)
+      const v0 = CID.createV0(digest)
+      const v1 = CID.createV1(dagPb.code, digest)
+      const car = await buildCar(v1, [{ cid: v1, bytes: data }])
+
+      const staged = await stageMember(v0.toString(), ['fake://gw'], dir, {}, async () => ({
+        url: 'fake://gw/x',
+        body: streamOf(car),
+      }))
+      expect(staged.cid).toBe(v0.toString())
     } finally {
       await rm(dir, { recursive: true, force: true })
     }

--- a/src/test/unit/migrate-verify-car.test.ts
+++ b/src/test/unit/migrate-verify-car.test.ts
@@ -1,0 +1,203 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { calculate } from '@filoz/synapse-core/piece'
+import { CarWriter } from '@ipld/car'
+import * as dagCbor from '@ipld/dag-cbor'
+import { CID } from 'multiformats/cid'
+import * as raw from 'multiformats/codecs/raw'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { describe, expect, it } from 'vitest'
+import { stageMember, verifyCarStream } from '../../migrate/verify-car.js'
+
+// The download stage's whole safety story: every block hash-verified, the
+// DAG walked for completeness, and the commitment computed over the exact
+// bytes that land on disk. A truncated or corrupt gateway response must
+// fail loudly here, never migrate.
+
+async function rawBlock(seed: number, size = 64): Promise<{ cid: CID; bytes: Uint8Array }> {
+  const bytes = new Uint8Array(size).map((_, i) => (i * seed) % 251)
+  return { cid: CID.createV1(raw.code, await sha256.digest(bytes)), bytes }
+}
+
+async function cborBlock(value: unknown): Promise<{ cid: CID; bytes: Uint8Array }> {
+  const bytes = dagCbor.encode(value)
+  return { cid: CID.createV1(dagCbor.code, await sha256.digest(bytes)), bytes }
+}
+
+async function buildCar(root: CID, blocks: Array<{ cid: CID; bytes: Uint8Array }>): Promise<Uint8Array> {
+  const { writer, out } = CarWriter.create([root])
+  const chunks: Uint8Array[] = []
+  const drained = (async () => {
+    for await (const chunk of out) chunks.push(chunk)
+  })()
+  for (const block of blocks) await writer.put(block)
+  await writer.close()
+  await drained
+  const total = chunks.reduce((sum, c) => sum + c.length, 0)
+  const outBytes = new Uint8Array(total)
+  let offset = 0
+  for (const c of chunks) {
+    outBytes.set(c, offset)
+    offset += c.length
+  }
+  return outBytes
+}
+
+function streamOf(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  const from = (ReadableStream as unknown as { from(it: Iterable<Uint8Array>): ReadableStream<Uint8Array> }).from
+  return from([bytes])
+}
+
+function memorySink() {
+  const chunks: Uint8Array[] = []
+  return {
+    sink: {
+      async write(chunk: Uint8Array) {
+        chunks.push(chunk.slice())
+      },
+      async end() {
+        // in-memory sink; nothing to flush
+      },
+    },
+    bytes: () => {
+      const total = chunks.reduce((sum, c) => sum + c.length, 0)
+      const out = new Uint8Array(total)
+      let offset = 0
+      for (const c of chunks) {
+        out.set(c, offset)
+        offset += c.length
+      }
+      return out
+    },
+  }
+}
+
+/** A two-block DAG: a dag-cbor root linking one raw leaf. */
+async function linkedDag() {
+  const leaf = await rawBlock(7, 128)
+  const root = await cborBlock({ child: leaf.cid })
+  return { root, leaf }
+}
+
+describe('verifyCarStream', () => {
+  it('accepts a complete CAR and computes the same commitment as the SDK', async () => {
+    const { root, leaf } = await linkedDag()
+    const car = await buildCar(root.cid, [root, leaf])
+    const { sink, bytes } = memorySink()
+
+    const verified = await verifyCarStream(streamOf(car), sink)
+
+    expect(verified.rawSize).toBe(car.length)
+    expect(verified.blockCount).toBe(2)
+    expect(bytes()).toEqual(car)
+    expect(verified.pieceCid).toBe((await calculate(car)).toString())
+  })
+
+  it('rejects a CAR missing a reachable block (truncated response)', async () => {
+    const { root, leaf } = await linkedDag()
+    // The root parses cleanly, declares its link, and the leaf never arrives:
+    // the shape of a response that ended early at a block boundary.
+    const truncated = await buildCar(root.cid, [root])
+    void leaf
+    const { sink } = memorySink()
+
+    await expect(verifyCarStream(streamOf(truncated), sink)).rejects.toThrow(/incomplete/)
+  })
+
+  it('rejects a block whose bytes do not match its CID', async () => {
+    const leaf = await rawBlock(7, 128)
+    const corrupted = leaf.bytes.slice()
+    corrupted[0] = (corrupted[0] ?? 0) ^ 0xff
+    const car = await buildCar(leaf.cid, [{ cid: leaf.cid, bytes: corrupted }])
+    const { sink } = memorySink()
+
+    await expect(verifyCarStream(streamOf(car), sink)).rejects.toThrow(/does not match its multihash/)
+  })
+
+  it('aborts when the byte callback throws (the staging-budget cutoff)', async () => {
+    const leaf = await rawBlock(7, 128)
+    const car = await buildCar(leaf.cid, [leaf])
+    const { sink } = memorySink()
+
+    await expect(
+      verifyCarStream(streamOf(car), sink, {
+        onBytes: () => {
+          throw new Error('budget exhausted')
+        },
+      })
+    ).rejects.toThrow(/budget exhausted/)
+  })
+})
+
+describe('stageMember', () => {
+  it('lands a verified member atomically and reports its commitment', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'fp-stage-'))
+    try {
+      const { root, leaf } = await linkedDag()
+      const car = await buildCar(root.cid, [root, leaf])
+      const cid = root.cid.toString()
+
+      const staged = await stageMember(cid, ['fake://gw'], dir, {}, async (gateway, requested) => ({
+        url: `${gateway}/ipfs/${requested}`,
+        body: streamOf(car),
+      }))
+
+      expect(staged.memberCarPath).toBe(join(dir, `${cid}.car`))
+      expect(await readFile(staged.memberCarPath)).toEqual(Buffer.from(car))
+      expect(staged.rawSize).toBe(car.length)
+      expect(staged.pieceCid).toBe((await calculate(car)).toString())
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a CAR whose requested root is incomplete even when another declared root is complete', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'fp-stage-decoy-'))
+    try {
+      // Decoy: a complete single-block DAG declared as the first root. The
+      // requested DAG's root block is present but its leaf is not.
+      const decoy = await rawBlock(11, 64)
+      const { root: requestedRoot } = await linkedDag()
+      const requested = requestedRoot.cid.toString()
+      const { writer, out } = CarWriter.create([decoy.cid, requestedRoot.cid])
+      const chunks: Uint8Array[] = []
+      const drained = (async () => {
+        for await (const chunk of out) chunks.push(chunk)
+      })()
+      await writer.put(decoy)
+      await writer.put(requestedRoot)
+      await writer.close()
+      await drained
+      const total = chunks.reduce((sum, c) => sum + c.length, 0)
+      const car = new Uint8Array(total)
+      let offset = 0
+      for (const c of chunks) {
+        car.set(c, offset)
+        offset += c.length
+      }
+
+      await expect(
+        stageMember(requested, ['fake://gw'], dir, {}, async () => ({ url: 'fake://gw/x', body: streamOf(car) }))
+      ).rejects.toThrow(/incomplete/)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a CAR whose root is not the requested CID and leaves no file behind', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'fp-stage-root-'))
+    try {
+      const { root, leaf } = await linkedDag()
+      const car = await buildCar(root.cid, [root, leaf])
+      const other = (await rawBlock(3)).cid.toString()
+
+      await expect(
+        stageMember(other, ['fake://gw'], dir, {}, async () => ({ url: 'fake://gw/x', body: streamOf(car) }))
+      ).rejects.toThrow(/all gateways failed/)
+      await expect(readFile(join(dir, `${other}.car`))).rejects.toThrow()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
### What changed

Part 2 of 5 splitting #652. Fetches each CID as a CAR in one trustless-gateway request (`?format=car&dag-scope=all`) and verifies the untrusted response in a single pass: every block hash-checked, DAG walked from the requested root for completeness (a truncated response parses cleanly but fails the walk), piece commitment and sha256 computed over the exact bytes landed on disk via temp file + atomic rename. Transport failures map to the resume store's failure categories.

Also moves `@ipld/dag-cbor` from devDependencies to dependencies: `verify-car.ts` imports it at runtime, so published installs would fail on any dag-cbor block.

Single-request CAR fetch is deliberate, per-block Helia transport was considered and rejected for now (one request per CID vs thousands for a large DAG). If helia block-brokers grows a streaming CAR transport, this module is the swap point.

### How to verify

```
pnpm install && pnpm run build && pnpm run test:unit -- migrate-verify-car
```

### Notes / risks

Base: `feat/migrate-1-state-store`. Merge order 1 through 5.
