### PR TITLE
feat!: stop exposing piece metadata

### DIFF
--- a/documentation/behind-the-scenes-of-adding-a-file.md
+++ b/documentation/behind-the-scenes-of-adding-a-file.md
@@ -28,7 +28,7 @@ graph TD
     SetupPay[FP: Setup Filecoin Pay Account<br/><br/>✓ Filecoin Pay balance visible]
     IdentifyDataSet[FP: Identify Data Set SP and ID]
     CreateDataSet{{SP: Create Data Set & Add Piece<br/><br/>✓ Blockchain Transaction}}
-    ConfirmBlockchainTx[FP: Confirm Blockchain Transaction<br/><br/>✓ Data Set & Piece metadata onchain]
+    ConfirmBlockchainTx[FP: Confirm Blockchain Transaction<br/><br/>✓ Data Set metadata stored<br/>✓ Piece metadata emitted]
     ProveData{{SP: Prove Data Possession<br/><br/>✓ Cryptographic proofs onchain and visible on explorers}}
 
     %% Milestone
@@ -91,10 +91,13 @@ This is a function of the size of the input file and the hardware. Typical DAGif
 
 The [Service Provider](glossary.md#service-provider) needs to be given the bytes to store so it can serve retrievals and prove to the chain that it possesses them.   This is done via an HTTP `PUT /pdp/piece/upload`.
 
-The upload includes [metadata](glossary.md#metadata) that will be stored on-chain:
-- `ipfsRootCid`: The IPFS Root CID, linking the [Piece](glossary.md#piece) back to IPFS
-- `withIPFSIndexing`: Signals the SP to index and advertise to [IPNI](glossary.md#ipni)
-- `name`: Original basename of the source file or directory (auto-derived from the input path; user-supplied piece metadata wins)
+The storage workflow supplies [metadata](glossary.md#metadata) when creating a Data Set or adding a Piece:
+
+- Data Set `withIPFSIndexing`: Signals the SP to index and advertise to [IPNI](glossary.md#ipni). Data Set metadata is stored and queryable on-chain.
+- Piece `ipfsRootCID`: Links the [Piece](glossary.md#piece) back to its IPFS Root CID.
+- Piece `name`: Preserves the source file or directory basename; user-supplied piece metadata wins.
+
+Piece metadata, including custom `--metadata` entries, is emitted in the `PieceAdded` event but is not retained for later contract queries.
 
 *Outputs:*
 
@@ -186,7 +189,7 @@ This should take less than a couple of seconds as it involves hitting RPC provid
 
 *What/why:*
 
-A single blockchain transaction that create a [Data Set](glossary.md#data-set) if one doesn't already exist and adds a [Piece](glossary.md#piece) to the Data Set for the corresponding [CAR](glossary.md#car) file.  This is done as one operation rather than just "Create Data Set" and "Add Piece" to improve interaction latency.  The Piece uses a Filecoin-internal hash function resulting in a [Piece CID](glossary.md#piece-cid), which is what is stored onchain.  The [Filecoin Warm Storage Service](glossary.md#filecoin-warm-storage-service) then has record of what SP is storing which data that it needs to periodically prove it has possession of.  Filecoin Pin stores additional [metadata](glossary.md#metadata) on the piece denoting that the uploaded data should be indexed by the SP and advertised to [IPNI](glossary.md#ipni) indexers.  
+A single blockchain transaction creates a [Data Set](glossary.md#data-set), if necessary, and adds a [Piece](glossary.md#piece) for the corresponding [CAR](glossary.md#car). Combining these operations reduces interaction latency. The [Filecoin Warm Storage Service](glossary.md#filecoin-warm-storage-service) stores the resulting [Piece CID](glossary.md#piece-cid) and Data Set metadata so it can track what the SP must prove. Signed Piece metadata is emitted in `PieceAdded` but is not retained for later contract queries.
 
 *Outputs:*
 

--- a/documentation/glossary.md
+++ b/documentation/glossary.md
@@ -128,14 +128,16 @@ IPNI is the content routing system that [Filecoin Pin](#filecoin-pin) relies upo
 
 ## Metadata
 
-Key-value pairs stored on-chain, either scoped to [Data Sets](#data-set) or [Pieces](#piece). [Filecoin Pin](#filecoin-pin) uses specific metadata keys:
+Key-value pairs supplied when creating [Data Sets](#data-set) or adding [Pieces](#piece). [Filecoin Pin](#filecoin-pin) uses specific metadata keys:
 
 Key | Purpose | Scope
 --- | --- | ---
 `source` | Set to 'filecoin-pin' to identify data created by this tool | Data Set
 `withIPFSIndexing` | Set to empty string to signal the [SP](#service-provider) to index and advertise the data to [IPNI](#ipni) | Data Set
-`ipfsRootCid` | Stored on each Piece to link the [Piece CID](#piece-cid) back to the [IPFS Root CID](#ipfs-root-cid).  While this is a convention that Filecoin Pin follows, there is nothing onchain enforcing a correct link between `ipfsRootCid` and `pieceCid`. | Piece
+`ipfsRootCID` | Submitted with each Piece to link the [Piece CID](#piece-cid) back to the [IPFS Root CID](#ipfs-root-cid). While this is a convention that Filecoin Pin follows, there is nothing onchain enforcing a correct link between `ipfsRootCID` and `pieceCid`. | Piece
 `name` | Original basename of the source path (file or directory). Auto-derived during `add` so the human-readable label survives even though the [UnixFS profile](#unixfs-v1-2025-profile) does not wrap single files in a parent directory. User-supplied piece metadata wins over the auto-derived value; an explicit empty string is treated as an opt-out. Consumers that need to know whether the source was a file or a directory inspect the [IPFS Root CID](#ipfs-root-cid) (codec + UnixFS `Data.Type`), matching the IPFS Pinning Service `name` convention. | Piece
+
+Data Set metadata is stored and remains queryable on-chain. Piece metadata (`ipfsRootCID`, `name`, and user-supplied `--metadata`) is signed and emitted in the Filecoin Warm Storage Service's `PieceAdded` event, but is not retained for later contract queries. Filecoin Pin therefore writes piece metadata during uploads but does not read or display it. `filecoin-pin data-set show` still displays Data Set metadata, while `filecoin-pin data-set piece-status` displays piece ID, PieceCID, size, and reconciled status.
 
 ## unixfs-v1-2025 profile
 
@@ -181,13 +183,12 @@ Because the two hashing schemes are structurally different, there is **no crypto
 
 ### How the link is established
 
-[Filecoin Pin](#filecoin-pin) bridges this gap by recording the IPFS Root CID as signed on-chain [Metadata](#metadata) (`ipfsRootCid`) on each [Piece](#piece). The client signs this metadata at upload time, so the mapping is attested by the uploader, not computed from proof. This means:
+[Filecoin Pin](#filecoin-pin) submits the IPFS Root CID as signed Piece [Metadata](#metadata) (`ipfsRootCID`) during upload. The mapping is attested by the uploader, not computed from proof. Filecoin Warm Storage Service emits the metadata in its `PieceAdded` event but does not retain it for later contract queries. This means:
 
-- **On-chain metadata** is the primary source of truth for the mapping. Anyone can look up a Piece's metadata and find the `ipfsRootCid` the uploader declared.
+- **Event indexers**, including subgraphs such as PDP Explorer, can recover the uploader-declared `ipfsRootCID` from `PieceAdded`. Filecoin Pin does not currently perform this lookup.
 - **[IPNI](#ipni)** provides a reverse lookup path: IPNI indexes IPFS CIDs and each advertisement's ContextID encodes the Piece CID, so you can go from an IPFS CID to a Piece CID via the indexer. This is trust-based: you trust the [Service Provider](#service-provider) to have created the advertisement correctly. See [How to go from IPFS CID to Piece CID using IPNI](#how-to-go-from-ipfs-cid-to-piece-cid-using-ipni) for a worked example.
-- **Subgraphs** (e.g., PDP Explorer) can also surface the `ipfsRootCid` metadata for a given Piece, independently of the SP.
 
-All of these paths are **trust-based, not trustless**. The on-chain metadata is as reliable as the client that signed it; the IPNI path trusts the SP's advertisement; the subgraph path trusts the indexer. For end-to-end verification, retrieve the data via [`/piece` retrieval](#piece-retrieval), decode the CAR, and confirm that the DAG root matches the declared IPFS Root CID.
+Both paths are **trust-based, not trustless**. Event metadata attests only what the client declared, event lookups trust the indexer, and IPNI lookups trust the SP and indexer. For end-to-end verification, retrieve the data via [`/piece` retrieval](#piece-retrieval), decode the CAR, and confirm that the DAG root matches the declared IPFS Root CID.
 
 See [Retrieving Your Data](retrieval.md) for how to use each CID to fetch your content.
 
@@ -207,7 +208,7 @@ const pieceCid = CID.decode(Buffer.from(contextId, 'base64').slice(1))
 // baga6ea4seaqglrzq3oucbywv2cqcxrjgm76uacacvaifyt5n7a2m5diipchq6ji
 ```
 
-This gives you the Piece CID that the [Service Provider](#service-provider) advertised for that content. From there you can look up the Piece's on-chain [Metadata](#metadata) to confirm the `ipfsRootCid`, or retrieve the data via [`/piece` retrieval](#piece-retrieval).
+This gives you the Piece CID that the [Service Provider](#service-provider) advertised for that content. From there, use an event indexer to recover the emitted `ipfsRootCID`, or retrieve the data via [`/piece` retrieval](#piece-retrieval) and verify the CAR's DAG root directly.
 
 Note that this mapping is **trust-based**: you are trusting the SP to have created the IPNI advertisement correctly, and the indexer to have recorded it faithfully.
 

--- a/package.json
+++ b/package.json
@@ -149,7 +149,6 @@
     "it-to-buffer": "^5.0.0",
     "libp2p": "^3.2.2",
     "multiformats": "^14.0.0",
-    "p-queue": "^9.1.0",
     "picocolors": "^1.1.1",
     "pino": "^10.3.1",
     "semver": "^7.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       multiformats:
         specifier: ^14.0.0
         version: 14.0.4
-      p-queue:
-        specifier: ^9.1.0
-        version: 9.3.3
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1

--- a/src/commands/data-set.ts
+++ b/src/commands/data-set.ts
@@ -74,7 +74,7 @@ addAuthOptions(dataSetTerminateCommand)
 export const dataSetPieceStatusCommand = new Command('piece-status')
   .description("Show the reconciled status of a data set's pieces")
   .argument('<dataSetId>', 'Data set ID to inspect')
-  .argument('[pieceCid]', 'Optional PieceCID (or IPFS root CID) to filter to a single piece')
+  .argument('[pieceCid]', 'Optional PieceCID to filter to a single piece')
   .action(async (dataSetId: string, pieceCid: string | undefined, options) => {
     try {
       await runDataSetPieceStatusCommand(parseStrictId(dataSetId), pieceCid, { ...options })

--- a/src/core/data-set/get-data-set-pieces.ts
+++ b/src/core/data-set/get-data-set-pieces.ts
@@ -1,7 +1,7 @@
 /**
  * Get Data Set Pieces
  *
- * Functions for retrieving pieces from a dataset with optional metadata enrichment.
+ * Functions for retrieving pieces from a dataset.
  *
  * @module core/data-set/get-data-set-pieces
  */
@@ -9,8 +9,7 @@
 import { getActivePieces, getScheduledRemovals } from '@filoz/synapse-core/pdp-verifier'
 import { from as pieceFromCID } from '@filoz/synapse-core/piece'
 import { getDataSet as getProviderDataSet } from '@filoz/synapse-core/sp'
-import { getAllPieceMetadata } from '@filoz/synapse-core/warm-storage'
-import { type DataSetPieceData, METADATA_KEYS, type Synapse } from '@filoz/synapse-sdk'
+import type { DataSetPieceData, Synapse } from '@filoz/synapse-sdk'
 import { reconcilePieceStatus } from '../piece/piece-status.js'
 import type { Warning } from '../utils/types.js'
 import {
@@ -172,7 +171,7 @@ export async function* iterateDataSetPieces(
  * Get all pieces for a dataset.
  *
  * Fetches on-chain pieces via PDPVerifier and provider-side pieces from the
- * service URL, reconciles statuses, and optionally enriches with metadata.
+ * service URL, and reconciles statuses.
  *
  * @param synapse - Initialized Synapse instance
  * @param dataSetId - Dataset ID to fetch pieces for
@@ -186,9 +185,6 @@ export async function getDataSetPieces(
   serviceURL: string,
   options?: GetDataSetPiecesOptions
 ): Promise<DataSetPiecesResult> {
-  const logger = options?.logger
-  const includeMetadata = options?.includeMetadata ?? false
-
   const pieces: PieceInfo[] = []
   const warnings: Warning[] = []
 
@@ -198,11 +194,6 @@ export async function getDataSetPieces(
   }
 
   pieces.sort((a, b) => Number(a.pieceId - b.pieceId))
-
-  // Optionally enrich with metadata
-  if (includeMetadata && pieces.length > 0) {
-    await enrichPiecesWithMetadata(synapse, dataSetId, pieces, warnings, logger)
-  }
 
   // Calculate total size from pieces that have sizes
   const piecesWithSizes = pieces.filter((p): p is PieceInfo & { size: number } => p.size != null)
@@ -218,62 +209,4 @@ export async function getDataSetPieces(
   }
 
   return result
-}
-
-/**
- * Internal helper: Enrich pieces with metadata from WarmStorage via synapse-core
- */
-async function enrichPiecesWithMetadata(
-  synapse: Synapse,
-  dataSetId: bigint,
-  pieces: PieceInfo[],
-  warnings: Warning[],
-  logger?: GetDataSetPiecesOptions['logger']
-): Promise<void> {
-  for (const piece of pieces) {
-    const warning = await enrichPieceMetadata(synapse, dataSetId, piece, logger)
-    if (warning) {
-      warnings.push(warning)
-    }
-  }
-}
-
-/**
- * Fetch and attach WarmStorage metadata for a single piece.
- *
- * Mutates the provided `piece` by setting `metadata` and, when present, `rootIpfsCid`.
- * Metadata lookup failures are non-fatal and returned as warnings so callers can
- * decide whether to collect or display them.
- */
-export async function enrichPieceMetadata(
-  synapse: Synapse,
-  dataSetId: bigint,
-  piece: PieceInfo,
-  logger?: GetDataSetPiecesOptions['logger']
-): Promise<Warning | undefined> {
-  try {
-    const metadata = await getAllPieceMetadata(synapse.client, { dataSetId, pieceId: piece.pieceId })
-
-    const rootIpfsCid = metadata[METADATA_KEYS.IPFS_ROOT_CID]
-    if (rootIpfsCid) {
-      piece.rootIpfsCid = rootIpfsCid
-    }
-
-    piece.metadata = metadata
-    return
-  } catch (error) {
-    logger?.warn(
-      { dataSetId: dataSetId.toString(), pieceId: piece.pieceId.toString(), error },
-      'Failed to fetch metadata for piece'
-    )
-    return {
-      code: 'METADATA_FETCH_FAILED',
-      message: `Failed to fetch metadata for piece ${piece.pieceId}`,
-      context: {
-        pieceId: piece.pieceId.toString(),
-        dataSetId: dataSetId.toString(),
-        error: String(error),
-      },
-    }
-  }
 }

--- a/src/core/data-set/get-data-set-pieces.ts
+++ b/src/core/data-set/get-data-set-pieces.ts
@@ -15,7 +15,6 @@ import type { Warning } from '../utils/types.js'
 import {
   type DataSetPiecesResult,
   type GetDataSetPiecesOptions,
-  type IterateDataSetPiecesOptions,
   type IterateDataSetPiecesResult,
   type PieceInfo,
   PieceStatus,
@@ -39,7 +38,7 @@ export async function* iterateDataSetPieces(
   synapse: Synapse,
   dataSetId: bigint,
   serviceURL: string,
-  options?: IterateDataSetPiecesOptions
+  options?: GetDataSetPiecesOptions
 ): AsyncGenerator<IterateDataSetPiecesResult> {
   const logger = options?.logger
   const initialWarnings: Warning[] = []

--- a/src/core/data-set/get-detailed-data-set.ts
+++ b/src/core/data-set/get-detailed-data-set.ts
@@ -47,7 +47,6 @@ export async function getDetailedDataSet(
     }
 
     const piecesResult = await getDataSetPieces(synapse, dataSetId, pdpDataSet.provider.pdp?.serviceURL ?? '', {
-      includeMetadata: true,
       logger,
     })
 

--- a/src/core/data-set/index.ts
+++ b/src/core/data-set/index.ts
@@ -7,7 +7,7 @@
  *
  * Key features:
  * - List datasets with optional provider enrichment
- * - Get pieces from a StorageContext with optional metadata
+ * - Get and reconcile pieces from a StorageContext
  * - Calculate actual storage across all data sets
  * - Graceful error handling with structured warnings
  * - Clean separation of concerns (follows SOLID principles)

--- a/src/core/data-set/index.ts
+++ b/src/core/data-set/index.ts
@@ -7,7 +7,7 @@
  *
  * Key features:
  * - List datasets with optional provider enrichment
- * - Get and reconcile pieces from a StorageContext
+ * - Get and reconcile pieces for a data set ID
  * - Calculate actual storage across all data sets
  * - Graceful error handling with structured warnings
  * - Clean separation of concerns (follows SOLID principles)

--- a/src/core/data-set/types.ts
+++ b/src/core/data-set/types.ts
@@ -39,12 +39,8 @@ export interface PieceInfo {
   /** Piece Commitment (CommP) as string */
   pieceCid: string
   status: PieceStatus
-  /** Root IPFS CID (from metadata, if available) */
-  rootIpfsCid?: string
   /** Piece size in bytes (if available) */
   size?: number
-  /** Additional piece metadata (key-value pairs) */
-  metadata?: Record<string, string>
 }
 
 /**
@@ -127,7 +123,7 @@ export interface ListDataSetsOptions {
 /**
  * Options for getting pieces from a dataset
  */
-export interface IterateDataSetPiecesOptions {
+export interface GetDataSetPiecesOptions {
   /** Abort signal for cancellation */
   signal?: AbortSignal
   /** Logger instance for debugging (optional) */
@@ -135,9 +131,6 @@ export interface IterateDataSetPiecesOptions {
 }
 
 /**
- * Options for getting pieces from a dataset
+ * Options for iterating over pieces from a dataset
  */
-export interface GetDataSetPiecesOptions extends IterateDataSetPiecesOptions {
-  /** Whether to fetch and include piece metadata from WarmStorage */
-  includeMetadata?: boolean
-}
+export interface IterateDataSetPiecesOptions extends GetDataSetPiecesOptions {}

--- a/src/core/data-set/types.ts
+++ b/src/core/data-set/types.ts
@@ -121,7 +121,7 @@ export interface ListDataSetsOptions {
 }
 
 /**
- * Options for getting pieces from a dataset
+ * Options for getting or iterating over pieces from a dataset
  */
 export interface GetDataSetPiecesOptions {
   /** Abort signal for cancellation */
@@ -129,8 +129,3 @@ export interface GetDataSetPiecesOptions {
   /** Logger instance for debugging (optional) */
   logger?: Logger | undefined
 }
-
-/**
- * Options for iterating over pieces from a dataset
- */
-export interface IterateDataSetPiecesOptions extends GetDataSetPiecesOptions {}

--- a/src/core/utils/types.ts
+++ b/src/core/utils/types.ts
@@ -7,7 +7,7 @@ export type ProgressEvent<T extends string = string, D = undefined> = D extends 
 export type ProgressEventHandler<E extends AnyProgressEvent = AnyProgressEvent> = (event: E) => void
 
 export interface Warning {
-  /** Machine-readable warning code (e.g., 'METADATA_FETCH_FAILED') */
+  /** Machine-readable warning code (e.g., 'PROVIDER_PIECES_UNAVAILABLE') */
   code: string
   /** Human-readable warning message */
   message: string

--- a/src/data-set/display.ts
+++ b/src/data-set/display.ts
@@ -1,4 +1,3 @@
-import { METADATA_KEYS } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
 import type { DataSetSummary, PieceInfo } from '../core/data-set/types.js'
 import { PieceStatus } from '../core/data-set/types.js'
@@ -172,7 +171,7 @@ function renderMetadata(metadata: Record<string, string>, indentLevel: number = 
 }
 
 /**
- * Render a single piece entry including CommP, root CID, size, and extra metadata.
+ * Render a single piece entry including PieceCID, size, and reconciled status.
  */
 function renderPiece(piece: PieceInfo, baseIndentLevel: number = 2): void {
   const sizeDisplay = piece.size != null ? formatFileSize(piece.size) : pc.gray('unknown')
@@ -198,8 +197,7 @@ function renderPiece(piece: PieceInfo, baseIndentLevel: number = 2): void {
   log.indent(pc.bold(`#${piece.pieceId} (${pieceStatusDisplay})`), baseIndentLevel)
   log.indent(`PieceCID: ${piece.pieceCid}`, baseIndentLevel + 1)
   log.indent(`Size: ${sizeDisplay}`, baseIndentLevel + 1)
-  const extraMetadataEntries = Object.entries(piece.metadata ?? {})
-  renderMetadata(Object.fromEntries(extraMetadataEntries), baseIndentLevel + 1)
+  log.line('')
 }
 
 function renderPieces(dataSet: DataSetSummary, indentLevel: number = 0): void {
@@ -222,12 +220,8 @@ function renderPieces(dataSet: DataSetSummary, indentLevel: number = 0): void {
     return
   }
   const uniqueCommPs = new Set(dataSet.pieces.map((p) => p.pieceCid))
-  const uniqueRootCids = new Set(
-    dataSet.pieces.map((p) => p.rootIpfsCid ?? p.metadata?.[METADATA_KEYS.IPFS_ROOT_CID]).filter(Boolean)
-  )
   log.indent(`Total size: ${formatBytes(dataSet.totalSizeBytes)}`, indentLevel + 1)
   log.indent(`Unique PieceCIDs: ${uniqueCommPs.size}`, indentLevel + 1)
-  log.indent(`Unique IPFS Root CIDs: ${uniqueRootCids.size}`, indentLevel + 1)
   log.line('')
 
   for (const piece of dataSet.pieces) {

--- a/src/data-set/display.ts
+++ b/src/data-set/display.ts
@@ -155,8 +155,8 @@ function renderPaymentDetails(dataSet: DataSetSummary, indentLevel: number = 0):
 /**
  * Render metadata key-value pairs with consistent indentation.
  */
-function renderMetadata(metadata: Record<string, string>, indentLevel: number = 1, title: string = 'Metadata'): void {
-  log.indent(pc.bold(title), indentLevel)
+function renderMetadata(metadata: Record<string, string>, indentLevel: number = 1): void {
+  log.indent(pc.bold('Metadata'), indentLevel)
   const entries = Object.entries(metadata)
   if (entries.length === 0) {
     log.indent(pc.gray('none'), indentLevel + 1)

--- a/src/data-set/piece-status-pager.ts
+++ b/src/data-set/piece-status-pager.ts
@@ -2,18 +2,15 @@
  * Interactive piece-status pager
  *
  * Drives the generic `runPager` from `utils/cli-pager.ts` over pieces pulled
- * lazily from `iterateDataSetPieces`, enriching each page with WarmStorage
- * metadata before it is shown.
+ * lazily from `iterateDataSetPieces`.
  *
  * @module data-set/piece-status-pager
  */
 
-import { METADATA_KEYS, type Synapse } from '@filoz/synapse-sdk'
-import PQueue from 'p-queue'
+import type { Synapse } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
 import {
   type DataSetSummary,
-  enrichPieceMetadata,
   type IterateDataSetPiecesResult,
   iterateDataSetPieces,
   type PieceInfo,
@@ -25,13 +22,10 @@ import { type PagerPageResult, runPager } from '../utils/cli-pager.js'
 
 const MAX_PAGE_SIZE = 20
 const MIN_PAGE_SIZE = 1
-/** Concurrency cap for background metadata prefetch, so paging ahead doesn't burst dozens of concurrent RPCs */
-const PREFETCH_CONCURRENCY = 10
-/** Approximate terminal rows consumed by each piece block (row + ipfsRootCID line + blank line) */
-const LINES_PER_PIECE = 3
+/** Approximate terminal rows consumed by each piece block (row + blank line) */
+const LINES_PER_PIECE = 2
 /** Approximate terminal rows consumed by header/footer chrome around the piece list (network line, title, total-pieces line, page label, navigation footer, blank line, tip line, and spacing) */
 const RESERVED_CHROME_LINES = 11
-const PIECE_DETAIL_INDENT = ' '.repeat(9)
 
 interface PiecePage {
   pieces: PieceInfo[]
@@ -65,54 +59,6 @@ export async function runPieceStatusPager(
   const buffer: PieceInfo[] = []
   let iteratorDone = false
   let totalLoaded = 0
-  // Keyed by pieceId -> the in-flight/resolved enrichment request, so a page
-  // is never rendered before its own pieces' enrichment has actually
-  // resolved, regardless of whether it was started by this page's own load
-  // or by a previous page's background prefetch.
-  const metadataRequests = new Map<string, Promise<void>>()
-  // Bounds background enrichment so a single buffered on-chain batch doesn't
-  // fire dozens of concurrent getAllPieceMetadata calls at once.
-  const prefetchQueue = new PQueue({ concurrency: PREFETCH_CONCURRENCY })
-
-  // Fetches metadata for `piece` and evicts its cache entry on failure so a
-  // future visit can retry. Shared by the immediate (foreground) and queued
-  // (background prefetch) paths.
-  const runEnrich = (piece: PieceInfo): Promise<void> => {
-    const cacheKey = piece.pieceId.toString()
-    return enrichPieceMetadata(synapse, dataSet.dataSetId, piece).then((warning) => {
-      if (warning) {
-        metadataRequests.delete(cacheKey)
-      }
-    })
-  }
-
-  const enrichOne = (piece: PieceInfo): Promise<void> => {
-    const cacheKey = piece.pieceId.toString()
-    let pending = metadataRequests.get(cacheKey)
-    if (!pending) {
-      pending = runEnrich(piece)
-      metadataRequests.set(cacheKey, pending)
-    }
-    return pending
-  }
-
-  const ensureEnriched = (pieces: PieceInfo[]) => Promise.all(pieces.map(enrichOne))
-
-  const prefetchRest = (pieces: PieceInfo[]): void => {
-    for (const piece of pieces) {
-      const cacheKey = piece.pieceId.toString()
-      if (metadataRequests.has(cacheKey)) {
-        continue
-      }
-      // Reserve the slot now, at enqueue time, so a later prefetchRest sweep
-      // for the same piece sees it's already scheduled and skips adding a
-      // duplicate queue job - even before this one has run.
-      metadataRequests.set(
-        cacheKey,
-        prefetchQueue.add(() => runEnrich(piece))
-      )
-    }
-  }
 
   const fillBufferTo = async (targetLength: number): Promise<void> => {
     while (buffer.length < targetLength && !iteratorDone) {
@@ -132,11 +78,6 @@ export async function runPieceStatusPager(
 
     const start = pageIndex * pageSize
     const pagePieces = buffer.slice(start, start + pageSize)
-    await ensureEnriched(pagePieces)
-
-    // Kick off background enrichment for the rest of what's already buffered
-    // but not yet shown, so navigating forward later finds it in flight or done.
-    prefetchRest(buffer.slice(start + pageSize))
 
     totalLoaded = buffer.length
     const hasNext = buffer.length > start + pageSize || !iteratorDone
@@ -158,11 +99,7 @@ export async function runPieceStatusPager(
   ): string =>
     renderPiecePage(network, dataSet, page, pageIndex, pageSize, renderOptions.loading, renderOptions.loadingPageIndex)
 
-  try {
-    await runPager({ firstPage, loadPage, renderPage, input, output })
-  } finally {
-    prefetchQueue.clear()
-  }
+  await runPager({ firstPage, loadPage, renderPage, input, output })
 
   log.section('Summary', [
     `Network: ${network}`,
@@ -220,7 +157,7 @@ function renderPiecePage(
     lines.push(pc.gray(formatNavigationHelp(hasPrevious, hasNext)))
     lines.push('')
     lines.push(
-      pc.dim(`  Tip: Run "filecoin-pin data-set piece-status ${dataSet.dataSetId} <pieceCid>" for full details`)
+      pc.dim(`  Tip: Run "filecoin-pin data-set piece-status ${dataSet.dataSetId} <pieceCid>" to filter to one piece`)
     )
   }
 
@@ -230,25 +167,12 @@ function renderPiecePage(
 function formatPieceBlock(piece: PieceInfo): string {
   const id = `#${piece.pieceId}`.padEnd(6)
   const pieceCid = piece.pieceCid.padEnd(piece.pieceCid.length + 10)
-  const row = `  ${pc.bold(id)} ${pieceCid} ${formatPieceSize(piece)} ${formatPieceStatus(piece.status)}`
-  return [row, `${PIECE_DETAIL_INDENT}${pc.bold(pc.gray('ipfsRootCID:'))} ${formatRootCid(piece)}`].join('\n')
+  return `  ${pc.bold(id)} ${pieceCid} ${formatPieceSize(piece)} ${formatPieceStatus(piece.status)}`
 }
 
 function formatPieceSize(piece: PieceInfo): string {
   if (piece.size == null) return pc.gray('unknown'.padEnd(10))
   return formatFileSize(piece.size).padEnd(10)
-}
-
-function formatRootCid(piece: PieceInfo): string {
-  // enrichPieceMetadata always sets piece.metadata on success (even to {} when
-  // the piece has no metadata entries) and only leaves it unset when the fetch
-  // itself threw. So metadata == null means the fetch failed - distinct from a
-  // successful fetch that simply found no IPFS root CID for this piece.
-  if (piece.metadata == null) {
-    return pc.yellow('metadata fetch failed')
-  }
-  const rootCid = piece.rootIpfsCid ?? piece.metadata[METADATA_KEYS.IPFS_ROOT_CID]
-  return rootCid == null || rootCid === '' ? pc.gray('-') : pc.gray(rootCid)
 }
 
 function formatPieceStatus(status: PieceStatus): string {

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -64,12 +64,11 @@ export async function runDataSetDetailsCommand(dataSetId: number, options: DataS
 /**
  * Display the reconciled status of a data set's pieces.
  *
- * When `cid` is provided, only the matching piece (by PieceCID or IPFS root
- * CID) is shown; otherwise every piece in the data set is listed.
+ * When `cid` is provided, only the matching piece (by PieceCID) is shown;
+ * otherwise every piece in the data set is listed.
  */
 export async function runDataSetPieceStatusCommand(
   dataSetId: number,
-  // pieceCid or ipfsRootCid
   cid: string | undefined,
   options: DataSetCommandOptions
 ): Promise<void> {
@@ -106,11 +105,7 @@ export async function runDataSetPieceStatusCommand(
     let pieces: PieceInfo[] = allPieces
     let emptyMessage: string | undefined
     if (cid != null) {
-      // A cheaper PieceCID-only lookup can use findPieceIdsByCid from
-      // @filoz/synapse-core/pdp-verifier, then getAllPieceMetadata({ dataSetId, pieceId })
-      // from @filoz/synapse-core/warm-storage. But IPFS root CID filtering still
-      // needs this metadata scan because there is no root-CID index today.
-      pieces = allPieces.filter((piece) => piece.pieceCid === cid || piece.rootIpfsCid === cid)
+      pieces = allPieces.filter((piece) => piece.pieceCid === cid)
       if (pieces.length === 0) {
         emptyMessage = `No piece matching ${cid} was found in data set ${dataSetId}.`
       }

--- a/src/test/mocks/synapse-sdk.ts
+++ b/src/test/mocks/synapse-sdk.ts
@@ -43,7 +43,7 @@ export const mainnet = {
 export const METADATA_KEYS = {
   WITH_CDN: 'withCDN',
   WITH_IPFS_INDEXING: 'withIPFSIndexing',
-  IPFS_ROOT_CID: 'ipfsRootCid',
+  IPFS_ROOT_CID: 'ipfsRootCID',
   SOURCE: 'source',
 }
 

--- a/src/test/unit/core-data-set.test.ts
+++ b/src/test/unit/core-data-set.test.ts
@@ -6,21 +6,13 @@
 
 import { METADATA_KEYS } from '@filoz/synapse-sdk'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  enrichPieceMetadata,
-  getDataSetPieces,
-  iterateDataSetPieces,
-  listDataSets,
-  type PieceInfo,
-} from '../../core/data-set/index.js'
-import { PieceStatus } from '../../core/data-set/types.js'
+import { getDataSetPieces, iterateDataSetPieces, listDataSets, type PieceInfo } from '../../core/data-set/index.js'
 
 const TEST_DATA_SET_ID = 123n
 const TEST_SERVICE_URL = 'https://provider.example.com'
 
 const {
   mockSynapse,
-  mockGetAllPieceMetadata,
   mockFindDataSets,
   mockGetProviders,
   mockGetActivePieces,
@@ -33,7 +25,6 @@ const {
     datasets: [] as any[],
     providers: [] as any[],
     pieces: [] as Array<{ pieceId: bigint; pieceCid: { toString: () => string } }>,
-    pieceMetadata: {} as Record<number, Record<string, string>>,
     providerPieces: undefined as
       | Array<{
           pieceId: bigint
@@ -64,9 +55,6 @@ const {
     return { id: 123n, nextChallengeEpoch: 100, pieces }
   })
 
-  const mockGetAllPieceMetadata = vi.fn(async (_client: any, { pieceId }: any) => {
-    return state.pieceMetadata[Number(pieceId)] ?? {}
-  })
   const mockPieceFromCID = vi.fn((cid: { toString: () => string } | string) => {
     const cidString = typeof cid === 'string' ? cid : cid.toString()
     if (cidString === 'bafkpiece0') return { size: 1048576 }
@@ -84,7 +72,6 @@ const {
 
   return {
     mockSynapse,
-    mockGetAllPieceMetadata,
     mockFindDataSets,
     mockGetProviders,
     mockGetActivePieces,
@@ -101,10 +88,6 @@ vi.mock('@filoz/synapse-sdk', async () => {
     ...sharedMock,
   }
 })
-
-vi.mock('@filoz/synapse-core/warm-storage', () => ({
-  getAllPieceMetadata: mockGetAllPieceMetadata,
-}))
 
 vi.mock('@filoz/synapse-core/pdp-verifier', () => ({
   getActivePieces: mockGetActivePieces,
@@ -209,7 +192,6 @@ describe('getDataSetPieces', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     state.pieces = []
-    state.pieceMetadata = {}
     state.providerPieces = undefined
     mockGetActivePieces.mockImplementation(async () => ({
       pieces: state.pieces.map((p) => ({ id: p.pieceId, cid: p.pieceCid })),
@@ -232,96 +214,22 @@ describe('getDataSetPieces', () => {
     expect(result.warnings).toEqual([])
   })
 
-  it('retrieves pieces without metadata when includeMetadata is false', async () => {
+  it('retrieves pieces', async () => {
     state.pieces = [
       { pieceId: 0n, pieceCid: { toString: () => 'bafkpiece0' } },
       { pieceId: 1n, pieceCid: { toString: () => 'bafkpiece1' } },
     ]
 
-    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL, {
-      includeMetadata: false,
-    })
+    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)
 
     expect(result.pieces).toHaveLength(2)
     expect(result.pieces[0]).toMatchObject({
       pieceId: 0n,
       pieceCid: 'bafkpiece0',
     })
-    expect(result.pieces[0]?.metadata).toBeUndefined()
     expect(result.pieces[1]).toMatchObject({
       pieceId: 1n,
       pieceCid: 'bafkpiece1',
-    })
-  })
-
-  it('enriches pieces with metadata when includeMetadata is true', async () => {
-    state.pieces = [
-      { pieceId: 0n, pieceCid: { toString: () => 'bafkpiece0' } },
-      { pieceId: 1n, pieceCid: { toString: () => 'bafkpiece1' } },
-    ]
-    state.pieceMetadata = {
-      0: {
-        [METADATA_KEYS.IPFS_ROOT_CID]: 'bafyroot0',
-        label: 'test-file-0.txt',
-      },
-      1: {
-        [METADATA_KEYS.IPFS_ROOT_CID]: 'bafyroot1',
-        label: 'test-file-1.txt',
-      },
-    }
-
-    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL, {
-      includeMetadata: true,
-    })
-
-    expect(result.pieces).toHaveLength(2)
-    expect(result.pieces[0]).toMatchObject({
-      pieceId: 0n,
-      pieceCid: 'bafkpiece0',
-      rootIpfsCid: 'bafyroot0',
-      metadata: {
-        [METADATA_KEYS.IPFS_ROOT_CID]: 'bafyroot0',
-        label: 'test-file-0.txt',
-      },
-    })
-    expect(mockGetAllPieceMetadata).toHaveBeenCalledWith(mockSynapse.client, { dataSetId: 123n, pieceId: 0n })
-  })
-
-  it('handles metadata fetch failures gracefully with warnings', async () => {
-    state.pieces = [
-      { pieceId: 0n, pieceCid: { toString: () => 'bafkpiece0' } },
-      { pieceId: 1n, pieceCid: { toString: () => 'bafkpiece1' } },
-    ]
-    state.pieceMetadata = {
-      0: {
-        [METADATA_KEYS.IPFS_ROOT_CID]: 'bafyroot0',
-      },
-    }
-    // Simulate failure for piece 1
-    mockGetAllPieceMetadata.mockImplementation(async (_client: any, { pieceId }: any) => {
-      const metadata = state.pieceMetadata[Number(pieceId)]
-      if (metadata == null) {
-        throw new Error('Metadata not found')
-      }
-      return metadata
-    })
-
-    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL, {
-      includeMetadata: true,
-    })
-
-    expect(result.pieces).toHaveLength(2)
-    expect(result.pieces[0]?.metadata).toBeDefined()
-    expect(result.pieces[1]?.metadata).toBeUndefined()
-    expect(result.warnings).toHaveLength(1)
-    expect(result.warnings?.[0]).toMatchObject({
-      code: 'METADATA_FETCH_FAILED',
-      message: 'Failed to fetch metadata for piece 1',
-      context: {
-        pieceId: '1',
-        dataSetId: '123',
-        error: expect.any(String),
-      },
     })
   })
 
@@ -331,26 +239,6 @@ describe('getDataSetPieces', () => {
     await expect(getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL)).rejects.toThrow(
       'Failed to retrieve pieces for dataset 123'
     )
-  })
-
-  it('handles pieces without root IPFS CID in metadata', async () => {
-    state.pieces = [{ pieceId: 0n, pieceCid: { toString: () => 'bafkpiece0' } }]
-    state.pieceMetadata = {
-      0: {
-        label: 'no-cid-file.txt',
-        // No IPFS_ROOT_CID
-      },
-    }
-
-    const result = await getDataSetPieces(mockSynapse as any, TEST_DATA_SET_ID, TEST_SERVICE_URL, {
-      includeMetadata: true,
-    })
-
-    expect(result.pieces).toHaveLength(1)
-    expect(result.pieces[0]?.rootIpfsCid).toBeUndefined()
-    expect(result.pieces[0]?.metadata).toMatchObject({
-      label: 'no-cid-file.txt',
-    })
   })
 
   it('calculates piece sizes from piece CIDs', async () => {
@@ -519,7 +407,6 @@ describe('iterateDataSetPieces', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     state.pieces = []
-    state.pieceMetadata = {}
     state.providerPieces = undefined
   })
 
@@ -574,34 +461,5 @@ describe('iterateDataSetPieces', () => {
     expect(batches[0]).toEqual({ hasMore: true, pieceIds: [0n] })
     expect(batches[1]?.hasMore).toBe(false)
     expect(batches[1]?.pieceIds).toEqual([1n, 2n])
-  })
-})
-
-describe('enrichPieceMetadata', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    state.pieceMetadata = {}
-  })
-
-  it('sets metadata and rootIpfsCid on success', async () => {
-    state.pieceMetadata = { 5: { [METADATA_KEYS.IPFS_ROOT_CID]: 'bafyroot5', label: 'file.txt' } }
-    const piece: PieceInfo = { pieceId: 5n, pieceCid: 'bafkpiece5', status: PieceStatus.ACTIVE }
-
-    const warning = await enrichPieceMetadata(mockSynapse as any, TEST_DATA_SET_ID, piece)
-
-    expect(warning).toBeUndefined()
-    expect(piece.rootIpfsCid).toBe('bafyroot5')
-    expect(piece.metadata).toMatchObject({ label: 'file.txt' })
-  })
-
-  it('returns a warning and leaves the piece unmutated on failure', async () => {
-    mockGetAllPieceMetadata.mockRejectedValueOnce(new Error('boom'))
-    const piece: PieceInfo = { pieceId: 6n, pieceCid: 'bafkpiece6', status: PieceStatus.ACTIVE }
-
-    const warning = await enrichPieceMetadata(mockSynapse as any, TEST_DATA_SET_ID, piece)
-
-    expect(warning).toMatchObject({ code: 'METADATA_FETCH_FAILED' })
-    expect(piece.metadata).toBeUndefined()
-    expect(piece.rootIpfsCid).toBeUndefined()
   })
 })

--- a/src/test/unit/data-set-display.test.ts
+++ b/src/test/unit/data-set-display.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { DataSetSummary } from '../../core/data-set/types.js'
-import { displayDataSetList } from '../../data-set/display.js'
+import { type DataSetSummary, type PieceInfo, PieceStatus } from '../../core/data-set/types.js'
+import { displayDataSetList, displayPieceStatuses } from '../../data-set/display.js'
 
 const { logMock } = vi.hoisted(() => ({
   logMock: {
@@ -32,6 +32,10 @@ function row(fields: Partial<DataSetSummary> = {}): DataSetSummary {
 
 function lines(): string[] {
   return logMock.line.mock.calls.map(([line]) => line as string)
+}
+
+function renderedText(): string {
+  return [...logMock.line.mock.calls, ...logMock.indent.mock.calls].map(([line]) => String(line)).join('\n')
 }
 
 describe('displayDataSetList', () => {
@@ -83,5 +87,29 @@ describe('displayDataSetList', () => {
     const output = lines()
     expect(output.some((line) => /^1\s+inactive\s+10\s+1\s+disabled$/.test(line.trim()))).toBe(true)
     expect(output.some((line) => /^2\s+terminated\s+10\s+1\s+disabled$/.test(line.trim()))).toBe(true)
+  })
+})
+
+describe('displayPieceStatuses', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not expose legacy piece metadata fields', () => {
+    const piece = {
+      pieceId: 1n,
+      pieceCid: 'bafkpiece1',
+      status: PieceStatus.ACTIVE,
+      size: 1024,
+      rootIpfsCid: 'bafyroot1',
+      metadata: { ipfsRootCID: 'bafyroot1', secret: 'value' },
+    } as unknown as PieceInfo
+
+    displayPieceStatuses([piece], 1, 'calibration', '0xtest')
+
+    const output = renderedText()
+    expect(output).toContain('bafkpiece1')
+    expect(output).not.toContain('bafyroot1')
+    expect(output).not.toContain('secret')
   })
 })

--- a/src/test/unit/data-set.test.ts
+++ b/src/test/unit/data-set.test.ts
@@ -17,7 +17,6 @@ const {
   cancelMock,
   mockFindDataSets,
   mockGetProvider,
-  mockGetAllPieceMetadata,
   mockGetPdpDataSet,
   mockTerminateService,
   mockWaitForTransactionReceipt,
@@ -40,7 +39,6 @@ const {
   }
   const mockFindDataSets = vi.fn()
   const mockGetProvider = vi.fn()
-  const mockGetAllPieceMetadata = vi.fn(async () => ({ ...state.pieceMetadata }))
   const mockGetPdpDataSet = vi.fn()
   const mockTerminateService = vi.fn()
   const mockWaitForTransactionReceipt = vi.fn()
@@ -49,7 +47,6 @@ const {
   const mockIsCancel = vi.fn(() => false)
   const mockRunPieceStatusPager = vi.fn()
   const state = {
-    pieceMetadata: {} as Record<string, string>,
     pieceList: [] as Array<{ pieceId: bigint; pieceCid: string }>,
   }
 
@@ -118,7 +115,6 @@ const {
     spinnerMock,
     mockFindDataSets,
     mockGetProvider,
-    mockGetAllPieceMetadata,
     mockGetPdpDataSet,
     mockTerminateService,
     mockWaitForTransactionReceipt,
@@ -178,7 +174,6 @@ vi.mock('@filoz/synapse-sdk', async () => {
 })
 
 vi.mock('@filoz/synapse-core/warm-storage', () => ({
-  getAllPieceMetadata: mockGetAllPieceMetadata,
   getPdpDataSet: mockGetPdpDataSet,
 }))
 
@@ -286,11 +281,9 @@ describe('runDataSetCommand', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    state.pieceMetadata = {}
     state.pieceList = []
     mockFindDataSets.mockResolvedValue([summaryDataSet])
     mockGetProvider.mockResolvedValue(provider)
-    mockGetAllPieceMetadata.mockResolvedValue({})
     mockGetPdpDataSet.mockResolvedValue(toPdpDataSet(summaryDataSet, provider))
   })
 
@@ -430,7 +423,6 @@ describe('runDataSetCommand', () => {
     expect(dataSet?.dataSetId).toBe(158n)
     expect(dataSet?.pieces).toBeUndefined()
     expect(dataSet?.totalSizeBytes).toBeUndefined()
-    expect(mockGetAllPieceMetadata).not.toHaveBeenCalled()
   })
 
   it('does not enumerate the whole account when loading a single dataset', async () => {
@@ -500,11 +492,9 @@ describe('runTerminateDataSetCommand', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    state.pieceMetadata = {}
     state.pieceList = []
     mockFindDataSets.mockResolvedValue([terminatableDataSet])
     mockGetProvider.mockResolvedValue(provider)
-    mockGetAllPieceMetadata.mockResolvedValue({})
     mockGetPdpDataSet.mockResolvedValue(toPdpDataSet(terminatableDataSet, provider))
     mockTerminateService.mockResolvedValue({ txHash: '0xtxhash123', dataSetId: 158n, endEpoch: 0n })
     mockWaitForTransactionReceipt.mockResolvedValue({ status: 'success' })
@@ -525,7 +515,6 @@ describe('runTerminateDataSetCommand', () => {
 
     expect(mockTerminateService).toHaveBeenCalledWith({ dataSetId: 158n, skipProvider: true })
     expect(mockWaitForTransactionReceipt).not.toHaveBeenCalled()
-    expect(mockGetAllPieceMetadata).not.toHaveBeenCalled()
     expect(displayDataSetsMock).toHaveBeenCalledTimes(2)
     expect(displayDataSetListMock).not.toHaveBeenCalled()
   })
@@ -559,7 +548,6 @@ describe('runTerminateDataSetCommand', () => {
 
     expect(mockTerminateService).toHaveBeenCalledWith({ dataSetId: 158n, skipProvider: true })
     expect(mockWaitForTransactionReceipt).toHaveBeenCalledWith({ hash: '0xtxhash123' })
-    expect(mockGetAllPieceMetadata).not.toHaveBeenCalled()
     expect(displayDataSetsMock).toHaveBeenCalledTimes(2)
     expect(displayDataSetListMock).not.toHaveBeenCalled()
   })
@@ -665,13 +653,11 @@ describe('runDataSetPieceStatusCommand', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    state.pieceMetadata = {}
     state.pieceList = [
       { pieceId: 0n, pieceCid: 'bafkpiece0' },
       { pieceId: 1n, pieceCid: 'bafkpiece1' },
     ]
     mockGetProvider.mockResolvedValue(provider)
-    mockGetAllPieceMetadata.mockResolvedValue({})
     mockGetPdpDataSet.mockResolvedValue(toPdpDataSet(summaryDataSet, provider))
   })
 

--- a/src/test/unit/payments-setup.test.ts
+++ b/src/test/unit/payments-setup.test.ts
@@ -34,7 +34,7 @@ vi.mock('@filoz/synapse-sdk', () => {
     },
     METADATA_KEYS: {
       WITH_IPFS_INDEXING: 'withIPFSIndexing',
-      IPFS_ROOT_CID: 'ipfsRootCid',
+      IPFS_ROOT_CID: 'ipfsRootCID',
     },
     calibration: {
       id: 314159,

--- a/src/test/unit/piece-status-pager.test.ts
+++ b/src/test/unit/piece-status-pager.test.ts
@@ -3,16 +3,15 @@
  *
  * `runPager` (the generic alt-screen navigation engine) is mocked here so
  * these tests focus on this module's own logic: buffering pieces across
- * on-chain batches, the metadata enrichment/prefetch dedup and retry
- * behavior, page sizing, and rendering. Generic pager navigation mechanics
- * (arrow keys, q, Ctrl+C, cleanup) are covered in cli-pager.test.ts.
+ * on-chain batches, page sizing, and rendering. Generic pager navigation
+ * mechanics (arrow keys, q, Ctrl+C, cleanup) are covered in cli-pager.test.ts.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PieceStatus } from '../../core/data-set/types.js'
 import { runPieceStatusPager } from '../../data-set/piece-status-pager.js'
 
-const { mockIterateDataSetPieces, mockEnrichPieceMetadata, mockRunPager, mockLogSection, state } = vi.hoisted(() => {
+const { mockIterateDataSetPieces, mockRunPager, mockLogSection, state } = vi.hoisted(() => {
   const state = {
     batches: [] as Array<{ pieces: any[]; hasMore: boolean }>,
     capturedOptions: undefined as any,
@@ -29,11 +28,6 @@ const { mockIterateDataSetPieces, mockEnrichPieceMetadata, mockRunPager, mockLog
     return gen()
   })
 
-  const mockEnrichPieceMetadata = vi.fn(async (_synapse: any, _dataSetId: any, piece: any): Promise<any> => {
-    piece.metadata = {}
-    return undefined
-  })
-
   const mockRunPager = vi.fn(async (options: any) => {
     state.capturedOptions = options
     return new Promise<void>((resolve, reject) => {
@@ -44,7 +38,7 @@ const { mockIterateDataSetPieces, mockEnrichPieceMetadata, mockRunPager, mockLog
 
   const mockLogSection = vi.fn()
 
-  return { mockIterateDataSetPieces, mockEnrichPieceMetadata, mockRunPager, mockLogSection, state }
+  return { mockIterateDataSetPieces, mockRunPager, mockLogSection, state }
 })
 
 vi.mock('../../core/data-set/index.js', async () => {
@@ -52,7 +46,6 @@ vi.mock('../../core/data-set/index.js', async () => {
   return {
     ...actual,
     iterateDataSetPieces: mockIterateDataSetPieces,
-    enrichPieceMetadata: mockEnrichPieceMetadata,
   }
 })
 
@@ -83,18 +76,6 @@ function makePiece(pieceId: bigint, pieceCid: string): any {
   return { pieceId, pieceCid, status: PieceStatus.ACTIVE }
 }
 
-function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
-  let resolve!: (value: T) => void
-  const promise = new Promise<T>((res) => {
-    resolve = res
-  })
-  return { promise, resolve }
-}
-
-async function flush(): Promise<void> {
-  await new Promise((r) => setTimeout(r, 0))
-}
-
 describe('runPieceStatusPager', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -102,10 +83,6 @@ describe('runPieceStatusPager', () => {
     state.capturedOptions = undefined
     state.pagerResolve = undefined
     state.pagerReject = undefined
-    mockEnrichPieceMetadata.mockImplementation(async (_synapse: any, _dataSetId: any, piece: any) => {
-      piece.metadata = {}
-      return undefined
-    })
   })
 
   afterEach(() => {
@@ -130,7 +107,7 @@ describe('runPieceStatusPager', () => {
   })
 
   it('slices a page across two on-chain batches when pageSize is larger than one batch', async () => {
-    // rows=17 -> pageSize=2 (RESERVED_CHROME_LINES=11, LINES_PER_PIECE=3)
+    // rows=17 -> pageSize=3 (RESERVED_CHROME_LINES=11, LINES_PER_PIECE=2)
     state.batches = [
       { pieces: [makePiece(0n, 'bafkpiece0')], hasMore: true },
       { pieces: [makePiece(1n, 'bafkpiece1')], hasMore: false },
@@ -148,70 +125,8 @@ describe('runPieceStatusPager', () => {
     await resultPromise
   })
 
-  it('prefetches the rest of a buffered batch in the background and reuses it on a later page without re-fetching', async () => {
-    // rows=12 -> pageSize=1
-    state.batches = [
-      {
-        pieces: [makePiece(0n, 'bafkpiece0'), makePiece(1n, 'bafkpiece1'), makePiece(2n, 'bafkpiece2')],
-        hasMore: false,
-      },
-    ]
-
-    const resultPromise = runPieceStatusPager(fakeSynapse, makeDataSet(), { output: { rows: 12 } as any })
-    await vi.waitFor(() => expect(state.capturedOptions).toBeDefined())
-    expect(state.capturedOptions.firstPage.page.pieces.map((p: any) => p.pieceCid)).toEqual(['bafkpiece0'])
-
-    // Background prefetch for pieces 1 and 2 should complete without being asked.
-    await vi.waitFor(() => expect(mockEnrichPieceMetadata).toHaveBeenCalledTimes(3))
-
-    const secondPage = await state.capturedOptions.loadPage(1)
-    expect(secondPage.page.pieces.map((p: any) => p.pieceCid)).toEqual(['bafkpiece1'])
-    // Still 3: the second page's piece was already enriched by the background prefetch.
-    expect(mockEnrichPieceMetadata).toHaveBeenCalledTimes(3)
-
-    state.pagerResolve?.()
-    await resultPromise
-  })
-
-  it('does not resolve a page until its own piece metadata fetch resolves', async () => {
-    state.batches = [{ pieces: [makePiece(0n, 'bafkpiece0')], hasMore: false }]
-    const deferred = createDeferred<undefined>()
-    mockEnrichPieceMetadata.mockImplementationOnce(async () => deferred.promise)
-
-    const resultPromise = runPieceStatusPager(fakeSynapse, makeDataSet(), { output: { rows: 12 } as any })
-
-    await flush()
-    expect(state.capturedOptions).toBeUndefined()
-
-    deferred.resolve(undefined)
-    await vi.waitFor(() => expect(state.capturedOptions).toBeDefined())
-
-    state.pagerResolve?.()
-    await resultPromise
-  })
-
-  it('evicts a failed metadata fetch so revisiting the same page retries it', async () => {
-    state.batches = [{ pieces: [makePiece(0n, 'bafkpiece0')], hasMore: false }]
-    mockEnrichPieceMetadata.mockImplementationOnce(async () => ({
-      code: 'METADATA_FETCH_FAILED',
-      message: 'boom',
-      context: {},
-    }))
-
-    const resultPromise = runPieceStatusPager(fakeSynapse, makeDataSet(), { output: { rows: 12 } as any })
-    await vi.waitFor(() => expect(state.capturedOptions).toBeDefined())
-    expect(state.capturedOptions.firstPage.page.pieces[0].metadata).toBeUndefined()
-
-    const retried = await state.capturedOptions.loadPage(0)
-    expect(retried.page.pieces[0].metadata).toBeDefined()
-    expect(mockEnrichPieceMetadata).toHaveBeenCalledTimes(2)
-
-    state.pagerResolve?.()
-    await resultPromise
-  })
-
   it.each([
-    { rows: 24, expectedPageSize: 4 },
+    { rows: 24, expectedPageSize: 6 },
     { rows: undefined, expectedPageSize: 1 },
     { rows: 1000, expectedPageSize: 20 },
   ])('derives page size $expectedPageSize from output.rows=$rows', async ({ rows, expectedPageSize }) => {
@@ -249,35 +164,18 @@ describe('runPieceStatusPager', () => {
     await resultPromise
   })
 
-  it('distinguishes a metadata fetch failure from a successful fetch with no root CID', async () => {
+  it('renders a piece row without fetching or displaying any metadata', async () => {
     state.batches = [{ pieces: [makePiece(0n, 'bafkpiece0')], hasMore: false }]
     const resultPromise = runPieceStatusPager(fakeSynapse, makeDataSet(), { output: { rows: 12 } as any })
     await vi.waitFor(() => expect(state.capturedOptions).toBeDefined())
 
-    const failedPiece = { ...makePiece(0n, 'bafkpiece0'), metadata: undefined }
-    const failedRender = state.capturedOptions.renderPage(
-      { pieces: [failedPiece], iteratorDone: true, totalLoaded: 1 },
+    const rendered = state.capturedOptions.renderPage(
+      { pieces: [makePiece(0n, 'bafkpiece0')], iteratorDone: true, totalLoaded: 1 },
       0,
       { loading: false }
     )
-    expect(failedRender).toContain('metadata fetch failed')
-
-    const noCidPiece = { ...makePiece(1n, 'bafkpiece1'), metadata: {} }
-    const noCidRender = state.capturedOptions.renderPage(
-      { pieces: [noCidPiece], iteratorDone: true, totalLoaded: 1 },
-      0,
-      { loading: false }
-    )
-    expect(noCidRender).not.toContain('metadata fetch failed')
-    expect(noCidRender).toContain('-')
-
-    const withRootCidPiece = { ...makePiece(2n, 'bafkpiece2'), metadata: {}, rootIpfsCid: 'bafyroot2' }
-    const withRootCidRender = state.capturedOptions.renderPage(
-      { pieces: [withRootCidPiece], iteratorDone: true, totalLoaded: 1 },
-      0,
-      { loading: false }
-    )
-    expect(withRootCidRender).toContain('bafyroot2')
+    expect(rendered).toContain('bafkpiece0')
+    expect(rendered).not.toContain('ipfsRootCID')
 
     state.pagerResolve?.()
     await resultPromise
@@ -299,7 +197,7 @@ describe('runPieceStatusPager', () => {
     await resultPromise
   })
 
-  it('shows the navigation footer and a tip referencing the real data set id when not loading', async () => {
+  it('shows the navigation footer and a filtering tip with the real data set id when not loading', async () => {
     state.batches = [{ pieces: [makePiece(0n, 'bafkpiece0')], hasMore: false }]
     const resultPromise = runPieceStatusPager(fakeSynapse, makeDataSet({ dataSetId: 999n }), {
       output: { rows: 12 } as any,
@@ -312,12 +210,13 @@ describe('runPieceStatusPager', () => {
     expect(rendered).toContain('Navigate:')
     expect(rendered).toContain('q quit')
     expect(rendered).toContain('data-set piece-status 999 <pieceCid>')
+    expect(rendered).toContain('to filter to one piece')
 
     state.pagerResolve?.()
     await resultPromise
   })
 
-  it('cleans up and propagates the error when the pager rejects', async () => {
+  it('propagates the error when the pager rejects', async () => {
     state.batches = [{ pieces: [makePiece(0n, 'bafkpiece0')], hasMore: false }]
     const resultPromise = runPieceStatusPager(fakeSynapse, makeDataSet(), { output: { rows: 12 } as any })
     await vi.waitFor(() => expect(state.capturedOptions).toBeDefined())


### PR DESCRIPTION
## Summary

- Stop querying piece metadata from fwss
- Remove piece metadata and IPFS Root CID enrichment from piece-status output
- Preserves piece-metadata writes during `add` and `import`
- Preserve Data Set metadata reads and display
- Remove the metadata prefetch machinery and direct `p-queue` dependency
- Update documentation to distinguish stored dataset metadata from event-only piece metadata

Closes #668 

## Breaking Changes

- Remove `PieceInfo.metadata`
- Remove `PieceInfo.rootIpfsCid`
- Remove `GetDataSetPiecesOptions.includeMetadata`
- Remove the exported `enrichPieceMetadata()` function
- Remove IPFS Root CID filtering from `data-set piece-status`

**Note:** This PR does not use the preview packages from FilOzone/synapse-sdk#936. It removes filecoin-pin's calls to the piece-metadata getter APIs removed by that PR while retaining the currently release dependencies. Once synapse release prs FilOzone/synapse-sdk#941 and FilOzone/synapse-sdk#942 are merged and `@filoz/synapse-core@v0.9.0` and `@filoz/synapse-sdk@v2.0.0` are published, the dependency upgrade can be handled as a follow-up or included here.