### PR TITLE
chore: add pkg-pr-new workflow for package preview publishing

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,50 @@
+name: Pkg PR New
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: pkg-pr-new-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Fails fast instead of riding the default 6h limit.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          run_install: false
+
+      - name: Use Node.js lts/*
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 'lts/*'
+          check-latest: true
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      # Publishes a preview of the `filecoin-pin` root package only.
+      # `upload-action` is private and excluded by not passing its path.
+      - name: Publish preview package
+        run: pnpm exec pkg-pr-new publish --pnpm

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "@vitest/browser-playwright": "^4.0.18",
     "@vitest/coverage-v8": "^4.0.18",
     "blockstore-core": "^7.0.1",
+    "pkg-pr-new": "^0.0.88",
     "playwright": "1.60.0",
     "tsx": "~4.23.1",
     "typedoc": "^0.28.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       blockstore-core:
         specifier: ^7.0.1
         version: 7.0.1
+      pkg-pr-new:
+        specifier: ^0.0.88
+        version: 0.0.88
       playwright:
         specifier: 1.60.0
         version: 1.60.0
@@ -1976,6 +1979,10 @@ packages:
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  pkg-pr-new@0.0.88:
+    resolution: {integrity: sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==}
     hasBin: true
 
   playwright-core@1.60.0:
@@ -4571,6 +4578,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+
+  pkg-pr-new@0.0.88: {}
 
   playwright-core@1.60.0: {}
 


### PR DESCRIPTION
> [!WARNING]
> The `pkg.pr.new` Github app is not currently installed or authorized for this repository. This app must be installed before the workflow can publish preview packages.

## Summary

- Add a `pkg-pr-new` workflow for pull requests and pushes to `master`
- Publish only the root `filecoin-pin` package, excluding the `upload-action`