### PR TITLE
feat: add migrate piece packing and GC windows

### DIFF
--- a/src/migrate/gc-window.ts
+++ b/src/migrate/gc-window.ts
@@ -1,0 +1,107 @@
+/**
+ * Flush scheduling and GC-window estimation for the migrate direct-upload
+ * flow.
+ *
+ * Curio garbage-collects parked pieces that have not been added on chain.
+ * The window is roughly 2h, SP-configurable, and not discoverable, so the
+ * client flushes before its own best guess expires. The guess starts
+ * conservative and only ever moves down: a successful run proves you stayed
+ * under the window, not that the window is longer, while a detected GC proves
+ * the window is at most the collected piece's parked age.
+ *
+ * The costs are asymmetric: an early flush costs one extra transaction, a
+ * collected piece costs a full re-upload of up to MAX_UPLOAD_SIZE bytes, so
+ * every rounding here rounds toward flushing sooner.
+ *
+ * Everything in this module is pure; the orchestrator in direct-upload.ts
+ * owns the clock and the DB.
+ */
+
+import { SIZE_CONSTANTS } from '@filoz/synapse-sdk'
+
+/** FWSS `addPieces` batch cap, from the SDK. */
+export const MAX_ADD_PIECES_BATCH = SIZE_CONSTANTS.MAX_ADD_PIECES_BATCH_SIZE
+
+/**
+ * Starting guess for a provider's GC window. Half of Curio's ~2h default:
+ * under-guessing costs early flushes, over-guessing costs re-uploads.
+ */
+export const DEFAULT_ASSUMED_WINDOW_MS = 60 * 60_000
+
+/** Never trust a window guess below this: flushing degenerates to per-piece adds. */
+export const MIN_WINDOW_MS = 5 * 60_000
+
+/** Floor for the flush margin, covering commit build + confirmation. */
+export const MIN_MARGIN_MS = 10 * 60_000
+
+export type FlushReason = 'batch-full' | 'window' | 'drained'
+
+export interface FlushInput {
+  /** Parked pieces currently awaiting commit on this provider. */
+  batchSize: number
+  /** Epoch ms of the oldest parked piece, or null when the batch is empty. */
+  oldestParkedAtMs: number | null
+  nowMs: number
+  assumedWindowMs: number
+  marginMs: number
+  /** True when no further pieces will be parked (source drained). */
+  drained: boolean
+}
+
+/** Decide whether the parked batch must be committed now, and why. */
+export function shouldFlush(input: FlushInput): FlushReason | null {
+  if (input.batchSize <= 0) return null
+  if (input.batchSize >= MAX_ADD_PIECES_BATCH) return 'batch-full'
+  if (
+    input.oldestParkedAtMs != null &&
+    input.nowMs >= input.oldestParkedAtMs + input.assumedWindowMs - input.marginMs
+  ) {
+    return 'window'
+  }
+  if (input.drained) return 'drained'
+  return null
+}
+
+/**
+ * Margin derived from confirmations observed earlier in the same run: a
+ * constant cannot cover a congested chain. Doubling the worst observed commit
+ * duration leaves room for one full retry; the floor covers the first flush
+ * of a run, before any observation exists.
+ */
+export function marginFromConfirmations(observedCommitMs: number[], floorMs: number = MIN_MARGIN_MS): number {
+  if (observedCommitMs.length === 0) return floorMs
+  return Math.max(floorMs, 2 * Math.max(...observedCommitMs))
+}
+
+/**
+ * Lower the assumed window after a detected GC. The collected piece survived
+ * less than `collectedParkedAgeMs`, so the true window is at most that; 3/4
+ * of it keeps the next guess strictly inside. Never raises the estimate.
+ */
+export function lowerWindowOnGc(assumedWindowMs: number, collectedParkedAgeMs: number): number {
+  const fromEvidence = Math.floor((collectedParkedAgeMs * 3) / 4)
+  return Math.max(MIN_WINDOW_MS, Math.min(assumedWindowMs, fromEvidence))
+}
+
+/**
+ * The upload rate below which one max-size piece cannot be parked and
+ * confirmed inside the window: the flow cannot work at all under this and
+ * the caller should retain locally and upload in a burst instead.
+ */
+export function bandwidthFloorBytesPerSec(pieceSizeBytes: number, assumedWindowMs: number, marginMs: number): number {
+  const usableMs = Math.max(1, assumedWindowMs - marginMs)
+  return Math.ceil((pieceSizeBytes * 1000) / usableMs)
+}
+
+/**
+ * Parse Curio's GC rejection out of a failed addPieces/commit error. Returns
+ * the named sub-piece CID or null when the failure is something else. The
+ * message conflates "not parked" with "wrong service", so the caller should
+ * treat the result as evidence, not proof, and re-verify the whole batch
+ * (Curio returns on the FIRST miss; several collected pieces surface one at
+ * a time).
+ */
+export function collectedCidFromError(message: string): string | null {
+  const match = message.match(/subPiece CID ([A-Za-z0-9]+) not found or does not belong to service/)
+  return match?.[1] ?? null
+}

--- a/src/migrate/pack-cars.ts
+++ b/src/migrate/pack-cars.ts
@@ -1,0 +1,471 @@
+/**
+ * Pack verified member CARs into multi-root CAR pieces.
+ *
+ * Uploading one piece per source CID caps throughput on per-piece overhead
+ * (store round-trips, addPieces batch slots). Packing groups M source CIDs
+ * into one synthetic multi-root CAR and uploads that CAR as a single piece;
+ * the number of pieces (and the number of addPieces slots) drops by ~M.
+ *
+ * Pack stage:
+ *   1. Bin-pack the free verified members largest-first under the pack
+ *      target. Within each bin, members sort by parsed CID bytes (CIDv0 and
+ *      CIDv1 of the same DAG collapse), which pins the multi-root CAR's
+ *      bytes.
+ *   2. Assemble each bin from the LOCAL member files, streaming block by
+ *      block: no member CAR is ever buffered whole, so memory stays bounded
+ *      regardless of piece size. The assembled piece commitment and sha256
+ *      are computed from the same write stream.
+ *   3. Record the piece row and its member list in one transaction, then
+ *      delete the member files. A crash before the record leaves the members
+ *      intact and the bin rebuilds; a crash after it leaves redundant member
+ *      files the next run sweeps.
+ */
+
+import { createHash } from 'node:crypto'
+import { createReadStream, createWriteStream } from 'node:fs'
+import { mkdir, rename, unlink } from 'node:fs/promises'
+import path from 'node:path'
+import { hasher } from '@filoz/synapse-core/piece'
+import { SIZE_CONSTANTS } from '@filoz/synapse-sdk'
+import { CarBlockIterator, CarWriter } from '@ipld/car'
+import { CID } from 'multiformats/cid'
+import type { MigrationDB, PieceRow } from './db.js'
+import { log } from './util.js'
+
+/**
+ * Default target raw size for one assembled piece. 1016 MiB is the SDK's
+ * per-piece cap; 1000 MiB leaves headroom for the multi-root CAR header and
+ * framing the bin-packing weight ignores.
+ */
+export const DEFAULT_PACK_TARGET_BYTES = 1000n * 1024n * 1024n
+
+/** The SDK's per-piece upload cap (1016 MiB). */
+export const MAX_UPLOAD_BYTES = SIZE_CONSTANTS.MAX_UPLOAD_SIZE
+
+export interface PackPlanInput {
+  /** Source CID. */
+  cid: string
+  /** Raw CAR size in bytes: used as the bin-packing weight. */
+  rawSize: number
+}
+
+export interface PackedBin {
+  /** Member CIDs in the canonical (parsed-bytes ascending) order. */
+  memberCids: string[]
+  /** Sum of member raw sizes. Used as the planning weight, not the final CAR length. */
+  totalRawSize: number
+}
+
+/**
+ * Compare two CID strings by their parsed binary form. CIDv0 (`Qm...`) and
+ * CIDv1 (`baf...`) of the same DAG produce wildly different lexicographic
+ * orderings on the string form; comparing parsed bytes collapses that alias
+ * so a single canonical ordering exists regardless of which form the source
+ * CID was registered as.
+ */
+export function compareCidBytes(a: string, b: string): number {
+  const ba = CID.parse(a).bytes
+  const bb = CID.parse(b).bytes
+  const len = Math.min(ba.length, bb.length)
+  for (let i = 0; i < len; i += 1) {
+    const xa = ba[i] ?? 0
+    const xb = bb[i] ?? 0
+    if (xa !== xb) {
+      return xa - xb
+    }
+  }
+  return ba.length - bb.length
+}
+
+/**
+ * Largest-first bin pack under `targetSizeBytes` (raw bytes). Pieces above
+ * the target on their own are returned in the `oversized` list so the caller
+ * can ship each as a single-member bin (or refuse it past the upload cap).
+ * Within each bin the members are emitted in canonical sort order.
+ */
+export function planBins(
+  pieces: PackPlanInput[],
+  targetSizeBytes: number
+): { bins: PackedBin[]; oversized: PackPlanInput[] } {
+  if (targetSizeBytes <= 0) {
+    throw new Error(`pack target size must be > 0 (got ${targetSizeBytes})`)
+  }
+  // Reject the CID collision up-front: the same source CID appearing twice in
+  // the plan would collapse to one indexed entry on the provider side.
+  const seen = new Set<string>()
+  for (const p of pieces) {
+    if (seen.has(p.cid)) {
+      throw new Error(`duplicate source CID in pack plan: ${p.cid}`)
+    }
+    seen.add(p.cid)
+  }
+
+  const oversized: PackPlanInput[] = []
+  const fits = pieces.filter((p) => {
+    if (p.rawSize > targetSizeBytes) {
+      oversized.push(p)
+      return false
+    }
+    return true
+  })
+  // Largest first: keeps the bin count down.
+  const sorted = [...fits].sort((a, b) => b.rawSize - a.rawSize)
+  const bins: Array<{ pieces: PackPlanInput[]; used: number }> = []
+  for (const piece of sorted) {
+    let placed = false
+    for (const bin of bins) {
+      if (bin.used + piece.rawSize <= targetSizeBytes) {
+        bin.pieces.push(piece)
+        bin.used += piece.rawSize
+        placed = true
+        break
+      }
+    }
+    if (!placed) {
+      bins.push({ pieces: [piece], used: piece.rawSize })
+    }
+  }
+  return {
+    bins: bins.map((b) => ({
+      memberCids: b.pieces.map((p) => p.cid).sort(compareCidBytes),
+      totalRawSize: b.used,
+    })),
+    oversized,
+  }
+}
+
+/**
+ * Sink shape that `assembleMultiRootCar` writes through. The file-store
+ * implementation writes through to disk; tests can pass an in-memory
+ * stand-in to verify the assembly without touching the filesystem.
+ */
+export interface WritableStreamWithLength {
+  write(chunk: Uint8Array): Promise<void>
+  end(): Promise<void>
+}
+
+/**
+ * Build a multi-root CAR from member CAR streams, one block at a time.
+ *
+ * Each member is opened in canonical order, its declared roots checked
+ * against the expected CID, and its blocks copied straight into the writer:
+ * at no point is a whole member CAR held in memory, so a full-size piece
+ * assembles in constant memory. A zero-length block section in any member is
+ * a hard rejection. Curio's indexer treats it as EOF and would silently
+ * truncate everything after it (`ZeroLengthSectionAsEOF(true)`).
+ */
+export async function assembleMultiRootCar(
+  members: Array<{ cid: string; open(): ReadableStream<Uint8Array> }>,
+  sink: WritableStreamWithLength
+): Promise<{ pieceCid: string; assembledBytes: number; sha256: string; roots: string[] }> {
+  const roots = members.map((m) => CID.parse(m.cid))
+  const { writer, out } = CarWriter.create(roots)
+  const pieceHasher = hasher()
+  const sha = createHash('sha256')
+  let assembledBytes = 0
+
+  const drained = (async () => {
+    for await (const chunk of out) {
+      pieceHasher.write(chunk)
+      sha.update(chunk)
+      assembledBytes += chunk.length
+      await sink.write(chunk)
+    }
+  })()
+
+  try {
+    for (const member of members) {
+      const expected = CID.parse(member.cid)
+      const reader = await CarBlockIterator.fromIterable(toAsyncIterable(member.open()))
+      const memberRoots = await reader.getRoots()
+      if (!memberRoots.some((r) => r.equals(expected) || r.toString() === member.cid)) {
+        throw new Error(
+          `member ${member.cid}: CAR root mismatch (declares [${memberRoots.map((r) => r.toString()).join(', ')}])`
+        )
+      }
+      for await (const block of reader) {
+        if (block.bytes.length === 0) {
+          throw new Error(
+            `member ${member.cid}: zero-length block section at cid ${block.cid.toString()}; indexer would truncate`
+          )
+        }
+        await writer.put(block)
+      }
+    }
+  } catch (err) {
+    // Release the writer, the drain loop, and the sink's file descriptor
+    // before surfacing the member error; their own failures are secondary.
+    await writer.close().catch(() => undefined)
+    await drained.catch(() => undefined)
+    await sink.end().catch(() => undefined)
+    throw err
+  }
+  await writer.close()
+  await drained
+  await sink.end()
+
+  return {
+    pieceCid: pieceHasher.finalize().toString(),
+    assembledBytes,
+    sha256: sha.digest('hex'),
+    roots: roots.map((r) => r.toString()),
+  }
+}
+
+async function* toAsyncIterable(body: ReadableStream<Uint8Array>): AsyncIterable<Uint8Array> {
+  for await (const chunk of body as unknown as AsyncIterable<Uint8Array>) {
+    yield chunk
+  }
+}
+
+/**
+ * Stream-write sink backed by a file under the staging directory. A write or
+ * open failure unlinks the partial file and surfaces the original error.
+ */
+export function createCarStoreSink(filePath: string, onBytes?: (delta: number) => void): WritableStreamWithLength {
+  const stream = createWriteStream(filePath)
+  let firstError: Error | null = null
+  let cleanupDone = false
+  const unlinkPartial = async () => {
+    if (cleanupDone) return
+    cleanupDone = true
+    await unlink(filePath).catch(() => undefined)
+  }
+  stream.on('error', (err) => {
+    if (firstError == null) firstError = err
+    void unlinkPartial()
+  })
+  return {
+    write(chunk) {
+      if (firstError != null) return Promise.reject(firstError)
+      onBytes?.(chunk.length)
+      return new Promise<void>((resolve, reject) => {
+        if (firstError != null) {
+          reject(firstError)
+          return
+        }
+        const onError = (err: Error) => reject(err)
+        stream.once('error', onError)
+        const cleanup = () => stream.off('error', onError)
+        const ok = stream.write(chunk, (err) => {
+          cleanup()
+          if (err) reject(err)
+          else if (ok) resolve()
+        })
+        if (!ok)
+          stream.once('drain', () => {
+            cleanup()
+            resolve()
+          })
+      })
+    },
+    async end() {
+      if (firstError != null) {
+        await unlinkPartial()
+        throw firstError
+      }
+      await new Promise<void>((resolve, reject) => {
+        stream.end((err?: Error | null) => (err ? reject(err) : resolve()))
+      }).catch(async (err) => {
+        await unlinkPartial()
+        throw err
+      })
+    },
+  }
+}
+
+export interface PackCarsOptions {
+  /** Per-piece raw-size budget. Default `DEFAULT_PACK_TARGET_BYTES`. */
+  targetSizeBytes?: number
+  /** Directory under which assembled CAR files are persisted. */
+  carStore: string
+  /** Byte-accounting hook for assembly writes (the disk-budget counter). */
+  onBytesStaged?: ((delta: number) => void) | undefined
+  /** Byte-accounting hook fired as each member file is deleted post-record. */
+  onMemberEvicted?: ((bytes: number) => void) | undefined
+}
+
+export interface PackCarsSummary {
+  bins: number
+  built: number
+  failed: number
+  /** Source CIDs skipped because they exceed the per-piece upload cap. */
+  overCap: string[]
+  /**
+   * Source CIDs whose bin failed to assemble. They stay `done` and re-enter
+   * the free pool on the next run; a CID that keeps reappearing here has a
+   * permanent assembly problem the operator must investigate. Surfaced
+   * per-CID because `failed` counts bins, not CIDs.
+   */
+  failedMemberCids: string[]
+}
+
+/** The bin assembler `runPackCars` drives; injectable so the pack loop's
+ *  success/failure accounting is testable without real member files. */
+export type BinBuilder = (
+  bin: PackedBin,
+  carStore: string,
+  memberPaths: Map<string, string>,
+  onBytes?: (delta: number) => void
+) => Promise<{ pieceCid: string; assembledBytes: number; sha256: string; filePath: string }>
+
+/**
+ * Drive the pack stage: bin the free verified members, assemble each bin
+ * from local member files, record it, delete the member files. Idempotent:
+ * re-running picks up only members not yet locked into a piece.
+ */
+export async function runPackCars(
+  db: MigrationDB,
+  opts: PackCarsOptions,
+  buildBin: BinBuilder = buildOneBin
+): Promise<PackCarsSummary> {
+  const target = opts.targetSizeBytes ?? Number(DEFAULT_PACK_TARGET_BYTES)
+  if (target > MAX_UPLOAD_BYTES) {
+    throw new Error(`--pack-target-size ${target} exceeds the per-piece upload cap ${MAX_UPLOAD_BYTES}`)
+  }
+  await mkdir(opts.carStore, { recursive: true })
+
+  // Snapshot the free members once. planBins partitions them into disjoint
+  // bins, so this map stays valid for every bin even as each
+  // recordBuiltSubPiece locks its own members.
+  const free = db.donePiecesFreeForPacking()
+  const piecesByCid = new Map<string, PieceRow>(free.map((p) => [p.cid, p]))
+  const memberPaths = new Map<string, string>()
+  for (const p of free) {
+    if (p.memberCarPath != null) memberPaths.set(p.cid, p.memberCarPath)
+  }
+  const inputsForBuild: PackPlanInput[] = free
+    .filter((p) => p.memberCarPath != null)
+    .map((p) => ({ cid: p.cid, rawSize: p.rawSize ?? 0 }))
+  const { bins, oversized } = planBins(inputsForBuild, target)
+
+  // An oversized-for-bin member still ships as its own single-member piece,
+  // as long as it fits one uploadable piece. Anything over the per-piece cap
+  // genuinely cannot migrate on this path: mark it terminal and reclaim its
+  // staged bytes, or it would sit in the free pool consuming budget forever.
+  const overCap: string[] = []
+  for (const p of oversized) {
+    if (p.rawSize > MAX_UPLOAD_BYTES) {
+      log(`! ${p.cid} (${p.rawSize} bytes) exceeds the ${MAX_UPLOAD_BYTES}-byte upload cap; not migrated`)
+      overCap.push(p.cid)
+      db.markOversized([p.cid])
+      const memberPath = memberPaths.get(p.cid)
+      if (memberPath != null) {
+        const gone = await unlink(memberPath).then(
+          () => true,
+          () => false
+        )
+        if (gone) opts.onMemberEvicted?.(p.rawSize)
+      }
+      continue
+    }
+    bins.push({ memberCids: [p.cid], totalRawSize: p.rawSize })
+  }
+
+  const summary: PackCarsSummary = { bins: bins.length, built: 0, failed: 0, overCap, failedMemberCids: [] }
+  for (const bin of bins) {
+    // Track this bin's writes so a failed assembly returns its bytes to the
+    // budget along with the unlinked partial file.
+    let binWritten = 0
+    const onBytes = (delta: number): void => {
+      binWritten += delta
+      opts.onBytesStaged?.(delta)
+    }
+    try {
+      const built = await buildBin(bin, opts.carStore, memberPaths, onBytes)
+      // The multi-root header and framing add bytes the planning weight
+      // ignores; the assembled length is what the SDK caps.
+      if (built.assembledBytes > MAX_UPLOAD_BYTES) {
+        await unlink(built.filePath).catch(() => undefined)
+        throw new Error(
+          `assembled piece ${built.pieceCid} is ${built.assembledBytes} bytes, over the ${MAX_UPLOAD_BYTES}-byte cap; ` +
+            `lower --pack-target-size`
+        )
+      }
+      // One transaction inserts the piece row alongside its members. A crash
+      // anywhere before this returns leaves no partial DB state: the CAR
+      // file on disk is the only stranded artifact, and the next pack pass
+      // rebuilds it.
+      db.recordBuiltSubPiece({
+        subPieceCid: built.pieceCid,
+        assembledCarLength: built.assembledBytes,
+        targetSizeBytes: target,
+        carPath: built.filePath,
+        assembledSha256: built.sha256,
+        members: bin.memberCids.map((cid) => ({
+          cid,
+          rawSize: piecesByCid.get(cid)?.rawSize ?? null,
+          sha256: piecesByCid.get(cid)?.memberSha256 ?? null,
+        })),
+      })
+      // Members are redundant now that the recorded piece holds their bytes.
+      // Budget is returned only for files actually gone; a file that resists
+      // deletion keeps occupying real disk and must keep counting.
+      for (const cid of bin.memberCids) {
+        const memberPath = memberPaths.get(cid)
+        if (memberPath != null) {
+          const gone = await unlink(memberPath).then(
+            () => true,
+            (err: NodeJS.ErrnoException) => err.code === 'ENOENT'
+          )
+          if (gone) opts.onMemberEvicted?.(piecesByCid.get(cid)?.rawSize ?? 0)
+        }
+      }
+      log(`  + piece ${built.pieceCid} (${built.assembledBytes} bytes, ${bin.memberCids.length} member(s))`)
+      summary.built += 1
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      // No DB write: the members stay `done` and a transient failure recovers
+      // on the next pass. The partial bin file is gone, so its bytes return
+      // to the budget.
+      if (binWritten > 0) opts.onBytesStaged?.(-binWritten)
+      summary.failedMemberCids.push(...bin.memberCids)
+      log(`  ! piece build failed (${bin.memberCids.length} member(s): ${bin.memberCids.join(', ')}): ${message}`)
+      summary.failed += 1
+    }
+  }
+
+  return summary
+}
+
+async function buildOneBin(
+  bin: PackedBin,
+  carStore: string,
+  memberPaths: Map<string, string>,
+  onBytes?: (delta: number) => void
+): Promise<{ pieceCid: string; assembledBytes: number; sha256: string; filePath: string }> {
+  const members = bin.memberCids.map((cid) => {
+    const memberPath = memberPaths.get(cid)
+    if (memberPath == null) {
+      throw new Error(`member ${cid} has no staged CAR file`)
+    }
+    return {
+      cid,
+      open: () => webStreamFromFile(memberPath),
+    }
+  })
+
+  const tmpName = `pack-${process.pid}-${Date.now()}.car`
+  const tmpPath = path.join(carStore, tmpName)
+  const sink = createCarStoreSink(tmpPath, onBytes)
+  try {
+    const result = await assembleMultiRootCar(members, sink)
+    const finalPath = path.join(carStore, `${result.pieceCid}.car`)
+    // Rename through the same directory so it's an atomic move on local FS.
+    await rename(tmpPath, finalPath)
+    return {
+      pieceCid: result.pieceCid,
+      assembledBytes: result.assembledBytes,
+      sha256: result.sha256,
+      filePath: finalPath,
+    }
+  } catch (err) {
+    await unlink(tmpPath).catch(() => undefined)
+    throw err
+  }
+}
+
+function webStreamFromFile(filePath: string): ReadableStream<Uint8Array> {
+  const from = (ReadableStream as unknown as { from(it: AsyncIterable<Uint8Array>): ReadableStream<Uint8Array> }).from
+  return from(createReadStream(filePath) as unknown as AsyncIterable<Uint8Array>)
+}

--- a/src/migrate/pack-cars.ts
+++ b/src/migrate/pack-cars.ts
@@ -30,7 +30,7 @@ import { SIZE_CONSTANTS } from '@filoz/synapse-sdk'
 import { CarBlockIterator, CarWriter } from '@ipld/car'
 import { CID } from 'multiformats/cid'
 import type { MigrationDB, PieceRow } from './db.js'
-import { log } from './util.js'
+import { log } from '../utils/cli-logger.js'
 
 /**
  * Default target raw size for one assembled piece. 1016 MiB is the SDK's
@@ -363,7 +363,7 @@ export async function runPackCars(
   const overCap: string[] = []
   for (const p of oversized) {
     if (p.rawSize > MAX_UPLOAD_BYTES) {
-      log(`! ${p.cid} (${p.rawSize} bytes) exceeds the ${MAX_UPLOAD_BYTES}-byte upload cap; not migrated`)
+      log.message(`! ${p.cid} (${p.rawSize} bytes) exceeds the ${MAX_UPLOAD_BYTES}-byte upload cap; not migrated`)
       overCap.push(p.cid)
       db.markOversized([p.cid])
       const memberPath = memberPaths.get(p.cid)
@@ -434,7 +434,7 @@ export async function runPackCars(
           if (gone) opts.onMemberEvicted?.(piecesByCid.get(cid)?.rawSize ?? 0)
         }
       }
-      log(`  + piece ${built.pieceCid} (${built.assembledBytes} bytes, ${bin.memberCids.length} member(s))`)
+      log.message(`  + piece ${built.pieceCid} (${built.assembledBytes} bytes, ${bin.memberCids.length} member(s))`)
       summary.built += 1
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -444,7 +444,7 @@ export async function runPackCars(
       if (builtPath != null) await unlink(builtPath).catch(() => undefined)
       if (binWritten > 0) opts.onBytesStaged?.(-binWritten)
       summary.failedMemberCids.push(...bin.memberCids)
-      log(`  ! piece build failed (${bin.memberCids.length} member(s): ${bin.memberCids.join(', ')}): ${message}`)
+      log.message(`  ! piece build failed (${bin.memberCids.length} member(s): ${bin.memberCids.join(', ')}): ${message}`)
       summary.failed += 1
     }
   }

--- a/src/migrate/pack-cars.ts
+++ b/src/migrate/pack-cars.ts
@@ -57,15 +57,21 @@ export interface PackedBin {
 }
 
 /**
- * Compare two CID strings by their parsed binary form. CIDv0 (`Qm...`) and
- * CIDv1 (`baf...`) of the same DAG produce wildly different lexicographic
- * orderings on the string form; comparing parsed bytes collapses that alias
- * so a single canonical ordering exists regardless of which form the source
- * CID was registered as.
+ * Compare two CID strings by multihash bytes. CIDv0 (`Qm...`) and CIDv1
+ * (`baf...`) of the same DAG produce wildly different lexicographic
+ * orderings on the string form, and even parsed CID bytes differ (v0 is the
+ * bare multihash); comparing multihashes collapses the alias so a single
+ * canonical ordering exists regardless of which form the source CID was
+ * registered as.
  */
 export function compareCidBytes(a: string, b: string): number {
-  const ba = CID.parse(a).bytes
-  const bb = CID.parse(b).bytes
+  return compareMultihashBytes(CID.parse(a), CID.parse(b))
+}
+
+/** Order two CIDs by multihash bytes; v0 and v1 of the same block compare equal. */
+function compareMultihashBytes(a: CID, b: CID): number {
+  const ba = a.multihash.bytes
+  const bb = b.multihash.bytes
   const len = Math.min(ba.length, bb.length)
   for (let i = 0; i < len; i += 1) {
     const xa = ba[i] ?? 0
@@ -150,9 +156,11 @@ export interface WritableStreamWithLength {
  * Each member is opened in canonical order, its declared roots checked
  * against the expected CID, and its blocks copied straight into the writer:
  * at no point is a whole member CAR held in memory, so a full-size piece
- * assembles in constant memory. A zero-length block section in any member is
- * a hard rejection. Curio's indexer treats it as EOF and would silently
- * truncate everything after it (`ZeroLengthSectionAsEOF(true)`).
+ * assembles in constant memory. Zero-length *sections* (the Curio indexer's
+ * `ZeroLengthSectionAsEOF` truncation hazard) need no guard here: a
+ * section's length always covers its CID bytes, so even an empty block is a
+ * positive-length section, and `@ipld/car` rejects a true zero-length
+ * section in the parser.
  */
 export async function assembleMultiRootCar(
   members: Array<{ cid: string; open(): ReadableStream<Uint8Array> }>,
@@ -178,18 +186,18 @@ export async function assembleMultiRootCar(
       const expected = CID.parse(member.cid)
       const reader = await CarBlockIterator.fromIterable(toAsyncIterable(member.open()))
       const memberRoots = await reader.getRoots()
-      if (!memberRoots.some((r) => r.equals(expected) || r.toString() === member.cid)) {
+      // Multihash comparison: a member registered as CIDv0 may sit in a CAR
+      // whose gateway declared the equivalent CIDv1 root.
+      if (!memberRoots.some((r) => compareMultihashBytes(r, expected) === 0)) {
         throw new Error(
           `member ${member.cid}: CAR root mismatch (declares [${memberRoots.map((r) => r.toString()).join(', ')}])`
         )
       }
       for await (const block of reader) {
-        if (block.bytes.length === 0) {
-          throw new Error(
-            `member ${member.cid}: zero-length block section at cid ${block.cid.toString()}; indexer would truncate`
-          )
-        }
-        await writer.put(block)
+        // Raced against the drain loop: if the sink dies (disk full), the
+        // `out` channel stops being consumed and this put would otherwise
+        // park forever with the failure unobserved.
+        await Promise.race([writer.put(block), drained])
       }
     }
   } catch (err) {
@@ -247,16 +255,25 @@ export function createCarStoreSink(filePath: string, onBytes?: (delta: number) =
         const onError = (err: Error) => reject(err)
         stream.once('error', onError)
         const cleanup = () => stream.off('error', onError)
+        // A buffered write resolves immediately; a flush failure lands in
+        // `firstError` and fails the next write or end(). Only backpressure
+        // defers (to `drain`): waiting out each flush would serialize
+        // assembly on disk latency.
         const ok = stream.write(chunk, (err) => {
-          cleanup()
-          if (err) reject(err)
-          else if (ok) resolve()
+          if (err) {
+            cleanup()
+            reject(err)
+          }
         })
-        if (!ok)
+        if (ok) {
+          cleanup()
+          resolve()
+        } else {
           stream.once('drain', () => {
             cleanup()
             resolve()
           })
+        }
       })
     },
     async end() {
@@ -367,12 +384,17 @@ export async function runPackCars(
     // Track this bin's writes so a failed assembly returns its bytes to the
     // budget along with the unlinked partial file.
     let binWritten = 0
+    // Set while a finalized CAR exists on disk without a DB row; the catch
+    // unlinks it so a failed record does not strand a file whose bytes were
+    // refunded to the budget.
+    let builtPath: string | null = null
     const onBytes = (delta: number): void => {
       binWritten += delta
       opts.onBytesStaged?.(delta)
     }
     try {
       const built = await buildBin(bin, opts.carStore, memberPaths, onBytes)
+      builtPath = built.filePath
       // The multi-root header and framing add bytes the planning weight
       // ignores; the assembled length is what the SDK caps.
       if (built.assembledBytes > MAX_UPLOAD_BYTES) {
@@ -398,6 +420,7 @@ export async function runPackCars(
           sha256: piecesByCid.get(cid)?.memberSha256 ?? null,
         })),
       })
+      builtPath = null
       // Members are redundant now that the recorded piece holds their bytes.
       // Budget is returned only for files actually gone; a file that resists
       // deletion keeps occupying real disk and must keep counting.
@@ -416,8 +439,9 @@ export async function runPackCars(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       // No DB write: the members stay `done` and a transient failure recovers
-      // on the next pass. The partial bin file is gone, so its bytes return
-      // to the budget.
+      // on the next pass. A finalized CAR without a DB row is unlinked here
+      // so the refund below matches what is actually on disk.
+      if (builtPath != null) await unlink(builtPath).catch(() => undefined)
       if (binWritten > 0) opts.onBytesStaged?.(-binWritten)
       summary.failedMemberCids.push(...bin.memberCids)
       log(`  ! piece build failed (${bin.memberCids.length} member(s): ${bin.memberCids.join(', ')}): ${message}`)

--- a/src/test/unit/migrate-gc-window.test.ts
+++ b/src/test/unit/migrate-gc-window.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import {
+  bandwidthFloorBytesPerSec,
+  collectedCidFromError,
+  DEFAULT_ASSUMED_WINDOW_MS,
+  lowerWindowOnGc,
+  MAX_ADD_PIECES_BATCH,
+  MIN_MARGIN_MS,
+  MIN_WINDOW_MS,
+  marginFromConfirmations,
+  shouldFlush,
+} from '../../migrate/gc-window.js'
+
+// Locks in the flush-scheduling rules: every tie breaks toward flushing
+// sooner, and the window estimate only ever moves down.
+
+const base = {
+  batchSize: 1,
+  oldestParkedAtMs: 0,
+  nowMs: 0,
+  assumedWindowMs: DEFAULT_ASSUMED_WINDOW_MS,
+  marginMs: MIN_MARGIN_MS,
+  drained: false,
+}
+
+describe('shouldFlush', () => {
+  it('never flushes an empty batch, even drained', () => {
+    expect(shouldFlush({ ...base, batchSize: 0, drained: true })).toBeNull()
+  })
+
+  it('flushes a full batch regardless of timers', () => {
+    expect(shouldFlush({ ...base, batchSize: MAX_ADD_PIECES_BATCH })).toBe('batch-full')
+  })
+
+  it('includes the margin in window expiry', () => {
+    const edge = DEFAULT_ASSUMED_WINDOW_MS - MIN_MARGIN_MS
+    expect(shouldFlush({ ...base, nowMs: edge - 1 })).toBeNull()
+    expect(shouldFlush({ ...base, nowMs: edge })).toBe('window')
+  })
+
+  it('flushes a partial batch when drained', () => {
+    expect(shouldFlush({ ...base, drained: true })).toBe('drained')
+  })
+})
+
+describe('marginFromConfirmations', () => {
+  it('uses the floor without observations, 2x worst with', () => {
+    expect(marginFromConfirmations([])).toBe(MIN_MARGIN_MS)
+    expect(marginFromConfirmations([1_000, 2_000])).toBe(MIN_MARGIN_MS)
+    const slow = 20 * 60_000
+    expect(marginFromConfirmations([1_000, slow])).toBe(2 * slow)
+  })
+})
+
+describe('lowerWindowOnGc', () => {
+  it('lowers from evidence, never raises, floors', () => {
+    const hourMs = 60 * 60_000
+    expect(lowerWindowOnGc(hourMs, 40 * 60_000)).toBe(30 * 60_000)
+    // Evidence above the current guess must not raise it.
+    expect(lowerWindowOnGc(hourMs, 10 * hourMs)).toBe(hourMs)
+    expect(lowerWindowOnGc(hourMs, 0)).toBe(MIN_WINDOW_MS)
+  })
+})
+
+describe('bandwidthFloorBytesPerSec', () => {
+  it('matches the expected order of magnitude', () => {
+    // ~1016 MiB over 2h minus 10 min margin ≈ 1.3 Mbit/s ≈ 162 KB/s.
+    const floor = bandwidthFloorBytesPerSec(1_065_353_216, 2 * 60 * 60_000, 10 * 60_000)
+    expect(floor).toBeGreaterThan(100_000)
+    expect(floor).toBeLessThan(250_000)
+  })
+})
+
+describe('collectedCidFromError', () => {
+  it('parses the Curio GC rejection and nothing else', () => {
+    const cid = 'bafkzcibf3ck4uais4fgennh4hbfx5z3i6hue4xgq2cdeamtus4hjbsrjs5lf2azbxmsa'
+    expect(
+      collectedCidFromError(
+        `Failed to process request: subPiece CID ${cid} not found or does not belong to service foo`
+      )
+    ).toBe(cid)
+    expect(collectedCidFromError('insufficient funds')).toBeNull()
+  })
+})

--- a/src/test/unit/migrate-piece-hasher.test.ts
+++ b/src/test/unit/migrate-piece-hasher.test.ts
@@ -1,0 +1,177 @@
+import { calculate, hasher } from '@filoz/synapse-core/piece'
+import { CarWriter } from '@ipld/car'
+import { CID } from 'multiformats/cid'
+import * as raw from 'multiformats/codecs/raw'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { describe, expect, it } from 'vitest'
+import { assembleMultiRootCar, planBins, type WritableStreamWithLength } from '../../migrate/pack-cars.js'
+
+// The migrate runner computes piece commitments locally (streaming, chunked
+// writes) and the SDK recomputes them at store() time over the same bytes.
+// The two must agree for every write pattern, or the provider rejects the
+// upload with a commP mismatch.
+
+describe('local piece hasher equals the SDK calculation', () => {
+  it('agrees across fr32 padding edges', async () => {
+    // 0/1: degenerate; 64/65 and 127/128: fr32 254-bit padding boundaries;
+    // 1 MiB + 3: multi-chunk write paths; the rest: a mid-size payload.
+    const sizes = [0, 1, 64, 65, 127, 128, 1024, 1048579]
+    for (const size of sizes) {
+      const data = new Uint8Array(size).map((_, i) => (i * 7) % 251)
+      const streamed = hasher().write(data).finalize().toString()
+      const sdk = (await calculate(data)).toString()
+      expect(streamed, `hashers diverged at ${size} bytes`).toBe(sdk)
+    }
+  })
+
+  it('is chunk-size independent', async () => {
+    // Streaming hashers classically diverge on awkward write boundaries, not
+    // on single-shot input. Feed the same payload in prime-sized chunks and
+    // compare to the single write.
+    const data = new Uint8Array(1048579).map((_, i) => (i * 31) % 251)
+    const whole = (await calculate(data)).toString()
+    for (const chunkSize of [1024, 997, 65537]) {
+      const h = hasher()
+      for (let off = 0; off < data.length; off += chunkSize) {
+        h.write(data.subarray(off, Math.min(off + chunkSize, data.length)))
+      }
+      expect(h.finalize().toString(), `chunk size ${chunkSize} diverged from single-shot`).toBe(whole)
+    }
+  })
+})
+
+async function rawBlock(seed: number, size: number): Promise<{ cid: CID; bytes: Uint8Array }> {
+  const bytes = new Uint8Array(size).map((_, i) => (i * seed) % 251)
+  const digest = await sha256.digest(bytes)
+  return { cid: CID.createV1(raw.code, digest), bytes }
+}
+
+async function memberCar(seed: number): Promise<{ cid: string; open(): ReadableStream<Uint8Array> }> {
+  const block = await rawBlock(seed, 256 + seed)
+  const { writer, out } = CarWriter.create([block.cid])
+  const chunks: Uint8Array[] = []
+  const drained = (async () => {
+    for await (const chunk of out) chunks.push(chunk)
+  })()
+  await writer.put(block)
+  await writer.close()
+  await drained
+  const from = (ReadableStream as unknown as { from(it: Iterable<Uint8Array>): ReadableStream<Uint8Array> }).from
+  return { cid: block.cid.toString(), open: () => from([...chunks]) }
+}
+
+function memorySink(): { sink: WritableStreamWithLength; bytes: () => Uint8Array } {
+  const chunks: Uint8Array[] = []
+  return {
+    sink: {
+      async write(chunk) {
+        chunks.push(chunk.slice())
+      },
+      async end() {
+        // in-memory sink; nothing to flush
+      },
+    },
+    bytes: () => {
+      const total = chunks.reduce((sum, c) => sum + c.length, 0)
+      const out = new Uint8Array(total)
+      let offset = 0
+      for (const c of chunks) {
+        out.set(c, offset)
+        offset += c.length
+      }
+      return out
+    },
+  }
+}
+
+describe('assembleMultiRootCar', () => {
+  it("computes a piece CID equal to the SDK's over the assembled bytes", async () => {
+    const members = [await memberCar(3), await memberCar(5), await memberCar(7)]
+    const { sink, bytes } = memorySink()
+    const result = await assembleMultiRootCar(members, sink)
+
+    const assembled = bytes()
+    expect(result.assembledBytes).toBe(assembled.length)
+    expect(result.roots).toEqual(members.map((m) => m.cid))
+    const sdk = (await calculate(assembled)).toString()
+    expect(result.pieceCid).toBe(sdk)
+  })
+
+  it('rejects a member whose CAR is not rooted at its CID', async () => {
+    const member = await memberCar(3)
+    const other = await memberCar(5)
+    const { sink } = memorySink()
+    await expect(assembleMultiRootCar([{ cid: other.cid, open: member.open }], sink)).rejects.toThrow(
+      /CAR root mismatch/
+    )
+  })
+})
+
+describe('runPackCars oversized handling', () => {
+  it('marks an over-cap CID terminal and reclaims its staged bytes', async () => {
+    const { mkdtemp, rm, writeFile, readFile } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const { MigrationDB } = await import('../../migrate/db.js')
+    const { MAX_UPLOAD_BYTES, runPackCars } = await import('../../migrate/pack-cars.js')
+
+    const dir = await mkdtemp(join(tmpdir(), 'fp-overcap-'))
+    const db = new MigrationDB(join(dir, 'migrate.db'), 'calibration:0xabc')
+    try {
+      const cid = 'bafkzcibf3ck4uais4fgennh4hbfx5z3i6hue4xgq2cdeamtus4hjbsrjs5lf2azbxmsa'
+      const memberCarPath = join(dir, 'member.car')
+      await writeFile(memberCarPath, new Uint8Array(8))
+      db.addCids([cid])
+      db.recordPieceSuccess(cid, {
+        pieceCid: cid,
+        rawSize: MAX_UPLOAD_BYTES + 1,
+        gateway: 'g',
+        url: 'fake://gw/x',
+        memberCarPath,
+        memberSha256: 'sha',
+      })
+
+      const freed: number[] = []
+      const summary = await runPackCars(db, {
+        targetSizeBytes: 1000,
+        carStore: join(dir, 'cars'),
+        onMemberEvicted: (bytes) => freed.push(bytes),
+      })
+
+      expect(summary.overCap).toEqual([cid])
+      // Terminal: out of the free pool and the retry queue, budget returned,
+      // member file gone.
+      expect(db.counts().oversized).toBe(1)
+      expect(db.pendingCids()).toEqual([])
+      expect(db.freeMemberBytes()).toBe(0)
+      expect(freed).toEqual([MAX_UPLOAD_BYTES + 1])
+      await expect(readFile(memberCarPath)).rejects.toThrow()
+    } finally {
+      db.close()
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('planBins', () => {
+  it('rejects duplicate source CIDs', () => {
+    expect(() =>
+      planBins(
+        [
+          { cid: 'bafkzcibewpkqwewyhz3yxutlxbpt2nkb6si5qilg4qqtzzij32uw7ammsc73a4wkgi', rawSize: 1 },
+          { cid: 'bafkzcibewpkqwewyhz3yxutlxbpt2nkb6si5qilg4qqtzzij32uw7ammsc73a4wkgi', rawSize: 1 },
+        ],
+        10
+      )
+    ).toThrow(/duplicate source CID/)
+  })
+
+  it('returns pieces above the target as oversized', () => {
+    const small = { cid: 'bafkzcibewpkqwewyhz3yxutlxbpt2nkb6si5qilg4qqtzzij32uw7ammsc73a4wkgi', rawSize: 4 }
+    const big = { cid: 'bafkzcibf3ck4uais4fgennh4hbfx5z3i6hue4xgq2cdeamtus4hjbsrjs5lf2azbxmsa', rawSize: 100 }
+    const { bins, oversized } = planBins([small, big], 10)
+    expect(bins).toHaveLength(1)
+    expect(bins[0]?.memberCids).toEqual([small.cid])
+    expect(oversized).toEqual([big])
+  })
+})

--- a/src/test/unit/migrate-piece-hasher.test.ts
+++ b/src/test/unit/migrate-piece-hasher.test.ts
@@ -105,6 +105,29 @@ describe('assembleMultiRootCar', () => {
       /CAR root mismatch/
     )
   })
+
+  it('assembles a member containing an empty block', async () => {
+    // An empty file is a zero-byte raw block. Its CAR section still has a
+    // positive length (the CID bytes), so it is not the zero-length-section
+    // truncation hazard and must pack.
+    const empty = new Uint8Array(0)
+    const cid = CID.createV1(raw.code, await sha256.digest(empty))
+    const { writer, out } = CarWriter.create([cid])
+    const chunks: Uint8Array[] = []
+    const drained = (async () => {
+      for await (const chunk of out) chunks.push(chunk)
+    })()
+    await writer.put({ cid, bytes: empty })
+    await writer.close()
+    await drained
+    const from = (ReadableStream as unknown as { from(it: Iterable<Uint8Array>): ReadableStream<Uint8Array> }).from
+    const member = { cid: cid.toString(), open: () => from([...chunks]) }
+
+    const { sink, bytes } = memorySink()
+    const result = await assembleMultiRootCar([member], sink)
+    expect(result.roots).toEqual([cid.toString()])
+    expect((await calculate(bytes())).toString()).toBe(result.pieceCid)
+  })
 })
 
 describe('runPackCars oversized handling', () => {


### PR DESCRIPTION
### What changed

Part 3 of 5 splitting #652. Bin-packs verified member CARs largest-first under the ~1000MiB piece target, then streams each bin disk-to-disk into one multi-root CAR in constant memory, computing the piece commitment and sha256 from the same write stream. Pieces and their members are recorded in one `migrate.db` transaction before member files are deleted, so a crash between the two never loses track of bytes.

`gc-window.ts` is the pure flush policy for batched `addPieces` commits: flush on batch cap (40), estimated Curio GC-window expiry, or source drain, with the window estimate tightened from observed confirmations and GC rejections.

### How to verify

```
pnpm install && pnpm run build && pnpm run test:unit
```

`migrate-gc-window` and `migrate-piece-hasher` cover the policy and the packed-CAR commitment math.

### Notes / risks

Base: `feat/migrate-2-fetch-verify`. Merge order 1 through 5. Curio reads pieces with `ZeroLengthSectionAsEOF(true)`, so a zero-length CAR section would truncate the piece; none can occur here because a section always contains its CID bytes and `@ipld/car` rejects a zero-length section while parsing the member.
