### PR TITLE
test: use bigint literals for SDK bigint fields

### DIFF
--- a/src/test/unit/data-set.test.ts
+++ b/src/test/unit/data-set.test.ts
@@ -217,6 +217,10 @@ type EnhancedDataSetFixture = Record<string, unknown> & {
   isLive?: boolean
   isManaged?: boolean
   withCDN?: boolean
+  /** bigint to mirror synapse-sdk's DataSetInfo; number literals here misrepresent SDK data. */
+  pdpEndEpoch?: bigint
+  /** bigint to mirror synapse-sdk's DataSetInfo. */
+  commissionBps?: bigint
   metadata: Record<string, string>
   payer: string
 }
@@ -258,8 +262,8 @@ describe('runDataSetCommand', () => {
     payer: '0x123',
     payee: '0x456',
     serviceProvider: '0xservice',
-    commissionBps: 100,
-    pdpEndEpoch: 0,
+    commissionBps: 100n,
+    pdpEndEpoch: 0n,
     cdnEndEpoch: 0,
     metadata: {
       [METADATA_KEYS.WITH_IPFS_INDEXING]: '',
@@ -472,8 +476,8 @@ describe('runTerminateDataSetCommand', () => {
     payer: '0xtest',
     payee: '0x456',
     serviceProvider: '0xservice',
-    commissionBps: 100,
-    pdpEndEpoch: 0,
+    commissionBps: 100n,
+    pdpEndEpoch: 0n,
     cdnEndEpoch: 0,
     metadata: {
       [METADATA_KEYS.WITH_IPFS_INDEXING]: '',
@@ -542,7 +546,7 @@ describe('runTerminateDataSetCommand', () => {
 
   it('terminates a dataset and waits for confirmation', async () => {
     state.pieceList = [{ pieceId: 0n, pieceCid: 'bafkpiece0' }]
-    const updatedDataSet = { ...terminatableDataSet, isLive: false, pdpEndEpoch: 5000 }
+    const updatedDataSet = { ...terminatableDataSet, isLive: false, pdpEndEpoch: 5000n }
     mockGetPdpDataSet
       .mockResolvedValueOnce(toPdpDataSet(terminatableDataSet, provider))
       .mockResolvedValueOnce(toPdpDataSet(updatedDataSet, provider))
@@ -603,7 +607,7 @@ describe('runTerminateDataSetCommand', () => {
   })
 
   it('reports already-terminated datasets without error', async () => {
-    const terminatedDataSet = { ...terminatableDataSet, pdpEndEpoch: 5000 }
+    const terminatedDataSet = { ...terminatableDataSet, pdpEndEpoch: 5000n }
     mockGetPdpDataSet.mockResolvedValue(toPdpDataSet(terminatedDataSet, provider))
 
     await runTerminateDataSetCommand(158, {
@@ -640,8 +644,8 @@ describe('runDataSetPieceStatusCommand', () => {
     payer: '0x123',
     payee: '0x456',
     serviceProvider: '0xservice',
-    commissionBps: 100,
-    pdpEndEpoch: 0,
+    commissionBps: 100n,
+    pdpEndEpoch: 0n,
     cdnEndEpoch: 0,
     metadata: {
       [METADATA_KEYS.WITH_IPFS_INDEXING]: '',


### PR DESCRIPTION
## What changed

`data-set.test.ts` fixtures set `pdpEndEpoch` and `commissionBps` as number literals, but synapse-sdk types both as `bigint` on `DataSetInfo`. The loose fixture type (`Record<string, unknown> & {...}`) let the mismatch through, and the display helpers only use relational comparisons, which accept mixed bigint/number operands. This switches the literals to bigint and declares both fields on `EnhancedDataSetFixture` so the compiler rejects number literals.

Runtime values were never affected; SDK data is always bigint. The number-typed fixtures were cited in #658 review as evidence that runtime `pdpEndEpoch` can be a number, which requested an unneeded `BigInt()` normalization in production code. Fixtures should not misrepresent SDK data shapes.

## How to verify

`npx vitest run src/test/unit/data-set.test.ts` and `npx tsc --noEmit`.
