### PR TITLE
feat(session): per-command scope gating with console-first remediation

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ In session-key mode, each command checks only the on-chain permissions it needs 
 | `rm` (`--piece` or `--all`) | `schedulePieceRemovals` |
 | `data-set terminate` | `terminateService` |
 | Pinning server (`filecoin-pinning-server`) | `createDataSet`, `addPieces`, `schedulePieceRemovals` |
+| `payments deposit`, `payments withdraw`, `payments fund`, `payments setup --auto` | Owner wallet only (session keys are refused) |
 
 If the session key is missing a required scope, the command fails up front with a console link to approve the missing scope with the owner wallet, plus the equivalent `filecoin-pin session authorize` / `filecoin-pin session create` commands for the account owner to run.
 

--- a/README.md
+++ b/README.md
@@ -269,15 +269,15 @@ Other arguments are possible for individual commands, use `--help` to find out m
 
 ### Session-Key Permissions
 
-In session-key mode, each command checks only the on-chain permissions it needs — a delegate does not need the full FWSS permission set to run a scoped subset of commands.
+In session-key mode, each command checks only the on-chain permissions it needs — a delegate does not need every storage-service permission to run a scoped subset of commands.
 
 | Command | Required scopes |
 | --- | --- |
 | Read commands (`payments status`, `data-set ls`, `provider ls`, `data-set show`, `data-set piece-status`, …) | None |
-| `add`, `import` | `CreateDataSet`, `AddPieces` |
-| `rm` (`--piece` or `--all`) | `SchedulePieceRemovals` |
-| `data-set terminate` | `TerminateService` |
-| Pinning server (`filecoin-pinning-server`) | `CreateDataSet`, `AddPieces`, `SchedulePieceRemovals` |
+| `add`, `import` | `createDataSet`, `addPieces` |
+| `rm` (`--piece` or `--all`) | `schedulePieceRemovals` |
+| `data-set terminate` | `terminateService` |
+| Pinning server (`filecoin-pinning-server`) | `createDataSet`, `addPieces`, `schedulePieceRemovals` |
 
 If the session key is missing a required scope, the command fails up front with a console link to approve the missing scope with the owner wallet, plus the equivalent `filecoin-pin session authorize` / `filecoin-pin session create` commands for the account owner to run.
 

--- a/README.md
+++ b/README.md
@@ -261,11 +261,25 @@ filecoin-pin add myfile.txt
 * `-v`, `--verbose`: Verbose output
 * `--private-key`: Ethereum-style (`0x`) private key (wallet and signer), funded with USDFC
 * `--wallet-address`: Session key mode: owner wallet address
-* `--session-key`: Session key mode: the session key's **private key** (printed as `SESSION_KEY` by `filecoin-pin session create` / `session generate`), not the session address
+* `--session-key`: Session key mode: the session key's **private key** (printed as `SESSION_KEY` by `filecoin-pin session create` / `session generate`), not the session address. Each command checks only the permissions it needs; see [Session-Key Permissions](#session-key-permissions) below.
 * `--network`: Filecoin network to use: `mainnet`, `calibration`, or `devnet` (default: `mainnet`). Mutually exclusive with `--rpc-url`.
 * `--rpc-url`: Filecoin RPC endpoint. Filecoin Pin probes its `eth_chainId` to derive the chain. Mutually exclusive with `--network`.
 
 Other arguments are possible for individual commands, use `--help` to find out more.
+
+### Session-Key Permissions
+
+In session-key mode, each command checks only the on-chain permissions it needs — a delegate does not need the full FWSS permission set to run a scoped subset of commands.
+
+| Command | Required scopes |
+| --- | --- |
+| Read commands (`payments status`, `data-set ls`, `provider ls`, `data-set show`, `data-set piece-status`, …) | None |
+| `add`, `import` | `CreateDataSet`, `AddPieces` |
+| `rm` (`--piece` or `--all`) | `SchedulePieceRemovals` |
+| `data-set terminate` | `TerminateService` |
+| Pinning server (`filecoin-pinning-server`) | `CreateDataSet`, `AddPieces`, `SchedulePieceRemovals` |
+
+If the session key is missing a required scope, the command fails up front with a console link to approve the missing scope with the owner wallet, plus the equivalent `filecoin-pin session authorize` / `filecoin-pin session create` commands for the account owner to run.
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ PRIVATE_KEY=0x...              # Ethereum private key with USDFC tokens
 # Optional - Network Configuration
 NETWORK=mainnet                # Network to use: mainnet, calibration, or devnet (default: mainnet)
 RPC_URL=wss://...              # Filecoin RPC endpoint (overrides NETWORK if specified)
+CONSOLE_URL=https://...        # Filecoin Cloud console base URL for remediation links (default: pay.filecoin.cloud)
                                # Mainnet: wss://wss.node.glif.io/apigw/lotus/rpc/v1
                                # Calibration: wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1
 

--- a/src/add/add.ts
+++ b/src/add/add.ts
@@ -8,6 +8,7 @@
 import { createReadStream } from 'node:fs'
 import { stat } from 'node:fs/promises'
 import { Readable } from 'node:stream'
+import { AddPiecesPermission, CreateDataSetPermission } from '@filoz/synapse-core/session-key'
 import pc from 'picocolors'
 import pino from 'pino'
 import { CliFatal, isCliFatal } from '../common/cli-errors.js'
@@ -180,6 +181,7 @@ export async function runAdd(options: AddOptions): Promise<AddResult | AddDryRun
       config.dataSetMetadata = dataSetMetadata
     }
     if (withCDN) config.withCDN = true
+    config.requiredPermissions = [CreateDataSetPermission, AddPiecesPermission]
 
     const synapse = await initializeSynapse(config, logger)
     const networkSlug = getNetworkSlug(synapse.chain)

--- a/src/core/session/console-url.ts
+++ b/src/core/session/console-url.ts
@@ -28,11 +28,28 @@ export function resolveConsoleUrl(chainId: number, override?: string): string | 
   return override ?? process.env.CONSOLE_URL ?? DEFAULT_CONSOLE_URLS[chainId]
 }
 
+/** Console network slug by chain id; the console validates and guards on it. */
+const CONSOLE_NETWORK_SLUG: Record<number, string> = {
+  314: 'mainnet',
+  314159: 'calibration',
+}
+
 /**
  * Build the console deep link that pre-fills the session address and the
- * scopes it needs on the session-keys authorization page.
+ * scopes it needs on the session-keys authorization page. Carries the
+ * network the failure happened on so the console can refuse to prefill
+ * when the connected wallet is on a different chain — without it, a
+ * calibration remediation link approved by a mainnet-connected wallet
+ * silently grants the scopes on mainnet.
  */
-export function buildAuthorizeUrl(consoleUrl: string, sessionAddress: string, scopeIds: string[]): string {
+export function buildAuthorizeUrl(
+  consoleUrl: string,
+  sessionAddress: string,
+  scopeIds: string[],
+  chainId?: number
+): string {
   const base = consoleUrl.endsWith('/') ? consoleUrl.slice(0, -1) : consoleUrl
-  return `${base}/console/session-keys?authorize=${sessionAddress}&scopes=${scopeIds.join(',')}`
+  const network = chainId != null ? CONSOLE_NETWORK_SLUG[chainId] : undefined
+  const networkParam = network ? `&network=${network}` : ''
+  return `${base}/console/session-keys?authorize=${sessionAddress}&scopes=${scopeIds.join(',')}${networkParam}`
 }

--- a/src/core/session/console-url.ts
+++ b/src/core/session/console-url.ts
@@ -20,12 +20,12 @@ export const DEFAULT_CONSOLE_URLS: Record<number, string> = {
 }
 
 /**
- * Pick the console base URL: an explicit override wins, then `CONSOLE_URL`,
- * then the known deployment for the chain. Returns `undefined` when none of
- * those resolve — the caller falls back to a console-without-a-link message.
+ * Pick the console base URL: `CONSOLE_URL` wins, then the known deployment
+ * for the chain. Returns `undefined` when neither resolves — the caller
+ * falls back to a console-without-a-link message.
  */
-export function resolveConsoleUrl(chainId: number, override?: string): string | undefined {
-  return override ?? process.env.CONSOLE_URL ?? DEFAULT_CONSOLE_URLS[chainId]
+export function resolveConsoleUrl(chainId: number): string | undefined {
+  return process.env.CONSOLE_URL ?? DEFAULT_CONSOLE_URLS[chainId]
 }
 
 /** Console network slug by chain id; the console validates and guards on it. */

--- a/src/core/session/console-url.ts
+++ b/src/core/session/console-url.ts
@@ -41,6 +41,10 @@ const CONSOLE_NETWORK_SLUG: Record<number, string> = {
  * when the connected wallet is on a different chain — without it, a
  * calibration remediation link approved by a mainnet-connected wallet
  * silently grants the scopes on mainnet.
+ *
+ * The address is lowercased: the console validates it with viem's strict
+ * `isAddress`, which accepts all-lowercase or a correct EIP-55 checksum but
+ * silently rejects mixed-case with a wrong checksum. Lowercase always passes.
  */
 export function buildAuthorizeUrl(
   consoleUrl: string,
@@ -51,5 +55,5 @@ export function buildAuthorizeUrl(
   const base = consoleUrl.endsWith('/') ? consoleUrl.slice(0, -1) : consoleUrl
   const network = chainId != null ? CONSOLE_NETWORK_SLUG[chainId] : undefined
   const networkParam = network ? `&network=${network}` : ''
-  return `${base}/console/session-keys?authorize=${sessionAddress}&scopes=${scopeIds.join(',')}${networkParam}`
+  return `${base}/console/session-keys?authorize=${sessionAddress.toLowerCase()}&scopes=${scopeIds.join(',')}${networkParam}`
 }

--- a/src/core/session/console-url.ts
+++ b/src/core/session/console-url.ts
@@ -4,23 +4,15 @@
  */
 
 /**
- * Console deployments by chain id. One deployment serves both networks and
- * the console switches network in-app, so mainnet and calibration share a
- * base URL; the network travels in the `network` query parameter.
- * `CONSOLE_URL` still overrides for local or preview consoles.
+ * One console deployment serves both networks and switches network in-app,
+ * so the network travels in the `network` query parameter rather than in
+ * the base URL. `CONSOLE_URL` overrides for local or preview consoles.
  */
-export const DEFAULT_CONSOLE_URLS: Record<number, string> = {
-  314: 'https://pay.filecoin.cloud',
-  314159: 'https://pay.filecoin.cloud',
-}
+export const DEFAULT_CONSOLE_URL = 'https://pay.filecoin.cloud'
 
-/**
- * Pick the console base URL: `CONSOLE_URL` wins, then the known deployment
- * for the chain. Returns `undefined` when neither resolves — the caller
- * falls back to a console-without-a-link message.
- */
-export function resolveConsoleUrl(chainId: number): string | undefined {
-  return process.env.CONSOLE_URL ?? DEFAULT_CONSOLE_URLS[chainId]
+/** Console base URL: `CONSOLE_URL` when set, otherwise the production deployment. */
+export function resolveConsoleUrl(): string {
+  return process.env.CONSOLE_URL ?? DEFAULT_CONSOLE_URL
 }
 
 /** Console network slug by chain id; the console validates and guards on it. */

--- a/src/core/session/console-url.ts
+++ b/src/core/session/console-url.ts
@@ -1,0 +1,34 @@
+/**
+ * Console URL helper for session-key preflight remediation messages.
+ *
+ * TEMPORARY: dedupe with the session console-pairing helpers
+ * (resolveConsoleUrl/buildAuthorizeUrl) when that work lands on master.
+ */
+
+/**
+ * Known console deployments by chain id.
+ *
+ * TODO: add pay.filecoin.cloud for 314/314159 once the console's
+ * session-keys page (and its ?authorize=&scopes= pairing params) ships to
+ * production — today it only exists on an unreleased branch, so a default
+ * link would 404. Until then the link only renders when CONSOLE_URL is set.
+ */
+export const DEFAULT_CONSOLE_URLS: Record<number, string> = {}
+
+/**
+ * Pick the console base URL: an explicit override wins, then `CONSOLE_URL`,
+ * then the known deployment for the chain. Returns `undefined` when none of
+ * those resolve — the caller falls back to a console-without-a-link message.
+ */
+export function resolveConsoleUrl(chainId: number, override?: string): string | undefined {
+  return override ?? process.env.CONSOLE_URL ?? DEFAULT_CONSOLE_URLS[chainId]
+}
+
+/**
+ * Build the console deep link that pre-fills the session address and the
+ * scopes it needs on the session-keys authorization page.
+ */
+export function buildAuthorizeUrl(consoleUrl: string, sessionAddress: string, scopeIds: string[]): string {
+  const base = consoleUrl.endsWith('/') ? consoleUrl.slice(0, -1) : consoleUrl
+  return `${base}/console/session-keys?authorize=${sessionAddress}&scopes=${scopeIds.join(',')}`
+}

--- a/src/core/session/console-url.ts
+++ b/src/core/session/console-url.ts
@@ -3,10 +3,15 @@
  * deep links. Session-key pairing/login work builds on these same helpers.
  */
 
-/** Console deployments by chain id; calibration lives under a path prefix. */
+/**
+ * Console deployments by chain id. One deployment serves both networks and
+ * the console switches network in-app, so mainnet and calibration share a
+ * base URL; the network travels in the `network` query parameter.
+ * `CONSOLE_URL` still overrides for local or preview consoles.
+ */
 export const DEFAULT_CONSOLE_URLS: Record<number, string> = {
   314: 'https://pay.filecoin.cloud',
-  314159: 'https://pay.filecoin.cloud/calibration',
+  314159: 'https://pay.filecoin.cloud',
 }
 
 /**

--- a/src/core/session/console-url.ts
+++ b/src/core/session/console-url.ts
@@ -1,22 +1,12 @@
 /**
- * Console URL helper for session-key preflight remediation messages.
- *
- * TEMPORARY: dedupe with the session console-pairing helpers
- * (resolveConsoleUrl/buildAuthorizeUrl) when that work lands on master.
+ * Console URL helpers: the canonical builder for Filecoin Cloud console
+ * deep links. Session-key pairing/login work builds on these same helpers.
  */
 
-/**
- * Known console deployments by chain id. One deployment serves both networks
- * (the console switches network in-app), so mainnet and calibration share a
- * base URL. `CONSOLE_URL` still overrides for local/preview consoles.
- *
- * NOTE: links 404 until the console's session-keys page (with its
- * ?authorize=&scopes= pairing params) is deployed — this PR is opened
- * together with that console PR and must not ship ahead of it.
- */
+/** Console deployments by chain id; calibration lives under a path prefix. */
 export const DEFAULT_CONSOLE_URLS: Record<number, string> = {
   314: 'https://pay.filecoin.cloud',
-  314159: 'https://pay.filecoin.cloud',
+  314159: 'https://pay.filecoin.cloud/calibration',
 }
 
 /**

--- a/src/core/session/console-url.ts
+++ b/src/core/session/console-url.ts
@@ -6,14 +6,18 @@
  */
 
 /**
- * Known console deployments by chain id.
+ * Known console deployments by chain id. One deployment serves both networks
+ * (the console switches network in-app), so mainnet and calibration share a
+ * base URL. `CONSOLE_URL` still overrides for local/preview consoles.
  *
- * TODO: add pay.filecoin.cloud for 314/314159 once the console's
- * session-keys page (and its ?authorize=&scopes= pairing params) ships to
- * production — today it only exists on an unreleased branch, so a default
- * link would 404. Until then the link only renders when CONSOLE_URL is set.
+ * NOTE: links 404 until the console's session-keys page (with its
+ * ?authorize=&scopes= pairing params) is deployed — this PR is opened
+ * together with that console PR and must not ship ahead of it.
  */
-export const DEFAULT_CONSOLE_URLS: Record<number, string> = {}
+export const DEFAULT_CONSOLE_URLS: Record<number, string> = {
+  314: 'https://pay.filecoin.cloud',
+  314159: 'https://pay.filecoin.cloud',
+}
 
 /**
  * Pick the console base URL: an explicit override wins, then `CONSOLE_URL`,

--- a/src/core/session/console-url.ts
+++ b/src/core/session/console-url.ts
@@ -45,10 +45,10 @@ export function buildAuthorizeUrl(
   consoleUrl: string,
   sessionAddress: string,
   scopeIds: string[],
-  chainId?: number
+  chainId: number
 ): string {
   const base = consoleUrl.endsWith('/') ? consoleUrl.slice(0, -1) : consoleUrl
-  const network = chainId != null ? CONSOLE_NETWORK_SLUG[chainId] : undefined
+  const network = CONSOLE_NETWORK_SLUG[chainId]
   const networkParam = network ? `&network=${network}` : ''
   return `${base}/console/session-keys?authorize=${sessionAddress.toLowerCase()}&scopes=${scopeIds.join(',')}${networkParam}`
 }

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -189,7 +189,7 @@ function checkSessionKeyPermissions(
   const lines = [problem, '']
   if (consoleUrl != null) {
     lines.push('Recommended — approve in the browser with the owner wallet:')
-    lines.push(`  ${buildAuthorizeUrl(consoleUrl, key.address, scopeIds)}`)
+    lines.push(`  ${buildAuthorizeUrl(consoleUrl, key.address, scopeIds, chainId)}`)
   } else {
     lines.push('Authorize in the Filecoin Pay console (set CONSOLE_URL for a direct link).')
   }

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -120,7 +120,8 @@ function isPrivateKeyConfig(config: SynapseSetupConfig): config is PrivateKeyCon
   return 'privateKey' in config && config.privateKey != null
 }
 
-function isSessionKeyConfig(config: SynapseSetupConfig): config is SessionKeyConfig {
+/** True when the config authenticates with a session key (owner address + session private key). */
+export function isSessionKeyConfig(config: SynapseSetupConfig): config is SessionKeyConfig {
   return (
     'walletAddress' in config &&
     'sessionKey' in config &&
@@ -202,7 +203,7 @@ function checkSessionKeyPermissions(
     : `Session key ${key.address} lacks ${scopeLabels} for this operation on ${networkName}.`
 
   const consoleUrl = resolveConsoleUrl(chainId)
-  const lines = neverAuthorized ? [problem, ''] : [problem, ...scopeDetails, '']
+  const lines = [problem, ...scopeDetails, '']
   if (consoleUrl != null) {
     lines.push('Recommended — approve in the browser with the owner wallet:')
     // pc.cyan+underline: conventional terminal hyperlink styling so the link

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -182,12 +182,25 @@ function checkSessionKeyPermissions(
   const scopeLabels = missing.map((p) => PermissionNames[p] ?? p).join(', ')
   const scopesArg = scopeIds.join(',')
 
+  // Per-scope detail preserves the expired-at vs never-granted distinction
+  // the on-chain expirations carry — an expired grant points at renewal,
+  // a never-granted scope points at a fresh authorization.
+  const now = BigInt(Math.floor(Date.now() / 1000))
+  const scopeDetails = missing.map((p) => {
+    const name = PermissionNames[p] ?? p
+    const expiry = key.expirations[p] ?? 0n
+    if (expiry > 0n && expiry <= now) {
+      return `  • ${name}: expired at ${new Date(Number(expiry) * 1000).toISOString()}`
+    }
+    return `  • ${name}: never granted`
+  })
+
   const problem = neverAuthorized
     ? `Session key ${key.address} isn't authorized for account ${ownerAddress} on ${networkName} — never authorized, expired/revoked, or the key is for a different network (check --network).`
     : `Session key ${key.address} lacks ${scopeLabels} for this operation on ${networkName}.`
 
   const consoleUrl = resolveConsoleUrl(chainId)
-  const lines = [problem, '']
+  const lines = neverAuthorized ? [problem, ''] : [problem, ...scopeDetails, '']
   if (consoleUrl != null) {
     lines.push('Recommended — approve in the browser with the owner wallet:')
     // pc.cyan+underline: conventional terminal hyperlink styling so the link

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -13,14 +13,7 @@ import { calibration, type FilecoinChain, mainnet, Synapse, type SynapseOptions 
 export { calibration, mainnet, type FilecoinChain }
 
 import type { SessionKey } from '@filoz/synapse-core/session-key'
-import {
-  AddPiecesPermission,
-  CreateDataSetPermission,
-  DefaultFwssPermissions,
-  fromSecp256k1,
-  SchedulePieceRemovalsPermission,
-  TerminateServicePermission,
-} from '@filoz/synapse-core/session-key'
+import { fromSecp256k1, type Permission, PermissionNames } from '@filoz/synapse-core/session-key'
 import type { Logger } from 'pino'
 import {
   type Account,
@@ -32,6 +25,7 @@ import {
   type WebSocketTransport,
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
+import { buildAuthorizeUrl, resolveConsoleUrl } from '../session/console-url.js'
 import { APPLICATION_SOURCE } from './constants.js'
 import { createTransport } from './create-transport.js'
 import { resolveChainFromRpc } from './resolve-chain-from-rpc.js'
@@ -70,6 +64,12 @@ interface BaseSynapseConfig {
   withCDN?: boolean
   /** Default metadata to apply when creating datasets */
   dataSetMetadata?: Record<string, string>
+  /**
+   * Session-key mode only: on-chain permissions this invocation needs, checked
+   * up front so a missing grant fails with a remediation message instead of a
+   * tx revert. Defaults to none — commands that only read require no permissions.
+   */
+  requiredPermissions?: Permission[]
 }
 
 /**
@@ -130,14 +130,6 @@ function isSessionKeyConfig(config: SynapseSetupConfig): config is SessionKeyCon
 function isReadOnlyConfig(config: SynapseSetupConfig): config is ReadOnlyConfig {
   return 'readOnly' in config && (config as ReadOnlyConfig).readOnly === true && 'walletAddress' in config
 }
-
-const PERMISSION_NAMES: Record<string, string> = {
-  [CreateDataSetPermission]: 'CreateDataSet',
-  [TerminateServicePermission]: 'TerminateService',
-  [AddPiecesPermission]: 'AddPieces',
-  [SchedulePieceRemovalsPermission]: 'SchedulePieceRemovals',
-}
-
 /**
  * Reject malformed session key material before it reaches the SDK, whose own
  * error ("invalid private key, expected hex or 32 bytes") never names the flag.
@@ -153,28 +145,60 @@ export function assertSessionKeyPrivateKey(value: string): asserts value is Hex 
   )
 }
 
-function checkSessionKeyPermissions(key: SessionKey<'Secp256k1'>, ownerAddress: string): void {
-  const missing = DefaultFwssPermissions.filter((p) => !key.hasPermission(p))
+/**
+ * Preflight a session key against the permissions an operation needs.
+ *
+ * Two failure shapes, both console-first (spec: problem -> console
+ * recommended -> owner CLI). Never tells a delegate to run a root-key
+ * command as their own action.
+ *
+ *  - Not authorized at all: every on-chain expiration is 0 (never granted,
+ *    or fully expired/revoked — on-chain state can't tell those apart).
+ *  - Missing the required scope: some grant is live, but not the one this
+ *    operation needs.
+ */
+function checkSessionKeyPermissions(
+  key: SessionKey<'Secp256k1'>,
+  ownerAddress: string,
+  required: Permission[],
+  chainId: number,
+  networkName: string
+): void {
+  const missing = required.filter((p) => !key.hasPermission(p))
   if (missing.length === 0) return
 
-  const now = BigInt(Math.floor(Date.now() / 1000))
-  const lines = missing.map((p) => {
-    const name = PERMISSION_NAMES[p] ?? p
-    const expiry = key.expirations[p] ?? 0n
-    if (expiry > 0n && expiry < now) {
-      return `  • ${name}: expired at ${new Date(Number(expiry) * 1000).toISOString()}`
-    }
-    return `  • ${name}: never authorized`
+  const allExpirations = Object.values(key.expirations)
+  const neverAuthorized = allExpirations.length > 0 && allExpirations.every((expiry) => expiry === 0n)
+
+  // Scope ids are the camelCase forms of the FWSS EIP-712 operation names
+  // (PermissionNames is PascalCase: CreateDataSet -> createDataSet). Derive
+  // them here rather than importing the CLI-layer session/scopes.ts into core.
+  const scopeIds = missing.map((p) => {
+    const name = PermissionNames[p]
+    if (name == null || name.length === 0) return p
+    return name.charAt(0).toLowerCase() + name.slice(1)
   })
+  const scopeLabels = missing.map((p) => PermissionNames[p] ?? p).join(', ')
+  const scopesArg = scopeIds.join(',')
 
-  const footnotes = missing.map((p) => `  ${PERMISSION_NAMES[p] ?? p}: ${p}`)
+  const problem = neverAuthorized
+    ? `Session key ${key.address} isn't authorized for account ${ownerAddress} on ${networkName} — never authorized, expired/revoked, or the key is for a different network (check --network).`
+    : `Session key ${key.address} lacks ${scopeLabels} for this operation on ${networkName}.`
 
-  throw new Error(
-    `Session key ${key.address} is missing ${missing.length} required permission(s):\n` +
-      lines.join('\n') +
-      `\nAuthorize this session key from owner wallet ${ownerAddress}.\nPermission hashes:\n` +
-      footnotes.join('\n')
-  )
+  const consoleUrl = resolveConsoleUrl(chainId)
+  const lines = [problem, '']
+  if (consoleUrl != null) {
+    lines.push('Recommended — approve in the browser with the owner wallet:')
+    lines.push(`  ${buildAuthorizeUrl(consoleUrl, key.address, scopeIds)}`)
+  } else {
+    lines.push('Authorize in the Filecoin Pay console (set CONSOLE_URL for a direct link).')
+  }
+  lines.push('')
+  lines.push('The account owner can also use the CLI:')
+  lines.push(`  filecoin-pin session authorize ${key.address} --scopes ${scopesArg}   (add scope to this key)`)
+  lines.push(`  filecoin-pin session create --scopes ${scopesArg}              (or mint a new scoped key)`)
+
+  throw new Error(lines.join('\n'))
 }
 
 /**
@@ -231,7 +255,7 @@ export async function initializeSynapse(config: SynapseSetupConfig, logger?: Log
       throw new Error(`Invalid --session-key / SESSION_KEY: ${reason}`, { cause: error })
     }
     await sessionKey.syncExpirations()
-    checkSessionKeyPermissions(sessionKey, walletAddress)
+    checkSessionKeyPermissions(sessionKey, walletAddress, config.requiredPermissions ?? [], chain.id, chain.name)
     logger?.info({ event: 'synapse.init', mode: 'session-key' }, 'Initializing Synapse (session key)')
   } else if (isPrivateKeyConfig(config)) {
     account = privateKeyToAccount(config.privateKey)
@@ -280,6 +304,10 @@ export async function initializeSynapse(config: SynapseSetupConfig, logger?: Log
   }
   if (sessionKey) {
     synapseOptions.sessionKey = sessionKey
+    // Match the SDK's own permission gate to this command's needs; without it
+    // Synapse.create defaults to requiring all FWSS permissions and re-rejects a
+    // subset key that our preflight already accepted.
+    synapseOptions.requiredPermissions = config.requiredPermissions ?? []
   }
   if (config.withCDN) {
     synapseOptions.withCDN = config.withCDN

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -66,9 +66,11 @@ interface BaseSynapseConfig {
   /** Default metadata to apply when creating datasets */
   dataSetMetadata?: Record<string, string>
   /**
-   * Session-key mode only: on-chain permissions this invocation needs, checked
-   * up front so a missing grant fails with a remediation message instead of a
-   * tx revert. Defaults to none — commands that only read require no permissions.
+   * Session-key mode only: the permissions this command needs. Before doing
+   * any work, we check the session key's on-chain grants cover these. If one
+   * is missing, the command stops immediately with instructions for getting
+   * it granted (console link), rather than failing later mid-transaction.
+   * Leave unset for read-only commands — they need no permissions.
    */
   requiredPermissions?: Permission[]
 }

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -207,8 +207,12 @@ function checkSessionKeyPermissions(
   }
   lines.push('')
   lines.push('The account owner can also use the CLI:')
-  lines.push(`  filecoin-pin session authorize ${key.address} --scopes ${scopesArg}   (add scope to this key)`)
-  lines.push(`  filecoin-pin session create --scopes ${scopesArg}              (or mint a new scoped key)`)
+  lines.push(`  filecoin-pin session authorize ${key.address} --scopes ${scopesArg}   (adds to this key, no new key)`)
+  if (neverAuthorized) {
+    lines.push(`  filecoin-pin session create --scopes ${scopesArg}              (or mint a new scoped key)`)
+  }
+  lines.push('')
+  lines.push('Then re-run this command.')
 
   throw new Error(lines.join('\n'))
 }

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -196,15 +196,10 @@ function checkSessionKeyPermissions(
     ? `Session key ${key.address} isn't authorized for account ${ownerAddress} on ${networkName} — never authorized, expired/revoked, or the key is for a different network (check --network).`
     : `Session key ${key.address} lacks ${scopeLabels} for this operation on ${networkName}.`
 
-  const consoleUrl = resolveConsoleUrl(chainId)
   const lines = [problem, ...scopeDetails, '']
-  if (consoleUrl != null) {
-    lines.push('Recommended — approve in the browser with the owner wallet:')
-    // Plain text: this is a library error, so no terminal styling here.
-    lines.push(`  ${buildAuthorizeUrl(consoleUrl, key.address, scopeIds, chainId)}`)
-  } else {
-    lines.push('Authorize in the Filecoin Cloud console (set CONSOLE_URL for a direct link).')
-  }
+  lines.push('Recommended — approve in the browser with the owner wallet:')
+  // Plain text: this is a library error, so no terminal styling here.
+  lines.push(`  ${buildAuthorizeUrl(resolveConsoleUrl(), key.address, scopeIds, chainId)}`)
   lines.push('')
   lines.push('The account owner can also use the CLI:')
   lines.push(`  filecoin-pin session authorize ${key.address} --scopes ${scopesArg}   (adds to this key, no new key)`)

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -14,7 +14,6 @@ export { calibration, mainnet, type FilecoinChain }
 
 import type { SessionKey } from '@filoz/synapse-core/session-key'
 import { fromSecp256k1, type Permission, PermissionNames } from '@filoz/synapse-core/session-key'
-import pc from 'picocolors'
 import type { Logger } from 'pino'
 import {
   type Account,
@@ -27,6 +26,7 @@ import {
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { buildAuthorizeUrl, resolveConsoleUrl } from '../session/console-url.js'
+import { scopeIdOf } from '../session/scopes.js'
 import { APPLICATION_SOURCE } from './constants.js'
 import { createTransport } from './create-transport.js'
 import { resolveChainFromRpc } from './resolve-chain-from-rpc.js'
@@ -175,14 +175,7 @@ function checkSessionKeyPermissions(
   const allExpirations = Object.values(key.expirations)
   const neverAuthorized = allExpirations.length > 0 && allExpirations.every((expiry) => expiry === 0n)
 
-  // Scope ids are the camelCase forms of the FWSS EIP-712 operation names
-  // (PermissionNames is PascalCase: CreateDataSet -> createDataSet). Derive
-  // them here rather than importing the CLI-layer session/scopes.ts into core.
-  const scopeIds = missing.map((p) => {
-    const name = PermissionNames[p]
-    if (name == null || name.length === 0) return p
-    return name.charAt(0).toLowerCase() + name.slice(1)
-  })
+  const scopeIds = missing.map(scopeIdOf)
   const scopeLabels = missing.map((p) => PermissionNames[p] ?? p).join(', ')
   const scopesArg = scopeIds.join(',')
 
@@ -207,11 +200,10 @@ function checkSessionKeyPermissions(
   const lines = [problem, ...scopeDetails, '']
   if (consoleUrl != null) {
     lines.push('Recommended — approve in the browser with the owner wallet:')
-    // pc.cyan+underline: conventional terminal hyperlink styling so the link
-    // stands out of the error wall; picocolors self-disables when not a TTY.
-    lines.push(`  ${pc.cyan(pc.underline(buildAuthorizeUrl(consoleUrl, key.address, scopeIds, chainId)))}`)
+    // Plain text: this is a library error, so no terminal styling here.
+    lines.push(`  ${buildAuthorizeUrl(consoleUrl, key.address, scopeIds, chainId)}`)
   } else {
-    lines.push('Authorize in the Filecoin Pay console (set CONSOLE_URL for a direct link).')
+    lines.push('Authorize in the Filecoin Cloud console (set CONSOLE_URL for a direct link).')
   }
   lines.push('')
   lines.push('The account owner can also use the CLI:')

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -131,7 +131,8 @@ export function isSessionKeyConfig(config: SynapseSetupConfig): config is Sessio
   )
 }
 
-function isReadOnlyConfig(config: SynapseSetupConfig): config is ReadOnlyConfig {
+/** True when the config is a view-only wallet address (no signer). */
+export function isReadOnlyConfig(config: SynapseSetupConfig): config is ReadOnlyConfig {
   return 'readOnly' in config && (config as ReadOnlyConfig).readOnly === true && 'walletAddress' in config
 }
 /**

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -14,6 +14,7 @@ export { calibration, mainnet, type FilecoinChain }
 
 import type { SessionKey } from '@filoz/synapse-core/session-key'
 import { fromSecp256k1, type Permission, PermissionNames } from '@filoz/synapse-core/session-key'
+import pc from 'picocolors'
 import type { Logger } from 'pino'
 import {
   type Account,
@@ -189,7 +190,9 @@ function checkSessionKeyPermissions(
   const lines = [problem, '']
   if (consoleUrl != null) {
     lines.push('Recommended — approve in the browser with the owner wallet:')
-    lines.push(`  ${buildAuthorizeUrl(consoleUrl, key.address, scopeIds, chainId)}`)
+    // pc.cyan+underline: conventional terminal hyperlink styling so the link
+    // stands out of the error wall; picocolors self-disables when not a TTY.
+    lines.push(`  ${pc.cyan(pc.underline(buildAuthorizeUrl(consoleUrl, key.address, scopeIds, chainId)))}`)
   } else {
     lines.push('Authorize in the Filecoin Pay console (set CONSOLE_URL for a direct link).')
   }

--- a/src/data-set/run.ts
+++ b/src/data-set/run.ts
@@ -1,4 +1,5 @@
 import { confirm, isCancel } from '@clack/prompts'
+import { TerminateServicePermission } from '@filoz/synapse-core/session-key'
 import type { EnhancedDataSetInfo, Synapse } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
 import { WaitForTransactionReceiptTimeoutError } from 'viem'
@@ -218,7 +219,7 @@ export async function runTerminateDataSetCommand(dataSetId: number, options: Dat
   spinner.start('Connecting to Synapse...')
 
   try {
-    const synapse = await getCliSynapse(options)
+    const synapse = await getCliSynapse(options, [TerminateServicePermission])
     const network = synapse.chain.name
     const address = getClientAddress(synapse)
 

--- a/src/filecoin-pinning-server.ts
+++ b/src/filecoin-pinning-server.ts
@@ -1,3 +1,8 @@
+import {
+  AddPiecesPermission,
+  CreateDataSetPermission,
+  SchedulePieceRemovalsPermission,
+} from '@filoz/synapse-core/session-key'
 import fastify, { type FastifyError, type FastifyInstance, type FastifyReply, type FastifyRequest } from 'fastify'
 import { CID } from 'multiformats/cid'
 import type { Logger } from 'pino'
@@ -105,6 +110,8 @@ function buildSynapseConfig(config: Config): SynapseSetupConfig {
       ...base,
       walletAddress: config.walletAddress,
       sessionKey: config.sessionKey,
+      // The pinning API creates datasets, adds pieces, and deletes pins.
+      requiredPermissions: [CreateDataSetPermission, AddPiecesPermission, SchedulePieceRemovalsPermission],
     }
   }
 

--- a/src/import/import.ts
+++ b/src/import/import.ts
@@ -8,6 +8,7 @@
 import { createReadStream } from 'node:fs'
 import { stat } from 'node:fs/promises'
 import { Readable } from 'node:stream'
+import { AddPiecesPermission, CreateDataSetPermission } from '@filoz/synapse-core/session-key'
 import { CarReader } from '@ipld/car'
 import { CID } from 'multiformats/cid'
 import pc from 'picocolors'
@@ -250,6 +251,7 @@ export async function runCarImport(options: ImportOptions): Promise<ImportResult
       config.dataSetMetadata = dataSetMetadata
     }
     if (withCDN) config.withCDN = true
+    config.requiredPermissions = [CreateDataSetPermission, AddPiecesPermission]
 
     const synapse = await initializeSynapse(config, logger)
     const networkSlug = getNetworkSlug(synapse.chain)

--- a/src/payments/auto.ts
+++ b/src/payments/auto.ts
@@ -24,7 +24,7 @@ import {
 import { DEFAULT_COPIES } from '../core/synapse/constants.js'
 import { getClientAddress, initializeSynapse } from '../core/synapse/index.js'
 import { formatUSDFC } from '../core/utils/format.js'
-import { getCLILogger, parseCLIAuth } from '../utils/cli-auth.js'
+import { assertOwnerAuth, getCLILogger, parseCLIAuth } from '../utils/cli-auth.js'
 import { cancel, createSpinner, intro, outro } from '../utils/cli-helpers.js'
 import { log } from '../utils/cli-logger.js'
 import { displayAccountInfo, displayDepositWarning } from './setup.js'
@@ -60,6 +60,7 @@ export async function runAutoSetup(options: PaymentSetupOptions): Promise<void> 
   try {
     // Parse and validate authentication
     const authConfig = parseCLIAuth(options)
+    assertOwnerAuth(authConfig, 'payments setup --auto')
 
     const logger = getCLILogger()
     const synapse = await initializeSynapse(authConfig, logger)

--- a/src/payments/deposit.ts
+++ b/src/payments/deposit.ts
@@ -19,7 +19,7 @@ import {
 import { initializeSynapse } from '../core/synapse/index.js'
 import { formatUSDFC } from '../core/utils/format.js'
 import { formatRunwaySummary } from '../core/utils/index.js'
-import { type CLIAuthOptions, getCLILogger, parseCLIAuth } from '../utils/cli-auth.js'
+import { assertOwnerAuth, type CLIAuthOptions, getCLILogger, parseCLIAuth } from '../utils/cli-auth.js'
 import { cancel, createSpinner, intro, outro } from '../utils/cli-helpers.js'
 import { log } from '../utils/cli-logger.js'
 
@@ -46,6 +46,7 @@ export async function runDeposit(options: DepositOptions): Promise<void> {
   try {
     // Parse and validate authentication
     const authConfig = parseCLIAuth(options)
+    assertOwnerAuth(authConfig, 'payments deposit')
 
     const logger = getCLILogger()
     const synapse = await initializeSynapse(authConfig, logger)

--- a/src/payments/fund.ts
+++ b/src/payments/fund.ts
@@ -24,7 +24,7 @@ import {
 import { initializeSynapse } from '../core/synapse/index.js'
 import { formatUSDFC } from '../core/utils/format.js'
 import { formatRunwaySummary } from '../core/utils/index.js'
-import { getCLILogger, parseCLIAuth } from '../utils/cli-auth.js'
+import { assertOwnerAuth, getCLILogger, parseCLIAuth } from '../utils/cli-auth.js'
 import type { Spinner } from '../utils/cli-helpers.js'
 import { cancel, createSpinner, intro, isInteractive, outro } from '../utils/cli-helpers.js'
 import { isTTY, log } from '../utils/cli-logger.js'
@@ -247,6 +247,7 @@ export async function runFund(options: FundOptions): Promise<void> {
   try {
     // Parse and validate authentication
     const authConfig = parseCLIAuth(options)
+    assertOwnerAuth(authConfig, 'payments fund')
 
     const logger = getCLILogger()
     const synapse = await initializeSynapse(authConfig, logger)

--- a/src/payments/withdraw.ts
+++ b/src/payments/withdraw.ts
@@ -8,7 +8,7 @@ import { CliFatal, isCliFatal } from '../common/cli-errors.js'
 import { checkFILBalance, getPaymentStatus, validateGasRequirement, withdrawUSDFC } from '../core/payments/index.js'
 import { initializeSynapse } from '../core/synapse/index.js'
 import { formatUSDFC } from '../core/utils/format.js'
-import { type CLIAuthOptions, getCLILogger, parseCLIAuth } from '../utils/cli-auth.js'
+import { assertOwnerAuth, type CLIAuthOptions, getCLILogger, parseCLIAuth } from '../utils/cli-auth.js'
 import { cancel, createSpinner, intro, outro } from '../utils/cli-helpers.js'
 import { log } from '../utils/cli-logger.js'
 
@@ -38,6 +38,7 @@ export async function runWithdraw(options: WithdrawOptions): Promise<void> {
   try {
     // Parse and validate authentication
     const authConfig = parseCLIAuth(options)
+    assertOwnerAuth(authConfig, 'payments withdraw')
 
     const logger = getCLILogger()
     const synapse = await initializeSynapse(authConfig, logger)

--- a/src/rm/remove-all-pieces.ts
+++ b/src/rm/remove-all-pieces.ts
@@ -9,6 +9,7 @@
  * - Return aggregated results (or throw on failure)
  */
 import { confirm, isCancel } from '@clack/prompts'
+import { SchedulePieceRemovalsPermission } from '@filoz/synapse-core/session-key'
 import pc from 'picocolors'
 import pino from 'pino'
 import { setIncompleteExitCode } from '../common/cli-errors.js'
@@ -62,6 +63,7 @@ export async function runRmAllPieces(options: RmAllPiecesOptions): Promise<RmAll
     spinner.start('Initializing Synapse SDK...')
 
     const authConfig = parseCLIAuth(options)
+    authConfig.requiredPermissions = [SchedulePieceRemovalsPermission]
     const synapse = await initializeSynapse(authConfig, logger)
     const network = synapse.chain.name
 

--- a/src/rm/remove-piece.ts
+++ b/src/rm/remove-piece.ts
@@ -7,6 +7,8 @@
  * - Wire up progress events to spinner output
  * - Return transaction hash and confirmation status (or throw on failure)
  */
+
+import { SchedulePieceRemovalsPermission } from '@filoz/synapse-core/session-key'
 import pc from 'picocolors'
 import pino from 'pino'
 import { setIncompleteExitCode } from '../common/cli-errors.js'
@@ -59,6 +61,7 @@ export async function runRmPiece(options: RmPieceOptions): Promise<RmPieceResult
     spinner.start('Initializing Synapse SDK...')
 
     const authConfig = parseCLIAuth(options)
+    authConfig.requiredPermissions = [SchedulePieceRemovalsPermission]
     const synapse = await initializeSynapse(authConfig, logger)
     const network = synapse.chain.name
 

--- a/src/test/mocks/synapse-core-session-key.ts
+++ b/src/test/mocks/synapse-core-session-key.ts
@@ -19,6 +19,13 @@ export const DefaultFwssPermissions = [
   SchedulePieceRemovalsPermission,
 ]
 
+export const PermissionNames: Record<string, string> = {
+  [CreateDataSetPermission]: 'CreateDataSet',
+  [TerminateServicePermission]: 'TerminateService',
+  [AddPiecesPermission]: 'AddPieces',
+  [SchedulePieceRemovalsPermission]: 'SchedulePieceRemovals',
+}
+
 const mockExpirations = Object.fromEntries(DefaultFwssPermissions.map((p) => [p, 0n]))
 
 export const fromSecp256k1: Mock = vi.fn(() => ({

--- a/src/test/mocks/synapse-core-session-key.ts
+++ b/src/test/mocks/synapse-core-session-key.ts
@@ -1,30 +1,23 @@
 import { type Mock, vi } from 'vitest'
 
 /**
- * Mock implementation of @filoz/synapse-core/session-key for testing
- *
- * Exports real permission constants (hardcoded to avoid circular mock imports)
- * and overrides fromSecp256k1 so tests never hit the real network.
+ * Mock of @filoz/synapse-core/session-key for tests: re-exports the real
+ * permission constants and names, and overrides fromSecp256k1 so tests never
+ * hit the network.
  */
 
-export const CreateDataSetPermission = '0x25ebf20299107c91b4624d5bac3a16d32cabf0db23b450ee09ab7732983b1dc9'
-export const TerminateServicePermission = '0xb5d6b3fc97881f05e96958136ac09d7e0bc7cbf17ea92fce7c431d88132d2b58'
-export const AddPiecesPermission = '0x954bdc254591a7eab1b73f03842464d9283a08352772737094d710a4428fd183'
-export const SchedulePieceRemovalsPermission = '0x5415701e313bb627e755b16924727217bb356574fe20e7061442c200b0822b22'
+const actual = await vi.importActual<typeof import('@filoz/synapse-core/session-key')>(
+  '@filoz/synapse-core/session-key'
+)
 
-export const DefaultFwssPermissions = [
+export const {
   CreateDataSetPermission,
   TerminateServicePermission,
   AddPiecesPermission,
   SchedulePieceRemovalsPermission,
-]
-
-export const PermissionNames: Record<string, string> = {
-  [CreateDataSetPermission]: 'CreateDataSet',
-  [TerminateServicePermission]: 'TerminateService',
-  [AddPiecesPermission]: 'AddPieces',
-  [SchedulePieceRemovalsPermission]: 'SchedulePieceRemovals',
-}
+  DefaultFwssPermissions,
+  PermissionNames,
+} = actual
 
 const mockExpirations = Object.fromEntries(DefaultFwssPermissions.map((p) => [p, 0n]))
 

--- a/src/test/unit/add.test.ts
+++ b/src/test/unit/add.test.ts
@@ -11,6 +11,7 @@
 import { randomBytes } from 'node:crypto'
 import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { basename, join } from 'node:path'
+import { AddPiecesPermission, CreateDataSetPermission } from '@filoz/synapse-core/session-key'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runAdd, runAddFromCli } from '../../add/add.js'
 import type { AddDryRunResult, AddResult } from '../../add/types.js'
@@ -228,6 +229,7 @@ describe('Add Command', () => {
       expect(vi.mocked(initializeSynapse)).toHaveBeenCalledWith(
         expect.objectContaining({
           dataSetMetadata: { purpose: 'erc8004' },
+          requiredPermissions: [CreateDataSetPermission, AddPiecesPermission],
         }),
         expect.anything()
       )

--- a/src/test/unit/cli-validation.test.ts
+++ b/src/test/unit/cli-validation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { parseContextSelectionOptions } from '../../utils/cli-auth.js'
+import { assertOwnerAuth, parseCLIAuth, parseContextSelectionOptions } from '../../utils/cli-auth.js'
 
 describe('parseContextSelectionOptions empty-list regression', () => {
   const originalEnv = { ...process.env }
@@ -72,5 +72,28 @@ describe('parseContextSelectionOptions unified ID flags', () => {
 
   it('returns an empty selection when nothing is provided', () => {
     expect(parseContextSelectionOptions({})).toEqual({})
+  })
+})
+
+describe('assertOwnerAuth', () => {
+  const sessionOptions = {
+    walletAddress: '0x0000000000000000000000000000000000000002',
+    sessionKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+  }
+
+  it('refuses a session key on owner-only commands, naming the command', () => {
+    expect(() => assertOwnerAuth(parseCLIAuth(sessionOptions), 'payments deposit')).toThrow(
+      /payments deposit needs the account owner's wallet/
+    )
+  })
+
+  it('accepts a private key', () => {
+    const config = parseCLIAuth({ privateKey: '0x0000000000000000000000000000000000000000000000000000000000000001' })
+    expect(() => assertOwnerAuth(config, 'payments deposit')).not.toThrow()
+  })
+
+  it('accepts a view-only address (read path, no signing)', () => {
+    const config = parseCLIAuth({ viewAddress: '0x0000000000000000000000000000000000000002' })
+    expect(() => assertOwnerAuth(config, 'payments deposit')).not.toThrow()
   })
 })

--- a/src/test/unit/cli-validation.test.ts
+++ b/src/test/unit/cli-validation.test.ts
@@ -92,8 +92,8 @@ describe('assertOwnerAuth', () => {
     expect(() => assertOwnerAuth(config, 'payments deposit')).not.toThrow()
   })
 
-  it('accepts a view-only address (read path, no signing)', () => {
+  it('refuses a view-only address, which cannot sign', () => {
     const config = parseCLIAuth({ viewAddress: '0x0000000000000000000000000000000000000002' })
-    expect(() => assertOwnerAuth(config, 'payments deposit')).not.toThrow()
+    expect(() => assertOwnerAuth(config, 'payments withdraw')).toThrow(/view-only address can't sign/)
   })
 })

--- a/src/test/unit/console-url.test.ts
+++ b/src/test/unit/console-url.test.ts
@@ -18,15 +18,14 @@ describe('resolveConsoleUrl', () => {
     expect(resolveConsoleUrl(314159)).toBe('https://pay.filecoin.cloud')
   })
 
-  it('returns undefined for unknown chains without an override', () => {
+  it('returns undefined for unknown chains', () => {
     delete process.env.CONSOLE_URL
     expect(resolveConsoleUrl(1)).toBeUndefined()
   })
 
-  it('prefers CONSOLE_URL over the default, and the explicit override over both', () => {
+  it('prefers CONSOLE_URL over the default', () => {
     process.env.CONSOLE_URL = 'http://localhost:3005'
     expect(resolveConsoleUrl(314)).toBe('http://localhost:3005')
-    expect(resolveConsoleUrl(314, 'http://preview.test')).toBe('http://preview.test')
   })
 })
 

--- a/src/test/unit/console-url.test.ts
+++ b/src/test/unit/console-url.test.ts
@@ -12,20 +12,14 @@ afterEach(() => {
 })
 
 describe('resolveConsoleUrl', () => {
-  it('defaults to the production console on both networks', () => {
+  it('defaults to the production console', () => {
     delete process.env.CONSOLE_URL
-    expect(resolveConsoleUrl(314)).toBe('https://pay.filecoin.cloud')
-    expect(resolveConsoleUrl(314159)).toBe('https://pay.filecoin.cloud')
-  })
-
-  it('returns undefined for unknown chains', () => {
-    delete process.env.CONSOLE_URL
-    expect(resolveConsoleUrl(1)).toBeUndefined()
+    expect(resolveConsoleUrl()).toBe('https://pay.filecoin.cloud')
   })
 
   it('prefers CONSOLE_URL over the default', () => {
     process.env.CONSOLE_URL = 'http://localhost:3005'
-    expect(resolveConsoleUrl(314)).toBe('http://localhost:3005')
+    expect(resolveConsoleUrl()).toBe('http://localhost:3005')
   })
 })
 

--- a/src/test/unit/console-url.test.ts
+++ b/src/test/unit/console-url.test.ts
@@ -30,20 +30,22 @@ describe('resolveConsoleUrl', () => {
 })
 
 describe('buildAuthorizeUrl', () => {
-  it('builds the session-keys deep link with pairing params', () => {
+  it('builds the session-keys deep link with pairing params, lowercasing the address', () => {
+    // Lowercase is the contract: the console's strict isAddress silently
+    // rejects mixed-case with a wrong EIP-55 checksum; lowercase always passes.
     expect(
       buildAuthorizeUrl('https://pay.filecoin.cloud', '0xAbC0000000000000000000000000000000000001', [
         'createDataSet',
         'addPieces',
       ])
     ).toBe(
-      'https://pay.filecoin.cloud/console/session-keys?authorize=0xAbC0000000000000000000000000000000000001&scopes=createDataSet,addPieces'
+      'https://pay.filecoin.cloud/console/session-keys?authorize=0xabc0000000000000000000000000000000000001&scopes=createDataSet,addPieces'
     )
   })
 
   it('tolerates a trailing slash on the base URL', () => {
     expect(buildAuthorizeUrl('http://localhost:3005/', '0xA', ['addPieces'])).toBe(
-      'http://localhost:3005/console/session-keys?authorize=0xA&scopes=addPieces'
+      'http://localhost:3005/console/session-keys?authorize=0xa&scopes=addPieces'
     )
   })
 })
@@ -51,7 +53,7 @@ describe('buildAuthorizeUrl', () => {
 describe('buildAuthorizeUrl network param', () => {
   it('carries the network slug for known chain ids', () => {
     expect(buildAuthorizeUrl('https://pay.filecoin.cloud', '0xA', ['addPieces'], 314159)).toBe(
-      'https://pay.filecoin.cloud/console/session-keys?authorize=0xA&scopes=addPieces&network=calibration'
+      'https://pay.filecoin.cloud/console/session-keys?authorize=0xa&scopes=addPieces&network=calibration'
     )
     expect(buildAuthorizeUrl('https://pay.filecoin.cloud', '0xA', ['addPieces'], 314)).toMatch(/&network=mainnet$/)
   })

--- a/src/test/unit/console-url.test.ts
+++ b/src/test/unit/console-url.test.ts
@@ -48,3 +48,17 @@ describe('buildAuthorizeUrl', () => {
     )
   })
 })
+
+describe('buildAuthorizeUrl network param', () => {
+  it('carries the network slug for known chain ids', () => {
+    expect(buildAuthorizeUrl('https://pay.filecoin.cloud', '0xA', ['addPieces'], 314159)).toBe(
+      'https://pay.filecoin.cloud/console/session-keys?authorize=0xA&scopes=addPieces&network=calibration'
+    )
+    expect(buildAuthorizeUrl('https://pay.filecoin.cloud', '0xA', ['addPieces'], 314)).toMatch(/&network=mainnet$/)
+  })
+
+  it('omits the param for unknown or missing chain ids', () => {
+    expect(buildAuthorizeUrl('https://pay.filecoin.cloud', '0xA', ['addPieces'], 1)).not.toMatch(/network=/)
+    expect(buildAuthorizeUrl('https://pay.filecoin.cloud', '0xA', ['addPieces'])).not.toMatch(/network=/)
+  })
+})

--- a/src/test/unit/console-url.test.ts
+++ b/src/test/unit/console-url.test.ts
@@ -34,18 +34,20 @@ describe('buildAuthorizeUrl', () => {
     // Lowercase is the contract: the console's strict isAddress silently
     // rejects mixed-case with a wrong EIP-55 checksum; lowercase always passes.
     expect(
-      buildAuthorizeUrl('https://pay.filecoin.cloud', '0xAbC0000000000000000000000000000000000001', [
-        'createDataSet',
-        'addPieces',
-      ])
+      buildAuthorizeUrl(
+        'https://pay.filecoin.cloud',
+        '0xAbC0000000000000000000000000000000000001',
+        ['createDataSet', 'addPieces'],
+        314
+      )
     ).toBe(
-      'https://pay.filecoin.cloud/console/session-keys?authorize=0xabc0000000000000000000000000000000000001&scopes=createDataSet,addPieces'
+      'https://pay.filecoin.cloud/console/session-keys?authorize=0xabc0000000000000000000000000000000000001&scopes=createDataSet,addPieces&network=mainnet'
     )
   })
 
   it('tolerates a trailing slash on the base URL', () => {
-    expect(buildAuthorizeUrl('http://localhost:3005/', '0xA', ['addPieces'])).toBe(
-      'http://localhost:3005/console/session-keys?authorize=0xa&scopes=addPieces'
+    expect(buildAuthorizeUrl('http://localhost:3005/', '0xA', ['addPieces'], 314)).toBe(
+      'http://localhost:3005/console/session-keys?authorize=0xa&scopes=addPieces&network=mainnet'
     )
   })
 })
@@ -58,8 +60,7 @@ describe('buildAuthorizeUrl network param', () => {
     expect(buildAuthorizeUrl('https://pay.filecoin.cloud', '0xA', ['addPieces'], 314)).toMatch(/&network=mainnet$/)
   })
 
-  it('omits the param for unknown or missing chain ids', () => {
+  it('omits the param for an unknown chain id', () => {
     expect(buildAuthorizeUrl('https://pay.filecoin.cloud', '0xA', ['addPieces'], 1)).not.toMatch(/network=/)
-    expect(buildAuthorizeUrl('https://pay.filecoin.cloud', '0xA', ['addPieces'])).not.toMatch(/network=/)
   })
 })

--- a/src/test/unit/console-url.test.ts
+++ b/src/test/unit/console-url.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { buildAuthorizeUrl, resolveConsoleUrl } from '../../core/session/console-url.js'
+
+const previousConsoleUrl = process.env.CONSOLE_URL
+
+afterEach(() => {
+  if (previousConsoleUrl == null) {
+    delete process.env.CONSOLE_URL
+  } else {
+    process.env.CONSOLE_URL = previousConsoleUrl
+  }
+})
+
+describe('resolveConsoleUrl', () => {
+  it('defaults to the production console on both networks', () => {
+    delete process.env.CONSOLE_URL
+    expect(resolveConsoleUrl(314)).toBe('https://pay.filecoin.cloud')
+    expect(resolveConsoleUrl(314159)).toBe('https://pay.filecoin.cloud')
+  })
+
+  it('returns undefined for unknown chains without an override', () => {
+    delete process.env.CONSOLE_URL
+    expect(resolveConsoleUrl(1)).toBeUndefined()
+  })
+
+  it('prefers CONSOLE_URL over the default, and the explicit override over both', () => {
+    process.env.CONSOLE_URL = 'http://localhost:3005'
+    expect(resolveConsoleUrl(314)).toBe('http://localhost:3005')
+    expect(resolveConsoleUrl(314, 'http://preview.test')).toBe('http://preview.test')
+  })
+})
+
+describe('buildAuthorizeUrl', () => {
+  it('builds the session-keys deep link with pairing params', () => {
+    expect(
+      buildAuthorizeUrl('https://pay.filecoin.cloud', '0xAbC0000000000000000000000000000000000001', [
+        'createDataSet',
+        'addPieces',
+      ])
+    ).toBe(
+      'https://pay.filecoin.cloud/console/session-keys?authorize=0xAbC0000000000000000000000000000000000001&scopes=createDataSet,addPieces'
+    )
+  })
+
+  it('tolerates a trailing slash on the base URL', () => {
+    expect(buildAuthorizeUrl('http://localhost:3005/', '0xA', ['addPieces'])).toBe(
+      'http://localhost:3005/console/session-keys?authorize=0xA&scopes=addPieces'
+    )
+  })
+})

--- a/src/test/unit/console-url.test.ts
+++ b/src/test/unit/console-url.test.ts
@@ -15,7 +15,7 @@ describe('resolveConsoleUrl', () => {
   it('defaults to the production console on both networks', () => {
     delete process.env.CONSOLE_URL
     expect(resolveConsoleUrl(314)).toBe('https://pay.filecoin.cloud')
-    expect(resolveConsoleUrl(314159)).toBe('https://pay.filecoin.cloud')
+    expect(resolveConsoleUrl(314159)).toBe('https://pay.filecoin.cloud/calibration')
   })
 
   it('returns undefined for unknown chains', () => {

--- a/src/test/unit/console-url.test.ts
+++ b/src/test/unit/console-url.test.ts
@@ -15,7 +15,7 @@ describe('resolveConsoleUrl', () => {
   it('defaults to the production console on both networks', () => {
     delete process.env.CONSOLE_URL
     expect(resolveConsoleUrl(314)).toBe('https://pay.filecoin.cloud')
-    expect(resolveConsoleUrl(314159)).toBe('https://pay.filecoin.cloud/calibration')
+    expect(resolveConsoleUrl(314159)).toBe('https://pay.filecoin.cloud')
   })
 
   it('returns undefined for unknown chains', () => {

--- a/src/test/unit/import.test.ts
+++ b/src/test/unit/import.test.ts
@@ -14,6 +14,7 @@ import { mkdir, rm, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { ReadableStream } from 'node:stream/web'
+import { AddPiecesPermission, CreateDataSetPermission } from '@filoz/synapse-core/session-key'
 import { CarWriter } from '@ipld/car'
 import { CID } from 'multiformats/cid'
 import * as raw from 'multiformats/codecs/raw'
@@ -406,6 +407,7 @@ describe('CAR Import', () => {
       expect(vi.mocked(initializeSynapse)).toHaveBeenCalledWith(
         expect.objectContaining({
           dataSetMetadata: { erc8004Files: '' },
+          requiredPermissions: [CreateDataSetPermission, AddPiecesPermission],
         }),
         expect.any(Object)
       )

--- a/src/test/unit/rm-cmd.test.ts
+++ b/src/test/unit/rm-cmd.test.ts
@@ -1,3 +1,4 @@
+import { SchedulePieceRemovalsPermission } from '@filoz/synapse-core/session-key'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runRmPiece } from '../../rm/remove-piece.js'
 import type { RmPieceOptions } from '../../rm/types.js'
@@ -113,7 +114,11 @@ describe('runRmPiece', () => {
     expect(process.exitCode).toBe(0)
 
     expect(mockInitializeSynapse).toHaveBeenCalledWith(
-      expect.objectContaining({ privateKey: '0xabc', rpcUrl: 'wss://rpc' }),
+      expect.objectContaining({
+        privateKey: '0xabc',
+        rpcUrl: 'wss://rpc',
+        requiredPermissions: [SchedulePieceRemovalsPermission],
+      }),
       expect.anything()
     )
     expect(mockRemovePiece).toHaveBeenCalledWith(

--- a/src/test/unit/run-fund.test.ts
+++ b/src/test/unit/run-fund.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../core/synapse/index.js', () => ({
 }))
 vi.mock('../../utils/cli-auth.js', () => ({
   parseCLIAuth: vi.fn(() => ({})),
+  assertOwnerAuth: vi.fn(),
   getCLILogger: vi.fn(() => ({})),
 }))
 vi.mock('../../utils/cli-helpers.js', () => ({

--- a/src/test/unit/session-scopes.test.ts
+++ b/src/test/unit/session-scopes.test.ts
@@ -1,12 +1,11 @@
 import {
   AddPiecesPermission,
   CreateDataSetPermission,
-  PermissionNames,
   SchedulePieceRemovalsPermission,
 } from '@filoz/synapse-core/session-key'
 import { describe, expect, it } from 'vitest'
 import { TerminateServicePermission } from '../../core/session/index.js'
-import { parseScopes, SCOPE_PERMISSIONS } from '../../session/scopes.js'
+import { parseScopes } from '../../session/scopes.js'
 
 describe('parseScopes', () => {
   it('returns ids in canonical order regardless of input order', () => {
@@ -42,20 +41,5 @@ describe('parseScopes', () => {
   it('rejects input with no valid scope', () => {
     expect(() => parseScopes('')).toThrow(/at least one/)
     expect(() => parseScopes(' , , ')).toThrow(/at least one/)
-  })
-})
-
-describe('scope-id derivation lockstep', () => {
-  // core/synapse/index.ts derives scope ids by camelCasing the SDK's
-  // PermissionNames instead of importing this CLI-layer map into core.
-  // That derivation is only safe while PascalCase->camelCase reproduces
-  // SCOPE_PERMISSIONS exactly — this cross-check makes a future rename
-  // fail loudly instead of silently diverging.
-  it('camelCased PermissionNames reproduce every canonical scope id', () => {
-    for (const [id, permission] of Object.entries(SCOPE_PERMISSIONS)) {
-      const name = PermissionNames[permission]
-      if (name == null) throw new Error(`PermissionNames missing entry for scope "${id}"`)
-      expect(name.charAt(0).toLowerCase() + name.slice(1)).toBe(id)
-    }
   })
 })

--- a/src/test/unit/session-scopes.test.ts
+++ b/src/test/unit/session-scopes.test.ts
@@ -1,11 +1,12 @@
 import {
   AddPiecesPermission,
   CreateDataSetPermission,
+  PermissionNames,
   SchedulePieceRemovalsPermission,
 } from '@filoz/synapse-core/session-key'
 import { describe, expect, it } from 'vitest'
 import { TerminateServicePermission } from '../../core/session/index.js'
-import { parseScopes } from '../../session/scopes.js'
+import { parseScopes, SCOPE_PERMISSIONS } from '../../session/scopes.js'
 
 describe('parseScopes', () => {
   it('returns ids in canonical order regardless of input order', () => {
@@ -41,5 +42,20 @@ describe('parseScopes', () => {
   it('rejects input with no valid scope', () => {
     expect(() => parseScopes('')).toThrow(/at least one/)
     expect(() => parseScopes(' , , ')).toThrow(/at least one/)
+  })
+})
+
+describe('scope-id derivation lockstep', () => {
+  // core/synapse/index.ts derives scope ids by camelCasing the SDK's
+  // PermissionNames instead of importing this CLI-layer map into core.
+  // That derivation is only safe while PascalCase->camelCase reproduces
+  // SCOPE_PERMISSIONS exactly — this cross-check makes a future rename
+  // fail loudly instead of silently diverging.
+  it('camelCased PermissionNames reproduce every canonical scope id', () => {
+    for (const [id, permission] of Object.entries(SCOPE_PERMISSIONS)) {
+      const name = PermissionNames[permission]
+      if (name == null) throw new Error(`PermissionNames missing entry for scope "${id}"`)
+      expect(name.charAt(0).toLowerCase() + name.slice(1)).toBe(id)
+    }
   })
 })

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -174,6 +174,33 @@ describe('synapse-service', () => {
       }
     })
 
+    it('should say a previously granted scope expired, with its timestamp, rather than the generic wording', async () => {
+      // AddPieces WAS granted and lapsed (nonzero past expiry); another grant is
+      // still live, so this is the missing-scope shape, not never-authorized.
+      mockSessionKeyOnce((p) => p !== AddPiecesPermission, {
+        [CreateDataSetPermission]: 9999999999n,
+        [AddPiecesPermission]: 1000n, // 1970-01-01T00:16:40.000Z — unambiguously past
+        [SchedulePieceRemovalsPermission]: 9999999999n,
+        [TerminateServicePermission]: 9999999999n,
+      })
+
+      const config: SynapseSetupConfig = {
+        walletAddress: '0x0000000000000000000000000000000000000002',
+        sessionKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        rpcUrl: 'wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1',
+        requiredPermissions: [AddPiecesPermission],
+      }
+
+      const error = await initializeSynapse(config, logger).then(
+        () => null,
+        (e: unknown) => e as Error
+      )
+      expect(error).not.toBeNull()
+      expect(error?.message).toContain('lacks AddPieces for this operation on ')
+      expect(error?.message).toContain('AddPieces: expired at 1970-01-01T00:16:40.000Z')
+      expect(error?.message).not.toContain('never granted')
+    })
+
     it("should use the 'never authorized, or expired/revoked' wording when the key holds no live grant", async () => {
       mockSessionKeyOnce(() => false, {
         [CreateDataSetPermission]: 0n,

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -1,3 +1,11 @@
+// Value import of the mocked module (vi.mock below replaces it at runtime).
+import {
+  AddPiecesPermission,
+  CreateDataSetPermission,
+  fromSecp256k1,
+  SchedulePieceRemovalsPermission,
+  TerminateServicePermission,
+} from '@filoz/synapse-core/session-key'
 import { CID } from 'multiformats/cid'
 import type { Logger } from 'pino'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -96,6 +104,115 @@ describe('synapse-service', () => {
         expect.objectContaining({ event: 'synapse.init', mode: 'session-key' }),
         'Initializing Synapse (session key)'
       )
+    })
+
+    // Queue a one-shot session key whose only meaningful behaviour is hasPermission
+    // and expirations. initializeSynapse touches just syncExpirations/hasPermission/
+    // expirations/address, so the partial object is cast to the concrete (unexported)
+    // class the real fromSecp256k1 returns.
+    const mockSessionKeyOnce = (hasPermission: (p: string) => boolean, expirations: Record<string, bigint>) => {
+      vi.mocked(fromSecp256k1).mockImplementationOnce((() => ({
+        syncExpirations: vi.fn().mockResolvedValue(undefined),
+        expirations,
+        address: '0x0000000000000000000000000000000000000001',
+        hasPermission: vi.fn(hasPermission),
+      })) as unknown as typeof fromSecp256k1)
+    }
+
+    it('should not require any permission by default (read-only commands)', async () => {
+      mockSessionKeyOnce(() => false, {}) // key granted nothing; no requiredPermissions means nothing to check
+
+      const config: SynapseSetupConfig = {
+        walletAddress: '0x0000000000000000000000000000000000000002',
+        sessionKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        rpcUrl: 'wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1',
+      }
+
+      await expect(initializeSynapse(config, logger)).resolves.toBeDefined()
+    })
+
+    it('should reject only the missing scope, with a console-first remediation message', async () => {
+      // Grant everything except AddPieces — a live grant exists, so this is case 3
+      // (missing scope), not case 2 (never authorized at all).
+      mockSessionKeyOnce((p) => p !== AddPiecesPermission, {
+        [CreateDataSetPermission]: 9999999999n,
+        [AddPiecesPermission]: 0n,
+        [SchedulePieceRemovalsPermission]: 9999999999n,
+        [TerminateServicePermission]: 9999999999n,
+      })
+
+      const previousConsoleUrl = process.env.CONSOLE_URL
+      process.env.CONSOLE_URL = 'https://pay.example.test'
+      try {
+        const config: SynapseSetupConfig = {
+          walletAddress: '0x0000000000000000000000000000000000000002',
+          sessionKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+          rpcUrl: 'wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1',
+          requiredPermissions: [AddPiecesPermission],
+        }
+
+        const error = await initializeSynapse(config, logger).then(
+          () => null,
+          (e: unknown) => e as Error
+        )
+        expect(error).not.toBeNull()
+        expect(error?.message).toContain('lacks AddPieces for this operation on ')
+        expect(error?.message).not.toContain('TerminateService')
+        expect(error?.message).toContain(
+          'https://pay.example.test/console/session-keys?authorize=0x0000000000000000000000000000000000000001&scopes=addPieces'
+        )
+        expect(error?.message).toContain(
+          'filecoin-pin session authorize 0x0000000000000000000000000000000000000001 --scopes addPieces'
+        )
+        expect(error?.message).toContain('filecoin-pin session create --scopes addPieces')
+      } finally {
+        if (previousConsoleUrl == null) {
+          delete process.env.CONSOLE_URL
+        } else {
+          process.env.CONSOLE_URL = previousConsoleUrl
+        }
+      }
+    })
+
+    it("should use the 'never authorized, or expired/revoked' wording when the key holds no live grant", async () => {
+      mockSessionKeyOnce(() => false, {
+        [CreateDataSetPermission]: 0n,
+        [AddPiecesPermission]: 0n,
+        [SchedulePieceRemovalsPermission]: 0n,
+        [TerminateServicePermission]: 0n,
+      })
+
+      const config: SynapseSetupConfig = {
+        walletAddress: '0x0000000000000000000000000000000000000002',
+        sessionKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        rpcUrl: 'wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1',
+        requiredPermissions: [AddPiecesPermission],
+      }
+
+      const error = await initializeSynapse(config, logger).then(
+        () => null,
+        (e: unknown) => e as Error
+      )
+      expect(error).not.toBeNull()
+      expect(error?.message).toContain("isn't authorized for account 0x0000000000000000000000000000000000000002 on ")
+      expect(error?.message).toContain('the key is for a different network (check --network)')
+    })
+
+    it('should pass when the key holds exactly the required permissions', async () => {
+      const granted: Record<string, true> = { [AddPiecesPermission]: true, [CreateDataSetPermission]: true }
+      mockSessionKeyOnce((p) => granted[p] === true, {
+        [CreateDataSetPermission]: 9999999999n,
+        [AddPiecesPermission]: 9999999999n,
+      })
+
+      const config: SynapseSetupConfig = {
+        walletAddress: '0x0000000000000000000000000000000000000002',
+        sessionKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        rpcUrl: 'wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1',
+        requiredPermissions: [AddPiecesPermission, CreateDataSetPermission],
+      }
+
+      await expect(initializeSynapse(config, logger)).resolves.toBeDefined()
     })
 
     it('should throw when no authentication is provided', async () => {

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -165,7 +165,8 @@ describe('synapse-service', () => {
         expect(error?.message).toContain(
           'filecoin-pin session authorize 0x0000000000000000000000000000000000000001 --scopes addPieces'
         )
-        expect(error?.message).toContain('filecoin-pin session create --scopes addPieces')
+        expect(error?.message).not.toContain('filecoin-pin session create')
+        expect(error?.message).toContain('Then re-run this command.')
       } finally {
         if (previousConsoleUrl == null) {
           delete process.env.CONSOLE_URL
@@ -225,6 +226,7 @@ describe('synapse-service', () => {
       expect(error?.message).toContain("isn't authorized for account 0x0000000000000000000000000000000000000002 on ")
       expect(error?.message).toContain('the key is for a different network (check --network)')
       expect(error?.message).toContain('AddPieces: never granted')
+      expect(error?.message).toContain('filecoin-pin session create --scopes addPieces')
     })
 
     it('should pass when the key holds exactly the required permissions', async () => {

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -6,6 +6,7 @@ import {
   SchedulePieceRemovalsPermission,
   TerminateServicePermission,
 } from '@filoz/synapse-core/session-key'
+import { Synapse } from '@filoz/synapse-sdk'
 import { CID } from 'multiformats/cid'
 import type { Logger } from 'pino'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -223,6 +224,7 @@ describe('synapse-service', () => {
       expect(error).not.toBeNull()
       expect(error?.message).toContain("isn't authorized for account 0x0000000000000000000000000000000000000002 on ")
       expect(error?.message).toContain('the key is for a different network (check --network)')
+      expect(error?.message).toContain('AddPieces: never granted')
     })
 
     it('should pass when the key holds exactly the required permissions', async () => {
@@ -240,6 +242,24 @@ describe('synapse-service', () => {
       }
 
       await expect(initializeSynapse(config, logger)).resolves.toBeDefined()
+      // The SDK's own gate defaults to all four permissions; the preflight
+      // result only holds if the same subset reaches Synapse.create.
+      expect(vi.mocked(Synapse.create)).toHaveBeenCalledWith(
+        expect.objectContaining({ requiredPermissions: [AddPiecesPermission, CreateDataSetPermission] })
+      )
+    })
+
+    it('should forward an empty permission list to Synapse.create when none are required', async () => {
+      mockSessionKeyOnce(() => false, {})
+
+      const config: SynapseSetupConfig = {
+        walletAddress: '0x0000000000000000000000000000000000000002',
+        sessionKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        rpcUrl: 'wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1',
+      }
+
+      await initializeSynapse(config, logger)
+      expect(vi.mocked(Synapse.create)).toHaveBeenCalledWith(expect.objectContaining({ requiredPermissions: [] }))
     })
 
     it('should throw when no authentication is provided', async () => {

--- a/src/utils/cli-auth.ts
+++ b/src/utils/cli-auth.ts
@@ -9,7 +9,7 @@ import type { Permission } from '@filoz/synapse-core/session-key'
 import type { FilecoinChain, Synapse } from '@filoz/synapse-sdk'
 import { getRpcUrl, NETWORK_CHAINS, resolveDevnetConfig } from '../common/get-rpc-url.js'
 import type { SynapseSetupConfig } from '../core/synapse/index.js'
-import { initializeSynapse } from '../core/synapse/index.js'
+import { initializeSynapse, isSessionKeyConfig } from '../core/synapse/index.js'
 import { createLogger } from '../logger.js'
 
 /**
@@ -247,6 +247,22 @@ export function parseContextSelectionOptions(options?: CLIAuthOptions): ContextS
  */
 export function getCLILogger() {
   return createLogger({ logLevel: process.env.LOG_LEVEL })
+}
+
+/**
+ * Refuse session-key auth for commands that move funds. Deposits, withdrawals,
+ * and service approvals are signed by the account owner's wallet; a session key
+ * would pass initialization and fail mid-transaction instead.
+ *
+ * @param config - Parsed auth config
+ * @param commandName - Command shown in the error, e.g. `payments deposit`
+ */
+export function assertOwnerAuth(config: SynapseSetupConfig, commandName: string): void {
+  if (!isSessionKeyConfig(config)) return
+  throw new Error(
+    `${commandName} needs the account owner's wallet; session keys can't move funds. ` +
+      'Rerun with --private-key / PRIVATE_KEY, or use the Filecoin Cloud console.'
+  )
 }
 
 export async function getCliSynapse(options: CLIAuthOptions, requiredPermissions?: Permission[]): Promise<Synapse> {

--- a/src/utils/cli-auth.ts
+++ b/src/utils/cli-auth.ts
@@ -9,7 +9,7 @@ import type { Permission } from '@filoz/synapse-core/session-key'
 import type { FilecoinChain, Synapse } from '@filoz/synapse-sdk'
 import { getRpcUrl, NETWORK_CHAINS, resolveDevnetConfig } from '../common/get-rpc-url.js'
 import type { SynapseSetupConfig } from '../core/synapse/index.js'
-import { initializeSynapse, isSessionKeyConfig } from '../core/synapse/index.js'
+import { initializeSynapse, isReadOnlyConfig, isSessionKeyConfig } from '../core/synapse/index.js'
 import { createLogger } from '../logger.js'
 
 /**
@@ -250,19 +250,27 @@ export function getCLILogger() {
 }
 
 /**
- * Refuse session-key auth for commands that move funds. Deposits, withdrawals,
- * and service approvals are signed by the account owner's wallet; a session key
- * would pass initialization and fail mid-transaction instead.
+ * Refuse anything but the owner's own signer for commands that move funds.
+ * Deposits, withdrawals, and service approvals are signed by the account
+ * owner's wallet; a session key or a view-only address would pass
+ * initialization and fail mid-transaction instead.
  *
  * @param config - Parsed auth config
  * @param commandName - Command shown in the error, e.g. `payments deposit`
  */
 export function assertOwnerAuth(config: SynapseSetupConfig, commandName: string): void {
-  if (!isSessionKeyConfig(config)) return
-  throw new Error(
-    `${commandName} needs the account owner's wallet; session keys can't move funds. ` +
-      'Rerun with --private-key / PRIVATE_KEY, or use the Filecoin Cloud console.'
-  )
+  if (isSessionKeyConfig(config)) {
+    throw new Error(
+      `${commandName} needs the account owner's wallet; session keys can't move funds. ` +
+        'Rerun with --private-key / PRIVATE_KEY, or use the Filecoin Cloud console.'
+    )
+  }
+  if (isReadOnlyConfig(config)) {
+    throw new Error(
+      `${commandName} needs the account owner's wallet; a view-only address can't sign. ` +
+        'Rerun with --private-key / PRIVATE_KEY, or use the Filecoin Cloud console.'
+    )
+  }
 }
 
 export async function getCliSynapse(options: CLIAuthOptions, requiredPermissions?: Permission[]): Promise<Synapse> {

--- a/src/utils/cli-auth.ts
+++ b/src/utils/cli-auth.ts
@@ -5,6 +5,7 @@
  * and preparing them for use with the Synapse SDK.
  */
 
+import type { Permission } from '@filoz/synapse-core/session-key'
 import type { FilecoinChain, Synapse } from '@filoz/synapse-sdk'
 import { getRpcUrl, NETWORK_CHAINS, resolveDevnetConfig } from '../common/get-rpc-url.js'
 import type { SynapseSetupConfig } from '../core/synapse/index.js'
@@ -248,8 +249,11 @@ export function getCLILogger() {
   return createLogger({ logLevel: process.env.LOG_LEVEL })
 }
 
-export async function getCliSynapse(options: CLIAuthOptions): Promise<Synapse> {
+export async function getCliSynapse(options: CLIAuthOptions, requiredPermissions?: Permission[]): Promise<Synapse> {
   const authConfig = parseCLIAuth(options)
+  if (requiredPermissions != null) {
+    authConfig.requiredPermissions = requiredPermissions
+  }
   const logger = getCLILogger()
   return initializeSynapse(authConfig, logger)
 }


### PR DESCRIPTION
e2e preview:https://inbrowser.link/ipfs/bafybeicfitpkj5i5nu37o2dlntbibzbzsl6dul3mvoh2fy3dn34qguxv64
depend on https://github.com/FilOzone/filecoin-pay-explorer/pull/355

Part of the login epic, tracked in #697.


currently session key mode preflights all four FWSS permissions on every command — even pure reads like `payments status` — so a least-privilege key (upload-only) can't use the CLI at all. Since SessionKeyRegistry supports per-permission grants, the chain already allows subsets; only the CLI refused them. (inherited from synapse)

Commands now declare what they need (checked in the preflight AND passed to `Synapse.create`, whose own gate otherwise defaults to all four):

| command | permissions required |
|---|---|
| reads (`payments status`, `data-set ls`, `provider ls`, …) | none |
| `add` / `import` | createDataSet, addPieces |
| `rm` | schedulePieceRemovals |
| `data-set terminate` | terminateService |
| pinning server | createDataSet, addPieces, schedulePieceRemovals |

A missing scope fails up front with a console-first message: the problem, with per-scope detail (`expired at <timestamp>` vs `never granted`, read from the on-chain expirations) and the network it happened on;

 a Filecoin Pay console deep link (`…/console/session-keys?authorize=<addr>&scopes=<missing>&network=<net>`) to approve with the owner wallet; then the owner-only CLI alternatives (`session authorize/create --scopes`, from the base PR). A delegate is never told to run a root-key command as their own action.
