### PR TITLE
feat(session): add on-chain authorization watcher

### DIFF
--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -25,3 +25,12 @@ export type {
   RevokeSessionResult,
   SessionKeypair,
 } from './types.js'
+export {
+  DEFAULT_WATCH_DEADLINE_MS,
+  DEFAULT_WATCH_INTERVAL_MS,
+  readScopeGrants,
+  type ScopeGrants,
+  type WatchAuthorizationOptions,
+  type WatchAuthorizationResult,
+  watchAuthorization,
+} from './watch-authorization.js'

--- a/src/core/session/index.ts
+++ b/src/core/session/index.ts
@@ -24,6 +24,7 @@ export type {
   RevokeSessionProgressEvents,
   RevokeSessionResult,
   SessionKeypair,
+  WatchAuthorizationProgressEvents,
 } from './types.js'
 export {
   DEFAULT_WATCH_DEADLINE_MS,

--- a/src/core/session/types.ts
+++ b/src/core/session/types.ts
@@ -35,6 +35,14 @@ export type RevokeSessionProgressEvents =
   | ProgressEvent<'revokeSession:submitted', { txHash: Hash; sessionAddress: Address }>
   | ProgressEvent<'revokeSession:confirmed', { txHash: Hash; blockNumber: bigint; sessionAddress: Address }>
 
+/**
+ * Progress events emitted while waiting for an on-chain authorization.
+ */
+export type WatchAuthorizationProgressEvents =
+  | ProgressEvent<'watch:tick', { remainingMs: number }>
+  | ProgressEvent<'watch:ownerFound', { owner: Address }>
+  | ProgressEvent<'watch:error', { error: unknown }>
+
 export interface SessionKeypair {
   privateKey: Hex
   address: Address

--- a/src/core/session/watch-authorization.ts
+++ b/src/core/session/watch-authorization.ts
@@ -1,0 +1,219 @@
+/**
+ * Wait for a session key to be authorized on-chain.
+ *
+ * `filecoin-pin login` prints a console link, and the wallet owner approves
+ * the key in the browser. Nothing calls back to the CLI: the registry
+ * contract is the shared state, so the CLI polls it.
+ *
+ * Two ways to detect the grant:
+ *
+ *  1. Owner unknown (first pairing): poll `eth_getLogs` for the registry's
+ *     `AuthorizationsUpdated` events from the block login started at, and
+ *     match the `signer` field to our key. One small, bounded query per
+ *     tick. The matching event names the owner.
+ *  2. Owner known (renewal, or after the event was found): read the
+ *     per-scope expiries directly. No events involved.
+ *
+ * Both paths end in the per-scope read, so partial grants (the owner
+ * declined a scope in the console) are reported scope by scope.
+ */
+
+import { type Expirations, extractLoginEvent, getExpirations, type Permission } from '@filoz/synapse-core/session-key'
+import { type Address, type Chain, type Client, isAddressEqual, type Log, type Transport, toEventSelector } from 'viem'
+
+/** Default poll deadline: about five minutes (PRD decision #11). */
+export const DEFAULT_WATCH_DEADLINE_MS = 5 * 60 * 1000
+/** Default interval between registry polls. */
+export const DEFAULT_WATCH_INTERVAL_MS = 5000
+
+const AUTHORIZATIONS_UPDATED_TOPIC = toEventSelector(
+  'AuthorizationsUpdated(address indexed identity,address signer,uint256 expiry,bytes32[] permissions,string origin)'
+)
+
+export interface WatchAuthorizationOptions {
+  /** viem client for the target chain. */
+  client: Client<Transport, Chain>
+  /** Session key address waiting for approval. */
+  sessionAddress: Address
+  /** Session key registry contract address. */
+  registryAddress: Address
+  /** Scopes the user asked for; each is confirmed individually. */
+  permissions: readonly Permission[]
+  /** Block to scan events from (the block `login` started at). Required when the owner is unknown. */
+  fromBlock?: bigint
+  /** Wallet owner, when already known (renewal). Skips the event scan. */
+  owner?: Address
+  /** Give up after this long. Defaults to {@link DEFAULT_WATCH_DEADLINE_MS}. */
+  deadlineMs?: number
+  /** Time between polls. Defaults to {@link DEFAULT_WATCH_INTERVAL_MS}. */
+  pollIntervalMs?: number
+  /** Called before each poll with the time left, for a countdown. */
+  onTick?: (remainingMs: number) => void
+}
+
+/** Per-scope state read from the registry. */
+export interface ScopeGrants {
+  /** `granted` when every requested scope is live, `partial` when some are, `none` when none is. */
+  status: 'granted' | 'partial' | 'none'
+  /** Wallet owner the scopes were read for. */
+  owner: Address
+  /** Latest expiry (unix seconds) among the granted scopes. */
+  expiry?: bigint
+  /** Requested scopes that are live. */
+  granted: Permission[]
+  /** Requested scopes that are not live. */
+  missing: Permission[]
+}
+
+export interface WatchAuthorizationResult {
+  /** `granted` when every requested scope is live, `partial` when some are, `timeout` when none arrived in time. */
+  status: 'granted' | 'partial' | 'timeout'
+  /** Wallet owner that authorized the key. Absent on timeout when it was never learned. */
+  owner?: Address
+  /** Latest expiry (unix seconds) among the granted scopes. */
+  expiry?: bigint
+  /** Requested scopes that are live. */
+  granted: Permission[]
+  /** Requested scopes that are not live. */
+  missing: Permission[]
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** Split requested scopes into live and not-live using on-chain expiries. */
+function classifyScopes(
+  permissions: readonly Permission[],
+  expirations: Expirations
+): Pick<WatchAuthorizationResult, 'granted' | 'missing' | 'expiry'> {
+  const now = BigInt(Math.floor(Date.now() / 1000))
+  const granted: Permission[] = []
+  const missing: Permission[] = []
+  let expiry: bigint | undefined
+  for (const permission of permissions) {
+    const value = expirations[permission] ?? 0n
+    if (value > now) {
+      granted.push(permission)
+      if (expiry === undefined || value > expiry) expiry = value
+    } else {
+      missing.push(permission)
+    }
+  }
+  return expiry === undefined ? { granted, missing } : { granted, missing, expiry }
+}
+
+/**
+ * Read the expiry of every requested scope for `owner` and classify them.
+ * This is mechanism 2, and the confirmation step after mechanism 1.
+ */
+export async function readScopeGrants(
+  options: Pick<WatchAuthorizationOptions, 'client' | 'sessionAddress' | 'registryAddress' | 'permissions'> & {
+    owner: Address
+  }
+): Promise<ScopeGrants> {
+  const expirations = await getExpirations(options.client, {
+    address: options.owner,
+    sessionKeyAddress: options.sessionAddress,
+    permissions: [...options.permissions],
+    contractAddress: options.registryAddress,
+  })
+  const scopes = classifyScopes(options.permissions, expirations)
+  const status = scopes.missing.length === 0 ? 'granted' : scopes.granted.length === 0 ? 'none' : 'partial'
+  return { status, owner: options.owner, ...scopes }
+}
+
+/**
+ * One `eth_getLogs` query for `AuthorizationsUpdated` events on the registry
+ * since `fromBlock`, returning the owner of the first event whose signer is
+ * our session key. Mechanism 1.
+ */
+async function findOwnerInLogs(
+  client: Client<Transport, Chain>,
+  registryAddress: Address,
+  sessionAddress: Address,
+  fromBlock: bigint
+): Promise<Address | undefined> {
+  const logs = (await client.request({
+    method: 'eth_getLogs',
+    params: [
+      {
+        address: registryAddress,
+        fromBlock: `0x${fromBlock.toString(16)}`,
+        toBlock: 'latest',
+        topics: [AUTHORIZATIONS_UPDATED_TOPIC],
+      },
+    ],
+  })) as Log[]
+
+  for (const log of logs) {
+    let event: ReturnType<typeof extractLoginEvent>
+    try {
+      event = extractLoginEvent([log])
+    } catch {
+      continue
+    }
+    if (isAddressEqual(event.args.signer, sessionAddress)) {
+      return event.args.identity
+    }
+  }
+  return undefined
+}
+
+interface WatchState {
+  owner: Address | undefined
+  eventSeen: boolean
+  last: WatchAuthorizationResult
+}
+
+/**
+ * One poll: scan events for our signer when `fromBlock` is set and no event
+ * has been seen yet, then read the scope expiries once the owner is known.
+ * Returns true when the wait is over.
+ */
+async function pollOnce(options: WatchAuthorizationOptions, state: WatchState): Promise<boolean> {
+  const { client, sessionAddress, registryAddress, permissions, fromBlock } = options
+  if (fromBlock !== undefined && !state.eventSeen) {
+    const found = await findOwnerInLogs(client, registryAddress, sessionAddress, fromBlock)
+    if (found !== undefined) {
+      state.owner = found
+      state.eventSeen = true
+    }
+  }
+  if (state.owner === undefined) return false
+
+  const grants = await readScopeGrants({ client, sessionAddress, registryAddress, permissions, owner: state.owner })
+  state.last = { ...grants, status: grants.status === 'none' ? 'timeout' : grants.status }
+  return grants.status === 'granted' || state.eventSeen
+}
+
+/**
+ * Poll until the session key is authorized or the deadline passes.
+ *
+ * A complete grant ends the wait at once. A new `AuthorizationsUpdated`
+ * event also ends it, with whatever the read shows, because the console
+ * grants every approved scope in one transaction: a shortfall after the
+ * event is the owner's decision, not a race. Without an event, a partial
+ * read (a pre-existing grant) keeps polling until the deadline.
+ */
+export async function watchAuthorization(options: WatchAuthorizationOptions): Promise<WatchAuthorizationResult> {
+  if (options.owner === undefined && options.fromBlock === undefined) {
+    throw new Error('watchAuthorization needs either owner or fromBlock')
+  }
+  const deadlineMs = options.deadlineMs ?? DEFAULT_WATCH_DEADLINE_MS
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_WATCH_INTERVAL_MS
+  const deadline = Date.now() + deadlineMs
+  const state: WatchState = {
+    owner: options.owner,
+    eventSeen: false,
+    last: { status: 'timeout', granted: [], missing: [...options.permissions] },
+  }
+
+  for (;;) {
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) return state.last
+    options.onTick?.(remainingMs)
+    if (await pollOnce(options, state)) return state.last
+    await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())))
+  }
+}

--- a/src/core/session/watch-authorization.ts
+++ b/src/core/session/watch-authorization.ts
@@ -18,8 +18,20 @@
  * declined a scope in the console) are reported scope by scope.
  */
 
+import { sessionKeyRegistry } from '@filoz/synapse-core/abis'
 import { type Expirations, extractLoginEvent, getExpirations, type Permission } from '@filoz/synapse-core/session-key'
-import { type Address, type Chain, type Client, isAddressEqual, type Log, type Transport, toEventSelector } from 'viem'
+import {
+  type Address,
+  type Chain,
+  type Client,
+  getAbiItem,
+  isAddressEqual,
+  type Log,
+  type Transport,
+  toEventSelector,
+} from 'viem'
+import type { ProgressEventHandler } from '../utils/types.js'
+import type { WatchAuthorizationProgressEvents } from './types.js'
 
 /** Default poll deadline: about five minutes (PRD decision #11). */
 export const DEFAULT_WATCH_DEADLINE_MS = 5 * 60 * 1000
@@ -27,7 +39,7 @@ export const DEFAULT_WATCH_DEADLINE_MS = 5 * 60 * 1000
 export const DEFAULT_WATCH_INTERVAL_MS = 5000
 
 const AUTHORIZATIONS_UPDATED_TOPIC = toEventSelector(
-  'AuthorizationsUpdated(address indexed identity,address signer,uint256 expiry,bytes32[] permissions,string origin)'
+  getAbiItem({ abi: sessionKeyRegistry, name: 'AuthorizationsUpdated' })
 )
 
 export interface WatchAuthorizationOptions {
@@ -47,8 +59,8 @@ export interface WatchAuthorizationOptions {
   deadlineMs?: number
   /** Time between polls. Defaults to {@link DEFAULT_WATCH_INTERVAL_MS}. */
   pollIntervalMs?: number
-  /** Called before each poll with the time left, for a countdown. */
-  onTick?: (remainingMs: number) => void
+  /** Progress events: a tick before each poll, the owner once found, and per-poll RPC errors. */
+  onProgress?: ProgressEventHandler<WatchAuthorizationProgressEvents>
 }
 
 /** Per-scope state read from the registry. */
@@ -66,8 +78,12 @@ export interface ScopeGrants {
 }
 
 export interface WatchAuthorizationResult {
-  /** `granted` when every requested scope is live, `partial` when some are, `timeout` when none arrived in time. */
-  status: 'granted' | 'partial' | 'timeout'
+  /**
+   * `granted`: every requested scope is live. `partial`: some are. `none`:
+   * the owner acted but none of the requested scopes is live. `timeout`:
+   * the deadline passed without an authorization.
+   */
+  status: 'granted' | 'partial' | 'none' | 'timeout'
   /** Wallet owner that authorized the key. Absent on timeout when it was never learned. */
   owner?: Address
   /** Latest expiry (unix seconds) among the granted scopes. */
@@ -164,6 +180,9 @@ interface WatchState {
   owner: Address | undefined
   eventSeen: boolean
   last: WatchAuthorizationResult
+  /** Whether any poll completed without an RPC error. */
+  anySuccess: boolean
+  lastError: unknown
 }
 
 /**
@@ -179,18 +198,38 @@ async function pollOnce(options: WatchAuthorizationOptions, state: WatchState): 
     if (found !== undefined) {
       state.owner = found
       state.eventSeen = true
+      options.onProgress?.({ type: 'watch:ownerFound', data: { owner: found } })
     }
   }
   if (state.owner === undefined) return false
 
   const grants = await readScopeGrants({ client, sessionAddress, registryAddress, permissions, owner: state.owner })
-  state.last = { ...grants, status: grants.status === 'none' ? 'timeout' : grants.status }
+  // Without an event, a `none` read only means nothing has happened yet.
+  state.last = grants.status === 'none' && !state.eventSeen ? { ...grants, status: 'timeout' } : grants
   return grants.status === 'granted' || state.eventSeen
+}
+
+/**
+ * Run one poll, tolerating RPC errors: a single failed request must not end
+ * a five-minute wait after the owner already approved in the browser.
+ */
+async function pollTolerantly(options: WatchAuthorizationOptions, state: WatchState): Promise<boolean> {
+  try {
+    const done = await pollOnce(options, state)
+    state.anySuccess = true
+    return done
+  } catch (error) {
+    state.lastError = error
+    options.onProgress?.({ type: 'watch:error', data: { error } })
+    return false
+  }
 }
 
 /**
  * Poll until the session key is authorized or the deadline passes.
  *
+ * RPC errors on individual polls are reported through `onProgress` and the
+ * wait continues; the error is thrown only when no poll ever succeeded.
  * A complete grant ends the wait at once. A new `AuthorizationsUpdated`
  * event also ends it, with whatever the read shows, because the console
  * grants every approved scope in one transaction: a shortfall after the
@@ -208,13 +247,18 @@ export async function watchAuthorization(options: WatchAuthorizationOptions): Pr
     owner: options.owner,
     eventSeen: false,
     last: { status: 'timeout', granted: [], missing: [...options.permissions] },
+    anySuccess: false,
+    lastError: undefined,
   }
 
   for (;;) {
     const remainingMs = deadline - Date.now()
-    if (remainingMs <= 0) return state.last
-    options.onTick?.(remainingMs)
-    if (await pollOnce(options, state)) return state.last
+    if (remainingMs <= 0) break
+    options.onProgress?.({ type: 'watch:tick', data: { remainingMs } })
+    if (await pollTolerantly(options, state)) return state.last
     await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())))
   }
+  // Every poll failed: the RPC endpoint, not the owner, is the problem.
+  if (!state.anySuccess && state.lastError !== undefined) throw state.lastError
+  return state.last
 }

--- a/src/core/session/watch-authorization.ts
+++ b/src/core/session/watch-authorization.ts
@@ -206,7 +206,9 @@ async function pollOnce(options: WatchAuthorizationOptions, state: WatchState): 
   const grants = await readScopeGrants({ client, sessionAddress, registryAddress, permissions, owner: state.owner })
   // Without an event, a `none` read only means nothing has happened yet.
   state.last = grants.status === 'none' && !state.eventSeen ? { ...grants, status: 'timeout' } : grants
-  return grants.status === 'granted' || state.eventSeen
+  // After the event, a `none` read may be a lagging RPC node: keep polling
+  // and let the deadline report it.
+  return grants.status === 'granted' || (state.eventSeen && grants.status !== 'none')
 }
 
 /**

--- a/src/core/session/watch-authorization.ts
+++ b/src/core/session/watch-authorization.ts
@@ -41,7 +41,7 @@ export interface WatchAuthorizationOptions {
   permissions: readonly Permission[]
   /** Block to scan events from (the block `login` started at). Required when the owner is unknown. */
   fromBlock?: bigint
-  /** Wallet owner, when already known (renewal). Skips the event scan. */
+  /** Wallet owner, when already known (renewal). Skips the event scan; never replaced by one. */
   owner?: Address
   /** Give up after this long. Defaults to {@link DEFAULT_WATCH_DEADLINE_MS}. */
   deadlineMs?: number
@@ -167,13 +167,14 @@ interface WatchState {
 }
 
 /**
- * One poll: scan events for our signer when `fromBlock` is set and no event
- * has been seen yet, then read the scope expiries once the owner is known.
- * Returns true when the wait is over.
+ * One poll: while the owner is unknown, scan events for our signer; once
+ * the owner is known (supplied or discovered) read the scope expiries. A
+ * supplied owner is never replaced by an event. Returns true when the wait
+ * is over.
  */
 async function pollOnce(options: WatchAuthorizationOptions, state: WatchState): Promise<boolean> {
   const { client, sessionAddress, registryAddress, permissions, fromBlock } = options
-  if (fromBlock !== undefined && !state.eventSeen) {
+  if (state.owner === undefined && fromBlock !== undefined) {
     const found = await findOwnerInLogs(client, registryAddress, sessionAddress, fromBlock)
     if (found !== undefined) {
       state.owner = found

--- a/src/core/session/watch-authorization.ts
+++ b/src/core/session/watch-authorization.ts
@@ -135,8 +135,13 @@ export async function readScopeGrants(
     contractAddress: options.registryAddress,
   })
   const scopes = classifyScopes(options.permissions, expirations)
-  const status = scopes.missing.length === 0 ? 'granted' : scopes.granted.length === 0 ? 'none' : 'partial'
-  return { status, owner: options.owner, ...scopes }
+  return { status: grantStatus(scopes), owner: options.owner, ...scopes }
+}
+
+function grantStatus(scopes: Pick<ScopeGrants, 'granted' | 'missing'>): ScopeGrants['status'] {
+  if (scopes.missing.length === 0) return 'granted'
+  if (scopes.granted.length === 0) return 'none'
+  return 'partial'
 }
 
 /**

--- a/src/core/session/watch-authorization.ts
+++ b/src/core/session/watch-authorization.ts
@@ -8,9 +8,11 @@
  * Two ways to detect the grant:
  *
  *  1. Owner unknown (first pairing): poll `eth_getLogs` for the registry's
- *     `AuthorizationsUpdated` events from the block login started at, and
- *     match the `signer` field to our key. One small, bounded query per
- *     tick. The matching event names the owner.
+ *     `AuthorizationsUpdated` events and match the `signer` field to our
+ *     key. The scan starts at the block login started at and moves forward
+ *     to the last block each answer covered, so a poll only re-reads the
+ *     blocks that arrived since the previous one. The matching event names
+ *     the owner.
  *  2. Owner known (renewal, or after the event was found): read the
  *     per-scope expiries directly. No events involved.
  *
@@ -149,12 +151,18 @@ function grantStatus(scopes: Pick<ScopeGrants, 'granted' | 'missing'>): ScopeGra
  * since `fromBlock`, returning the owner of the first event whose signer is
  * our session key. Mechanism 1.
  */
+interface LogScan {
+  owner?: Address
+  /** Highest block among the returned logs; the next scan can start there. */
+  lastBlock?: bigint
+}
+
 async function findOwnerInLogs(
   client: Client<Transport, Chain>,
   registryAddress: Address,
   sessionAddress: Address,
   fromBlock: bigint
-): Promise<Address | undefined> {
+): Promise<LogScan> {
   const logs = (await client.request({
     method: 'eth_getLogs',
     params: [
@@ -167,7 +175,13 @@ async function findOwnerInLogs(
     ],
   })) as Log[]
 
+  let lastBlock: bigint | undefined
   for (const log of logs) {
+    // Raw rows carry the block number as a hex string.
+    const blockNumber = log.blockNumber === null ? undefined : BigInt(log.blockNumber)
+    if (blockNumber !== undefined && (lastBlock === undefined || blockNumber > lastBlock)) {
+      lastBlock = blockNumber
+    }
     let event: ReturnType<typeof extractLoginEvent>
     try {
       event = extractLoginEvent([log])
@@ -175,14 +189,17 @@ async function findOwnerInLogs(
       continue
     }
     if (isAddressEqual(event.args.signer, sessionAddress)) {
-      return event.args.identity
+      const owner = event.args.identity
+      return lastBlock === undefined ? { owner } : { owner, lastBlock }
     }
   }
-  return undefined
+  return lastBlock === undefined ? {} : { lastBlock }
 }
 
 interface WatchState {
   owner: Address | undefined
+  /** Where the next event scan starts; advances to the last block a scan returned. */
+  scanFrom: bigint | undefined
   eventSeen: boolean
   last: WatchAuthorizationResult
   /** Whether any poll completed without an RPC error. */
@@ -197,13 +214,15 @@ interface WatchState {
  * is over.
  */
 async function pollOnce(options: WatchAuthorizationOptions, state: WatchState): Promise<boolean> {
-  const { client, sessionAddress, registryAddress, permissions, fromBlock } = options
-  if (state.owner === undefined && fromBlock !== undefined) {
-    const found = await findOwnerInLogs(client, registryAddress, sessionAddress, fromBlock)
-    if (found !== undefined) {
-      state.owner = found
+  const { client, sessionAddress, registryAddress, permissions } = options
+  if (state.owner === undefined && state.scanFrom !== undefined) {
+    const scan = await findOwnerInLogs(client, registryAddress, sessionAddress, state.scanFrom)
+    // Resume at the last block seen, not after it: the head tipset can still change.
+    if (scan.lastBlock !== undefined && scan.lastBlock > state.scanFrom) state.scanFrom = scan.lastBlock
+    if (scan.owner !== undefined) {
+      state.owner = scan.owner
       state.eventSeen = true
-      options.onProgress?.({ type: 'watch:ownerFound', data: { owner: found } })
+      options.onProgress?.({ type: 'watch:ownerFound', data: { owner: scan.owner } })
     }
   }
   if (state.owner === undefined) return false
@@ -252,6 +271,7 @@ export async function watchAuthorization(options: WatchAuthorizationOptions): Pr
   const deadline = Date.now() + deadlineMs
   const state: WatchState = {
     owner: options.owner,
+    scanFrom: options.fromBlock,
     eventSeen: false,
     last: { status: 'timeout', granted: [], missing: [...options.permissions] },
     anySuccess: false,

--- a/src/core/session/watch-authorization.ts
+++ b/src/core/session/watch-authorization.ts
@@ -42,6 +42,13 @@ import type { WatchAuthorizationProgressEvents } from './types.js'
 export const DEFAULT_WATCH_DEADLINE_MS = 5 * 60 * 1000
 /** Default interval between registry polls. */
 export const DEFAULT_WATCH_INTERVAL_MS = 5000
+/**
+ * Failed polls in a row before the wait gives up on the RPC endpoint. One
+ * failure is a blip and must not end a wait the owner may be about to
+ * finish; this many in a row means the endpoint is down, and the user
+ * should hear that now rather than at the deadline.
+ */
+export const MAX_CONSECUTIVE_POLL_FAILURES = 3
 
 const AUTHORIZATIONS_UPDATED_TOPIC = toEventSelector(
   getAbiItem({ abi: sessionKeyRegistry, name: 'AuthorizationsUpdated' })
@@ -207,6 +214,8 @@ interface WatchState {
   last: WatchAuthorizationResult
   /** Whether any poll completed without an RPC error. */
   anySuccess: boolean
+  /** Failed polls since the last successful one. */
+  consecutiveFailures: number
   lastError: unknown
 }
 
@@ -221,7 +230,10 @@ async function pollOnce(options: WatchAuthorizationOptions, state: WatchState): 
   if (state.owner === undefined && state.scanFrom !== undefined) {
     const scan = await findOwnerInLogs(client, registryAddress, sessionAddress, state.scanFrom)
     // Resume at the last block seen, not after it: the head tipset can still change.
-    if (scan.lastBlock !== undefined && scan.lastBlock > state.scanFrom) state.scanFrom = scan.lastBlock
+    // An empty answer names no block, so the head is read instead; otherwise every
+    // poll would re-scan from the block login started at.
+    const seenUpTo = scan.lastBlock ?? (await headBlock(client))
+    if (seenUpTo > state.scanFrom) state.scanFrom = seenUpTo
     if (scan.owner !== undefined) {
       state.owner = scan.owner
       state.eventSeen = true
@@ -238,6 +250,11 @@ async function pollOnce(options: WatchAuthorizationOptions, state: WatchState): 
   return grants.status === 'granted' || (state.eventSeen && grants.status !== 'none')
 }
 
+/** Current head block number. */
+async function headBlock(client: Client<Transport, Chain>): Promise<bigint> {
+  return BigInt((await client.request({ method: 'eth_blockNumber' })) as string)
+}
+
 /**
  * Run one poll, tolerating RPC errors: a single failed request must not end
  * a five-minute wait after the owner already approved in the browser.
@@ -246,19 +263,31 @@ async function pollTolerantly(options: WatchAuthorizationOptions, state: WatchSt
   try {
     const done = await pollOnce(options, state)
     state.anySuccess = true
+    state.consecutiveFailures = 0
     return done
   } catch (error) {
     state.lastError = error
+    state.consecutiveFailures += 1
     options.onProgress?.({ type: 'watch:error', data: { error } })
     return false
   }
+}
+
+/** The error `login` shows when the endpoint failed {@link MAX_CONSECUTIVE_POLL_FAILURES} polls in a row. */
+function endpointDownError(lastError: unknown): Error {
+  const reason = lastError instanceof Error ? lastError.message : String(lastError)
+  return new Error(
+    `The RPC endpoint failed ${MAX_CONSECUTIVE_POLL_FAILURES} polls in a row (${reason}). Your key is saved; rerun \`filecoin-pin login\` to resume.`,
+    { cause: lastError }
+  )
 }
 
 /**
  * Poll until the session key is authorized or the deadline passes.
  *
  * RPC errors on individual polls are reported through `onProgress` and the
- * wait continues; the error is thrown only when no poll ever succeeded.
+ * wait continues. The wait throws once {@link MAX_CONSECUTIVE_POLL_FAILURES}
+ * polls fail in a row, or at the deadline when no poll ever succeeded.
  * A complete grant ends the wait at once. A new `AuthorizationsUpdated`
  * event also ends it, with whatever the read shows, because the console
  * grants every approved scope in one transaction: a shortfall after the
@@ -278,6 +307,7 @@ export async function watchAuthorization(options: WatchAuthorizationOptions): Pr
     eventSeen: false,
     last: { status: 'timeout', granted: [], missing: [...options.permissions] },
     anySuccess: false,
+    consecutiveFailures: 0,
     lastError: undefined,
   }
 
@@ -286,6 +316,7 @@ export async function watchAuthorization(options: WatchAuthorizationOptions): Pr
     if (remainingMs <= 0) break
     options.onProgress?.({ type: 'watch:tick', data: { remainingMs } })
     if (await pollTolerantly(options, state)) return state.last
+    if (state.consecutiveFailures >= MAX_CONSECUTIVE_POLL_FAILURES) throw endpointDownError(state.lastError)
     await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())))
   }
   // Every poll failed: the RPC endpoint, not the owner, is the problem.

--- a/src/core/session/watch-authorization.ts
+++ b/src/core/session/watch-authorization.ts
@@ -35,7 +35,10 @@ import {
 import type { ProgressEventHandler } from '../utils/types.js'
 import type { WatchAuthorizationProgressEvents } from './types.js'
 
-/** Default poll deadline: about five minutes (PRD decision #11). */
+/**
+ * Default poll deadline. Long enough for the owner to open the link, find
+ * the wallet, and approve; `login` says how to resume when it runs out.
+ */
 export const DEFAULT_WATCH_DEADLINE_MS = 5 * 60 * 1000
 /** Default interval between registry polls. */
 export const DEFAULT_WATCH_INTERVAL_MS = 5000

--- a/src/test/unit/watch-authorization.test.ts
+++ b/src/test/unit/watch-authorization.test.ts
@@ -1,0 +1,187 @@
+import {
+  AddPiecesPermission,
+  CreateDataSetPermission,
+  getExpirations,
+  SchedulePieceRemovalsPermission,
+} from '@filoz/synapse-core/session-key'
+import {
+  type Address,
+  type Chain,
+  type Client,
+  encodeAbiParameters,
+  type Hex,
+  type Transport,
+  toEventSelector,
+} from 'viem'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readScopeGrants, watchAuthorization } from '../../core/session/watch-authorization.js'
+
+// Keep the real event decoder and permission constants; only the multicall read is faked.
+vi.mock('@filoz/synapse-core/session-key', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@filoz/synapse-core/session-key')>()
+  return { ...actual, getExpirations: vi.fn() }
+})
+
+const OWNER: Address = '0x00000000000000000000000000000000000000aa'
+const SESSION: Address = '0x00000000000000000000000000000000000000bb'
+const OTHER_SESSION: Address = '0x00000000000000000000000000000000000000cc'
+const REGISTRY: Address = '0x00000000000000000000000000000000000000dd'
+const FUTURE = BigInt(Math.floor(Date.now() / 1000) + 86400)
+const PAST = 1000n
+
+const TOPIC = toEventSelector('AuthorizationsUpdated(address,address,uint256,bytes32[],string)')
+
+/** Build a raw eth_getLogs entry for AuthorizationsUpdated(identity indexed, signer, expiry, permissions, origin). */
+function authorizationLog(identity: Address, signer: Address, permissions: Hex[]): Record<string, unknown> {
+  const data = encodeAbiParameters(
+    [{ type: 'address' }, { type: 'uint256' }, { type: 'bytes32[]' }, { type: 'string' }],
+    [signer, FUTURE, permissions, 'filecoin-pin']
+  )
+  return {
+    address: REGISTRY,
+    topics: [TOPIC, `0x000000000000000000000000${identity.slice(2)}`],
+    data,
+    blockNumber: '0x10',
+    transactionHash: `0x${'1'.repeat(64)}`,
+    transactionIndex: '0x0',
+    blockHash: `0x${'2'.repeat(64)}`,
+    logIndex: '0x0',
+    removed: false,
+  }
+}
+
+function fakeClient(logsPerCall: Array<Record<string, unknown>[]>): {
+  client: Client<Transport, Chain>
+  calls: unknown[]
+} {
+  const calls: unknown[] = []
+  let call = 0
+  const client = {
+    request: vi.fn(async (args: { method: string; params: unknown }) => {
+      calls.push(args)
+      if (args.method !== 'eth_getLogs') throw new Error(`unexpected ${args.method}`)
+      const logs = logsPerCall[Math.min(call, logsPerCall.length - 1)] ?? []
+      call += 1
+      return logs
+    }),
+  } as unknown as Client<Transport, Chain>
+  return { client, calls }
+}
+
+const base = {
+  sessionAddress: SESSION,
+  registryAddress: REGISTRY,
+  permissions: [CreateDataSetPermission, AddPiecesPermission],
+  pollIntervalMs: 1,
+}
+
+describe('watchAuthorization', () => {
+  beforeEach(() => {
+    vi.mocked(getExpirations).mockReset()
+  })
+
+  it('finds the owner from the matching event, then confirms every scope', async () => {
+    const { client, calls } = fakeClient([
+      [],
+      [authorizationLog(OWNER, OTHER_SESSION, []), authorizationLog(OWNER, SESSION, [])],
+    ])
+    // First tick: no logs. Second tick: an unrelated signer, then ours.
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
+
+    const result = await watchAuthorization({ ...base, client, fromBlock: 42n, deadlineMs: 2000 })
+
+    expect(result.status).toBe('granted')
+    expect(result.owner?.toLowerCase()).toBe(OWNER)
+    expect(result.expiry).toBe(FUTURE)
+    expect(result.granted).toEqual([CreateDataSetPermission, AddPiecesPermission])
+    expect(result.missing).toEqual([])
+    expect(calls[0]).toMatchObject({
+      method: 'eth_getLogs',
+      params: [{ address: REGISTRY, fromBlock: '0x2a', toBlock: 'latest', topics: [TOPIC] }],
+    })
+    expect(vi.mocked(getExpirations)).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({ sessionKeyAddress: SESSION, contractAddress: REGISTRY })
+    )
+  })
+
+  it('returns timeout, never having learned the owner, when no event arrives before the deadline', async () => {
+    const { client } = fakeClient([[]])
+    const ticks: number[] = []
+
+    const result = await watchAuthorization({
+      ...base,
+      client,
+      fromBlock: 1n,
+      deadlineMs: 20,
+      onTick: (ms) => ticks.push(ms),
+    })
+
+    expect(result).toEqual({ status: 'timeout', granted: [], missing: base.permissions })
+    expect(ticks.length).toBeGreaterThan(0)
+    expect(ticks[0]).toBeLessThanOrEqual(20)
+    expect(vi.mocked(getExpirations)).not.toHaveBeenCalled()
+  })
+
+  it('reports a partial grant as soon as the event lands', async () => {
+    const { client } = fakeClient([[authorizationLog(OWNER, SESSION, [])]])
+    vi.mocked(getExpirations).mockResolvedValue({
+      [CreateDataSetPermission]: FUTURE,
+      [AddPiecesPermission]: FUTURE,
+      [SchedulePieceRemovalsPermission]: 0n,
+    })
+
+    const result = await watchAuthorization({
+      ...base,
+      permissions: [CreateDataSetPermission, AddPiecesPermission, SchedulePieceRemovalsPermission],
+      client,
+      fromBlock: 1n,
+      deadlineMs: 2000,
+    })
+
+    expect(result.status).toBe('partial')
+    expect(result.granted).toEqual([CreateDataSetPermission, AddPiecesPermission])
+    expect(result.missing).toEqual([SchedulePieceRemovalsPermission])
+    expect(vi.mocked(getExpirations)).toHaveBeenCalledTimes(1)
+  })
+
+  it('with a known owner, skips the event scan and polls the expiries until granted', async () => {
+    const { client, calls } = fakeClient([[]])
+    vi.mocked(getExpirations)
+      .mockResolvedValueOnce({ [CreateDataSetPermission]: PAST, [AddPiecesPermission]: 0n })
+      .mockResolvedValueOnce({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
+
+    const result = await watchAuthorization({ ...base, client, owner: OWNER, deadlineMs: 2000 })
+
+    expect(result.status).toBe('granted')
+    expect(calls).toEqual([])
+    expect(vi.mocked(getExpirations)).toHaveBeenCalledTimes(2)
+  })
+
+  it('with a known owner and no event, a pre-existing partial grant is reported at the deadline', async () => {
+    const { client } = fakeClient([[]])
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: 0n })
+
+    const result = await watchAuthorization({ ...base, client, owner: OWNER, fromBlock: 1n, deadlineMs: 15 })
+
+    expect(result.status).toBe('partial')
+    expect(result.granted).toEqual([CreateDataSetPermission])
+    expect(result.missing).toEqual([AddPiecesPermission])
+  })
+
+  it('rejects a call with neither owner nor fromBlock', async () => {
+    const { client } = fakeClient([[]])
+    await expect(watchAuthorization({ ...base, client })).rejects.toThrow(/owner or fromBlock/)
+  })
+})
+
+describe('readScopeGrants', () => {
+  it('treats a lapsed expiry as not granted', async () => {
+    const { client } = fakeClient([[]])
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: PAST, [AddPiecesPermission]: 0n })
+
+    const grants = await readScopeGrants({ ...base, client, owner: OWNER })
+
+    expect(grants).toEqual({ status: 'none', owner: OWNER, granted: [], missing: base.permissions })
+  })
+})

--- a/src/test/unit/watch-authorization.test.ts
+++ b/src/test/unit/watch-authorization.test.ts
@@ -114,7 +114,9 @@ describe('watchAuthorization', () => {
       client,
       fromBlock: 1n,
       deadlineMs: 20,
-      onTick: (ms) => ticks.push(ms),
+      onProgress: (event) => {
+        if (event.type === 'watch:tick') ticks.push(event.data.remainingMs)
+      },
     })
 
     expect(result).toEqual({ status: 'timeout', granted: [], missing: base.permissions })
@@ -145,28 +147,67 @@ describe('watchAuthorization', () => {
     expect(vi.mocked(getExpirations)).toHaveBeenCalledTimes(1)
   })
 
-  it('with a known owner, skips the event scan and polls the expiries until granted', async () => {
-    const { client, calls } = fakeClient([[]])
+  it('with a known owner, never scans logs and polls the expiries until granted', async () => {
+    const { client, calls } = fakeClient([[authorizationLog(OTHER_SESSION, SESSION, [])]])
     vi.mocked(getExpirations)
       .mockResolvedValueOnce({ [CreateDataSetPermission]: PAST, [AddPiecesPermission]: 0n })
       .mockResolvedValueOnce({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
 
-    const result = await watchAuthorization({ ...base, client, owner: OWNER, deadlineMs: 2000 })
-
-    expect(result.status).toBe('granted')
-    expect(calls).toEqual([])
-    expect(vi.mocked(getExpirations)).toHaveBeenCalledTimes(2)
-  })
-
-  it('never replaces a supplied owner with one from an event, and does not scan logs', async () => {
-    const { client, calls } = fakeClient([[authorizationLog(OTHER_SESSION, SESSION, [])]])
-    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
-
     const result = await watchAuthorization({ ...base, client, owner: OWNER, fromBlock: 1n, deadlineMs: 2000 })
 
+    expect(result.status).toBe('granted')
     expect(result.owner).toBe(OWNER)
     expect(calls).toEqual([])
+    expect(vi.mocked(getExpirations)).toHaveBeenCalledTimes(2)
     expect(vi.mocked(getExpirations)).toHaveBeenCalledWith(client, expect.objectContaining({ address: OWNER }))
+  })
+
+  it('reports none, not timeout, when the owner acted but granted no requested scope', async () => {
+    const { client } = fakeClient([[authorizationLog(OWNER, SESSION, [])]])
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: 0n, [AddPiecesPermission]: 0n })
+
+    const result = await watchAuthorization({ ...base, client, fromBlock: 1n, deadlineMs: 2000 })
+
+    expect(result.status).toBe('none')
+    expect(result.owner?.toLowerCase()).toBe(OWNER)
+    expect(result.missing).toEqual(base.permissions)
+  })
+
+  it('keeps polling through a transient RPC error and reports it as progress', async () => {
+    const errors: unknown[] = []
+    const { client } = fakeClient([[], [authorizationLog(OWNER, SESSION, [])]])
+    const original = client.request
+    let first = true
+    ;(client as { request: unknown }).request = async (args: unknown) => {
+      if (first) {
+        first = false
+        throw new Error('429 rate limited')
+      }
+      return (original as (a: unknown) => Promise<unknown>)(args)
+    }
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
+
+    const result = await watchAuthorization({
+      ...base,
+      client,
+      fromBlock: 1n,
+      deadlineMs: 2000,
+      onProgress: (event) => {
+        if (event.type === 'watch:error') errors.push(event.data.error)
+      },
+    })
+
+    expect(result.status).toBe('granted')
+    expect(errors).toHaveLength(1)
+  })
+
+  it('throws the RPC error only when no poll ever succeeded', async () => {
+    const { client } = fakeClient([[]])
+    ;(client as { request: unknown }).request = async () => {
+      throw new Error('502 bad gateway')
+    }
+
+    await expect(watchAuthorization({ ...base, client, fromBlock: 1n, deadlineMs: 15 })).rejects.toThrow('502')
   })
 
   it('with a known owner and no event, a pre-existing partial grant is reported at the deadline', async () => {

--- a/src/test/unit/watch-authorization.test.ts
+++ b/src/test/unit/watch-authorization.test.ts
@@ -162,15 +162,17 @@ describe('watchAuthorization', () => {
     expect(vi.mocked(getExpirations)).toHaveBeenCalledWith(client, expect.objectContaining({ address: OWNER }))
   })
 
-  it('reports none, not timeout, when the owner acted but granted no requested scope', async () => {
+  it('reports none at the deadline, not timeout, when the owner acted but granted no requested scope', async () => {
     const { client } = fakeClient([[authorizationLog(OWNER, SESSION, [])]])
     vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: 0n, [AddPiecesPermission]: 0n })
 
-    const result = await watchAuthorization({ ...base, client, fromBlock: 1n, deadlineMs: 2000 })
+    const result = await watchAuthorization({ ...base, client, fromBlock: 1n, deadlineMs: 30 })
 
     expect(result.status).toBe('none')
     expect(result.owner?.toLowerCase()).toBe(OWNER)
     expect(result.missing).toEqual(base.permissions)
+    // Kept polling after the event rather than stopping on the first empty read.
+    expect(vi.mocked(getExpirations).mock.calls.length).toBeGreaterThan(1)
   })
 
   it('keeps polling through a transient RPC error and reports it as progress', async () => {

--- a/src/test/unit/watch-authorization.test.ts
+++ b/src/test/unit/watch-authorization.test.ts
@@ -13,7 +13,7 @@ import {
   type Transport,
   toEventSelector,
 } from 'viem'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { readScopeGrants, watchAuthorization } from '../../core/session/watch-authorization.js'
 
 // Keep the real event decoder and permission constants; only the multicall read is faked.
@@ -75,9 +75,23 @@ const base = {
   pollIntervalMs: 1,
 }
 
+/** Run the watcher under fake timers, draining every scheduled poll and the deadline. */
+async function watch(options: Parameters<typeof watchAuthorization>[0]) {
+  const pending = watchAuthorization(options)
+  // A rejection that lands while timers drain must not surface as unhandled.
+  pending.catch(() => undefined)
+  await vi.runAllTimersAsync()
+  return pending
+}
+
 describe('watchAuthorization', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     vi.mocked(getExpirations).mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('finds the owner from the matching event, then confirms every scope', async () => {
@@ -88,7 +102,7 @@ describe('watchAuthorization', () => {
     // First tick: no logs. Second tick: an unrelated signer, then ours.
     vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
 
-    const result = await watchAuthorization({ ...base, client, fromBlock: 42n, deadlineMs: 2000 })
+    const result = await watch({ ...base, client, fromBlock: 42n, deadlineMs: 2000 })
 
     expect(result.status).toBe('granted')
     expect(result.owner?.toLowerCase()).toBe(OWNER)
@@ -109,7 +123,7 @@ describe('watchAuthorization', () => {
     const { client } = fakeClient([[]])
     const ticks: number[] = []
 
-    const result = await watchAuthorization({
+    const result = await watch({
       ...base,
       client,
       fromBlock: 1n,
@@ -133,7 +147,7 @@ describe('watchAuthorization', () => {
       [SchedulePieceRemovalsPermission]: 0n,
     })
 
-    const result = await watchAuthorization({
+    const result = await watch({
       ...base,
       permissions: [CreateDataSetPermission, AddPiecesPermission, SchedulePieceRemovalsPermission],
       client,
@@ -153,7 +167,7 @@ describe('watchAuthorization', () => {
       .mockResolvedValueOnce({ [CreateDataSetPermission]: PAST, [AddPiecesPermission]: 0n })
       .mockResolvedValueOnce({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
 
-    const result = await watchAuthorization({ ...base, client, owner: OWNER, fromBlock: 1n, deadlineMs: 2000 })
+    const result = await watch({ ...base, client, owner: OWNER, fromBlock: 1n, deadlineMs: 2000 })
 
     expect(result.status).toBe('granted')
     expect(result.owner).toBe(OWNER)
@@ -166,7 +180,7 @@ describe('watchAuthorization', () => {
     const { client } = fakeClient([[authorizationLog(OWNER, SESSION, [])]])
     vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: 0n, [AddPiecesPermission]: 0n })
 
-    const result = await watchAuthorization({ ...base, client, fromBlock: 1n, deadlineMs: 30 })
+    const result = await watch({ ...base, client, fromBlock: 1n, deadlineMs: 30 })
 
     expect(result.status).toBe('none')
     expect(result.owner?.toLowerCase()).toBe(OWNER)
@@ -189,7 +203,7 @@ describe('watchAuthorization', () => {
     }
     vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
 
-    const result = await watchAuthorization({
+    const result = await watch({
       ...base,
       client,
       fromBlock: 1n,
@@ -209,14 +223,14 @@ describe('watchAuthorization', () => {
       throw new Error('502 bad gateway')
     }
 
-    await expect(watchAuthorization({ ...base, client, fromBlock: 1n, deadlineMs: 15 })).rejects.toThrow('502')
+    await expect(watch({ ...base, client, fromBlock: 1n, deadlineMs: 15 })).rejects.toThrow('502')
   })
 
   it('with a known owner and no event, a pre-existing partial grant is reported at the deadline', async () => {
     const { client } = fakeClient([[]])
     vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: 0n })
 
-    const result = await watchAuthorization({ ...base, client, owner: OWNER, fromBlock: 1n, deadlineMs: 15 })
+    const result = await watch({ ...base, client, owner: OWNER, fromBlock: 1n, deadlineMs: 15 })
 
     expect(result.status).toBe('partial')
     expect(result.granted).toEqual([CreateDataSetPermission])
@@ -225,7 +239,7 @@ describe('watchAuthorization', () => {
 
   it('rejects a call with neither owner nor fromBlock', async () => {
     const { client } = fakeClient([[]])
-    await expect(watchAuthorization({ ...base, client })).rejects.toThrow(/owner or fromBlock/)
+    await expect(watch({ ...base, client })).rejects.toThrow(/owner or fromBlock/)
   })
 })
 

--- a/src/test/unit/watch-authorization.test.ts
+++ b/src/test/unit/watch-authorization.test.ts
@@ -158,6 +158,17 @@ describe('watchAuthorization', () => {
     expect(vi.mocked(getExpirations)).toHaveBeenCalledTimes(2)
   })
 
+  it('never replaces a supplied owner with one from an event, and does not scan logs', async () => {
+    const { client, calls } = fakeClient([[authorizationLog(OTHER_SESSION, SESSION, [])]])
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
+
+    const result = await watchAuthorization({ ...base, client, owner: OWNER, fromBlock: 1n, deadlineMs: 2000 })
+
+    expect(result.owner).toBe(OWNER)
+    expect(calls).toEqual([])
+    expect(vi.mocked(getExpirations)).toHaveBeenCalledWith(client, expect.objectContaining({ address: OWNER }))
+  })
+
   it('with a known owner and no event, a pre-existing partial grant is reported at the deadline', async () => {
     const { client } = fakeClient([[]])
     vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: 0n })

--- a/src/test/unit/watch-authorization.test.ts
+++ b/src/test/unit/watch-authorization.test.ts
@@ -119,6 +119,25 @@ describe('watchAuthorization', () => {
     )
   })
 
+  it('moves the scan forward to the last block each answer covered', async () => {
+    const unrelated = { ...authorizationLog(OWNER, OTHER_SESSION, []), blockNumber: '0x64' }
+    const { client, calls } = fakeClient([
+      [unrelated],
+      [],
+      [{ ...authorizationLog(OWNER, SESSION, []), blockNumber: '0x70' }],
+    ])
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
+
+    const result = await watch({ ...base, client, fromBlock: 42n, deadlineMs: 2000 })
+
+    expect(result.status).toBe('granted')
+    const froms = calls
+      .filter((c) => (c as { method: string }).method === 'eth_getLogs')
+      .map((c) => (c as { params: [{ fromBlock: string }] }).params[0].fromBlock)
+    // Starts at 42; after a page ending at block 100 it resumes there; an empty page leaves it in place.
+    expect(froms).toEqual(['0x2a', '0x64', '0x64'])
+  })
+
   it('returns timeout, never having learned the owner, when no event arrives before the deadline', async () => {
     const { client } = fakeClient([[]])
     const ticks: number[] = []

--- a/src/test/unit/watch-authorization.test.ts
+++ b/src/test/unit/watch-authorization.test.ts
@@ -14,6 +14,7 @@ import {
   toEventSelector,
 } from 'viem'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WatchAuthorizationProgressEvents } from '../../core/session/types.js'
 import { readScopeGrants, watchAuthorization } from '../../core/session/watch-authorization.js'
 
 // Keep the real event decoder and permission constants; only the multicall read is faked.
@@ -23,10 +24,12 @@ vi.mock('@filoz/synapse-core/session-key', async (importOriginal) => {
 })
 
 const OWNER: Address = '0x00000000000000000000000000000000000000aa'
+const OTHER_OWNER: Address = '0x00000000000000000000000000000000000000ab'
 const SESSION: Address = '0x00000000000000000000000000000000000000bb'
 const OTHER_SESSION: Address = '0x00000000000000000000000000000000000000cc'
 const REGISTRY: Address = '0x00000000000000000000000000000000000000dd'
 const FUTURE = BigInt(Math.floor(Date.now() / 1000) + 86400)
+const LATER = FUTURE + 3600n
 const PAST = 1000n
 
 const TOPIC = toEventSelector('AuthorizationsUpdated(address,address,uint256,bytes32[],string)')
@@ -50,23 +53,56 @@ function authorizationLog(identity: Address, signer: Address, permissions: Hex[]
   }
 }
 
-function fakeClient(logsPerCall: Array<Record<string, unknown>[]>): {
+/** One eth_getLogs answer: the logs to return, or the error to throw. */
+type LogsAnswer = Record<string, unknown>[] | Error
+
+interface RpcCall {
+  method: string
+  params?: unknown
+}
+
+/**
+ * A client whose eth_getLogs answers follow `schedule` call by call; the last
+ * entry repeats once the schedule runs out. eth_blockNumber answers `head`.
+ */
+function fakeClient(
+  schedule: LogsAnswer[],
+  options: { head?: string } = {}
+): {
   client: Client<Transport, Chain>
-  calls: unknown[]
+  calls: RpcCall[]
 } {
-  const calls: unknown[] = []
+  const { head = '0x64' } = options
+  const calls: RpcCall[] = []
   let call = 0
   const client = {
-    request: vi.fn(async (args: { method: string; params: unknown }) => {
+    request: vi.fn(async (args: RpcCall) => {
       calls.push(args)
-      if (args.method === 'eth_blockNumber') return '0x64'
+      if (args.method === 'eth_blockNumber') return head
       if (args.method !== 'eth_getLogs') throw new Error(`unexpected ${args.method}`)
-      const logs = logsPerCall[Math.min(call, logsPerCall.length - 1)] ?? []
+      const answer = schedule[Math.min(call, schedule.length - 1)] ?? []
       call += 1
-      return logs
+      if (answer instanceof Error) throw answer
+      return answer
     }),
   } as unknown as Client<Transport, Chain>
   return { client, calls }
+}
+
+/** The fromBlock of every eth_getLogs call, in order. */
+function scanStarts(calls: RpcCall[]): string[] {
+  return calls
+    .filter((c): c is { method: string; params: [{ fromBlock: string }] } => c.method === 'eth_getLogs')
+    .map((c) => c.params[0].fromBlock)
+}
+
+/** Collect the data of every progress event of one type. */
+function progressOf<T extends WatchAuthorizationProgressEvents['type']>(type: T) {
+  const data: Extract<WatchAuthorizationProgressEvents, { type: T }>['data'][] = []
+  const onProgress = (event: WatchAuthorizationProgressEvents) => {
+    if (event.type === type) data.push(event.data as (typeof data)[number])
+  }
+  return { data, onProgress }
 }
 
 const base = {
@@ -96,20 +132,22 @@ describe('watchAuthorization', () => {
   })
 
   it('finds the owner from the matching event, then confirms every scope', async () => {
+    // First tick: no logs. Second tick: another owner's key, then ours.
     const { client, calls } = fakeClient([
       [],
-      [authorizationLog(OWNER, OTHER_SESSION, []), authorizationLog(OWNER, SESSION, [])],
+      [authorizationLog(OTHER_OWNER, OTHER_SESSION, []), authorizationLog(OWNER, SESSION, [])],
     ])
-    // First tick: no logs. Second tick: an unrelated signer, then ours.
-    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
+    const owners = progressOf('watch:ownerFound')
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: LATER })
 
-    const result = await watch({ ...base, client, fromBlock: 42n, deadlineMs: 2000 })
+    const result = await watch({ ...base, client, fromBlock: 42n, deadlineMs: 2000, onProgress: owners.onProgress })
 
     expect(result.status).toBe('granted')
     expect(result.owner?.toLowerCase()).toBe(OWNER)
-    expect(result.expiry).toBe(FUTURE)
+    expect(result.expiry).toBe(LATER)
     expect(result.granted).toEqual([CreateDataSetPermission, AddPiecesPermission])
     expect(result.missing).toEqual([])
+    expect(owners.data.map((d) => d.owner.toLowerCase())).toEqual([OWNER])
     expect(calls[0]).toMatchObject({
       method: 'eth_getLogs',
       params: [{ address: REGISTRY, fromBlock: '0x2a', toBlock: 'latest', topics: [TOPIC] }],
@@ -122,40 +160,53 @@ describe('watchAuthorization', () => {
 
   it('moves the scan forward to the last block each answer covered', async () => {
     const unrelated = { ...authorizationLog(OWNER, OTHER_SESSION, []), blockNumber: '0x64' }
-    const { client, calls } = fakeClient([
-      [unrelated],
-      [],
-      [{ ...authorizationLog(OWNER, SESSION, []), blockNumber: '0x70' }],
-    ])
+    const { client, calls } = fakeClient(
+      [[unrelated], [], [{ ...authorizationLog(OWNER, SESSION, []), blockNumber: '0x70' }]],
+      { head: '0x66' }
+    )
     vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
 
     const result = await watch({ ...base, client, fromBlock: 42n, deadlineMs: 2000 })
 
     expect(result.status).toBe('granted')
-    const froms = calls
-      .filter((c) => (c as { method: string }).method === 'eth_getLogs')
-      .map((c) => (c as { params: [{ fromBlock: string }] }).params[0].fromBlock)
-    // Starts at 42; after a page ending at block 100 it resumes there; an empty page leaves it in place.
-    expect(froms).toEqual(['0x2a', '0x64', '0x64'])
+    // Starts at 42; after a page ending at block 0x64 it resumes there; an empty page moves it to the head (0x66).
+    expect(scanStarts(calls)).toEqual(['0x2a', '0x64', '0x66'])
+  })
+
+  it('never moves the scan backwards when the head is behind the last block seen', async () => {
+    const ahead = { ...authorizationLog(OWNER, OTHER_SESSION, []), blockNumber: '0x70' }
+    const { client, calls } = fakeClient([[ahead], [], [authorizationLog(OWNER, SESSION, [])]], { head: '0x64' })
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
+
+    const result = await watch({ ...base, client, fromBlock: 42n, deadlineMs: 2000 })
+
+    expect(result.status).toBe('granted')
+    // The empty page reads a head (0x64) below the last block seen (0x70); the scan stays at 0x70.
+    expect(scanStarts(calls)).toEqual(['0x2a', '0x70', '0x70'])
+  })
+
+  it('skips a log it cannot decode and still finds the matching one behind it', async () => {
+    const garbage = { ...authorizationLog(OWNER, SESSION, []), data: '0xdeadbeef' }
+    const { client } = fakeClient([[garbage, authorizationLog(OWNER, SESSION, [])]])
+    const errors = progressOf('watch:error')
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
+
+    const result = await watch({ ...base, client, fromBlock: 1n, deadlineMs: 2000, onProgress: errors.onProgress })
+
+    expect(result.status).toBe('granted')
+    expect(result.owner?.toLowerCase()).toBe(OWNER)
+    expect(errors.data).toEqual([])
   })
 
   it('returns timeout, never having learned the owner, when no event arrives before the deadline', async () => {
     const { client } = fakeClient([[]])
-    const ticks: number[] = []
+    const ticks = progressOf('watch:tick')
 
-    const result = await watch({
-      ...base,
-      client,
-      fromBlock: 1n,
-      deadlineMs: 20,
-      onProgress: (event) => {
-        if (event.type === 'watch:tick') ticks.push(event.data.remainingMs)
-      },
-    })
+    const result = await watch({ ...base, client, fromBlock: 1n, deadlineMs: 20, onProgress: ticks.onProgress })
 
     expect(result).toEqual({ status: 'timeout', granted: [], missing: base.permissions })
-    expect(ticks.length).toBeGreaterThan(0)
-    expect(ticks[0]).toBeLessThanOrEqual(20)
+    expect(ticks.data.length).toBeGreaterThan(0)
+    expect(ticks.data[0]?.remainingMs).toBe(20)
     expect(vi.mocked(getExpirations)).not.toHaveBeenCalled()
   })
 
@@ -209,101 +260,71 @@ describe('watchAuthorization', () => {
     expect(vi.mocked(getExpirations).mock.calls.length).toBeGreaterThan(1)
   })
 
+  it('with a known owner and no event, reports timeout with the owner when no requested scope is live', async () => {
+    const { client } = fakeClient([[]])
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: 0n, [AddPiecesPermission]: 0n })
+
+    const result = await watch({ ...base, client, owner: OWNER, fromBlock: 1n, deadlineMs: 15 })
+
+    expect(result).toEqual({ status: 'timeout', owner: OWNER, granted: [], missing: base.permissions })
+  })
+
   it('keeps polling through a transient RPC error and reports it as progress', async () => {
-    const errors: unknown[] = []
-    const { client } = fakeClient([[], [authorizationLog(OWNER, SESSION, [])]])
-    const original = client.request
-    let first = true
-    ;(client as { request: unknown }).request = async (args: unknown) => {
-      if (first) {
-        first = false
-        throw new Error('429 rate limited')
-      }
-      return (original as (a: unknown) => Promise<unknown>)(args)
-    }
+    const { client } = fakeClient([new Error('429 rate limited'), [authorizationLog(OWNER, SESSION, [])]])
+    const errors = progressOf('watch:error')
     vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
 
-    const result = await watch({
-      ...base,
-      client,
-      fromBlock: 1n,
-      deadlineMs: 2000,
-      onProgress: (event) => {
-        if (event.type === 'watch:error') errors.push(event.data.error)
-      },
-    })
+    const result = await watch({ ...base, client, fromBlock: 1n, deadlineMs: 2000, onProgress: errors.onProgress })
 
     expect(result.status).toBe('granted')
-    expect(errors).toHaveLength(1)
+    expect(errors.data).toHaveLength(1)
   })
 
   it('gives up after three failed polls in a row, well before the deadline', async () => {
-    let polls = 0
-    const { client } = fakeClient([[]])
-    ;(client as { request: unknown }).request = async () => {
-      polls += 1
-      throw new Error('502 bad gateway')
-    }
+    const { client, calls } = fakeClient([new Error('502 bad gateway')])
 
     await expect(watch({ ...base, client, fromBlock: 1n, deadlineMs: 2000 })).rejects.toThrow(
       'failed 3 polls in a row (502 bad gateway)'
     )
-    expect(polls).toBe(3)
+    expect(scanStarts(calls)).toHaveLength(3)
   })
 
   it('throws the RPC error at the deadline when every poll failed but fewer than three ran', async () => {
-    const { client } = fakeClient([[]])
-    ;(client as { request: unknown }).request = async () => {
-      throw new Error('502 bad gateway')
-    }
+    const { client, calls } = fakeClient([new Error('502 bad gateway')])
 
     await expect(watch({ ...base, client, fromBlock: 1n, deadlineMs: 2, pollIntervalMs: 5 })).rejects.toThrow(
       '502 bad gateway'
     )
+    expect(scanStarts(calls)).toHaveLength(1)
   })
 
   it('a successful poll between failures resets the count, so scattered failures never give up', async () => {
-    // fail, fail, ok (no event), fail, fail, ok (event): four failures, never three in a row.
-    const outcomes = ['fail', 'fail', 'ok', 'fail', 'fail', 'event']
-    const errors: unknown[] = []
-    const { client } = fakeClient([[]])
-    const original = client.request as (a: unknown) => Promise<unknown>
-    ;(client as { request: unknown }).request = async (args: { method: string }) => {
-      if (args.method !== 'eth_getLogs') return original(args)
-      const outcome = outcomes.shift() ?? 'event'
-      if (outcome === 'fail') throw new Error('503')
-      return outcome === 'event' ? [authorizationLog(OWNER, SESSION, [])] : []
-    }
+    // fail, fail, ok (no event), fail, fail, event: four failures, never three in a row.
+    const { client } = fakeClient([
+      new Error('503'),
+      new Error('503'),
+      [],
+      new Error('503'),
+      new Error('503'),
+      [authorizationLog(OWNER, SESSION, [])],
+    ])
+    const errors = progressOf('watch:error')
     vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
 
-    const result = await watch({
-      ...base,
-      client,
-      fromBlock: 1n,
-      deadlineMs: 2000,
-      onProgress: (event) => {
-        if (event.type === 'watch:error') errors.push(event.data.error)
-      },
-    })
+    const result = await watch({ ...base, client, fromBlock: 1n, deadlineMs: 2000, onProgress: errors.onProgress })
 
     expect(result.status).toBe('granted')
-    expect(errors).toHaveLength(4)
+    expect(errors.data).toHaveLength(4)
   })
 
   it('moves the scan to the head block when an answer is empty, instead of re-reading from the start', async () => {
-    const { client, calls } = fakeClient([[], [authorizationLog(OWNER, SESSION, [])]])
+    const { client, calls } = fakeClient([[], [authorizationLog(OWNER, SESSION, [])]], { head: '0x5a' })
     vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
 
     await watch({ ...base, client, fromBlock: 42n, deadlineMs: 2000 })
 
-    const fromBlocks = calls
-      .filter(
-        (c): c is { method: string; params: [{ fromBlock: string }] } =>
-          (c as { method: string }).method === 'eth_getLogs'
-      )
-      .map((c) => c.params[0].fromBlock)
-    // First scan from login's block (0x2a); the empty answer moves the next one to the head (0x64).
-    expect(fromBlocks).toEqual(['0x2a', '0x64'])
+    // First scan from login's block (0x2a); the empty answer moves the next one to the head (0x5a).
+    expect(scanStarts(calls)).toEqual(['0x2a', '0x5a'])
   })
 
   it('with a known owner and no event, a pre-existing partial grant is reported at the deadline', async () => {
@@ -315,6 +336,8 @@ describe('watchAuthorization', () => {
     expect(result.status).toBe('partial')
     expect(result.granted).toEqual([CreateDataSetPermission])
     expect(result.missing).toEqual([AddPiecesPermission])
+    // Kept polling to the deadline rather than stopping on the first partial read.
+    expect(vi.mocked(getExpirations).mock.calls.length).toBeGreaterThan(1)
   })
 
   it('rejects a call with neither owner nor fromBlock', async () => {

--- a/src/test/unit/watch-authorization.test.ts
+++ b/src/test/unit/watch-authorization.test.ts
@@ -59,6 +59,7 @@ function fakeClient(logsPerCall: Array<Record<string, unknown>[]>): {
   const client = {
     request: vi.fn(async (args: { method: string; params: unknown }) => {
       calls.push(args)
+      if (args.method === 'eth_blockNumber') return '0x64'
       if (args.method !== 'eth_getLogs') throw new Error(`unexpected ${args.method}`)
       const logs = logsPerCall[Math.min(call, logsPerCall.length - 1)] ?? []
       call += 1
@@ -236,13 +237,73 @@ describe('watchAuthorization', () => {
     expect(errors).toHaveLength(1)
   })
 
-  it('throws the RPC error only when no poll ever succeeded', async () => {
+  it('gives up after three failed polls in a row, well before the deadline', async () => {
+    let polls = 0
+    const { client } = fakeClient([[]])
+    ;(client as { request: unknown }).request = async () => {
+      polls += 1
+      throw new Error('502 bad gateway')
+    }
+
+    await expect(watch({ ...base, client, fromBlock: 1n, deadlineMs: 2000 })).rejects.toThrow(
+      'failed 3 polls in a row (502 bad gateway)'
+    )
+    expect(polls).toBe(3)
+  })
+
+  it('throws the RPC error at the deadline when every poll failed but fewer than three ran', async () => {
     const { client } = fakeClient([[]])
     ;(client as { request: unknown }).request = async () => {
       throw new Error('502 bad gateway')
     }
 
-    await expect(watch({ ...base, client, fromBlock: 1n, deadlineMs: 15 })).rejects.toThrow('502')
+    await expect(watch({ ...base, client, fromBlock: 1n, deadlineMs: 2, pollIntervalMs: 5 })).rejects.toThrow(
+      '502 bad gateway'
+    )
+  })
+
+  it('a successful poll between failures resets the count, so scattered failures never give up', async () => {
+    // fail, fail, ok (no event), fail, fail, ok (event): four failures, never three in a row.
+    const outcomes = ['fail', 'fail', 'ok', 'fail', 'fail', 'event']
+    const errors: unknown[] = []
+    const { client } = fakeClient([[]])
+    const original = client.request as (a: unknown) => Promise<unknown>
+    ;(client as { request: unknown }).request = async (args: { method: string }) => {
+      if (args.method !== 'eth_getLogs') return original(args)
+      const outcome = outcomes.shift() ?? 'event'
+      if (outcome === 'fail') throw new Error('503')
+      return outcome === 'event' ? [authorizationLog(OWNER, SESSION, [])] : []
+    }
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
+
+    const result = await watch({
+      ...base,
+      client,
+      fromBlock: 1n,
+      deadlineMs: 2000,
+      onProgress: (event) => {
+        if (event.type === 'watch:error') errors.push(event.data.error)
+      },
+    })
+
+    expect(result.status).toBe('granted')
+    expect(errors).toHaveLength(4)
+  })
+
+  it('moves the scan to the head block when an answer is empty, instead of re-reading from the start', async () => {
+    const { client, calls } = fakeClient([[], [authorizationLog(OWNER, SESSION, [])]])
+    vi.mocked(getExpirations).mockResolvedValue({ [CreateDataSetPermission]: FUTURE, [AddPiecesPermission]: FUTURE })
+
+    await watch({ ...base, client, fromBlock: 42n, deadlineMs: 2000 })
+
+    const fromBlocks = calls
+      .filter(
+        (c): c is { method: string; params: [{ fromBlock: string }] } =>
+          (c as { method: string }).method === 'eth_getLogs'
+      )
+      .map((c) => c.params[0].fromBlock)
+    // First scan from login's block (0x2a); the empty answer moves the next one to the head (0x64).
+    expect(fromBlocks).toEqual(['0x2a', '0x64'])
   })
 
   it('with a known owner and no event, a pre-existing partial grant is reported at the deadline', async () => {


### PR DESCRIPTION
Stacked on #687 (`feat/per-command-scope-gating`).

Adds `watchAuthorization` in `src/core/session/watch-authorization.ts`: the polling half of `filecoin-pin login`. It implements the two detection mechanisms in PRD section 4 ("How the CLI detects approval"): an `eth_getLogs` scan for `AuthorizationsUpdated` events matching our signer when the owner is unknown, and direct per-scope expiry reads (`getExpirations` from synapse-core) once the owner is known. Events are decoded with `extractLoginEvent`; nothing is re-implemented from the registry ABI.

The wait is bounded by a deadline, five minutes by default (PRD appendix A, decision 11). The result carries owner, expiry, and the granted and missing scopes, so the caller can print a requested-versus-granted diff (decision 13); `none` means the owner acted but granted no requested scope, and `timeout` is reserved for the deadline. Progress goes through the same `onProgress` event pattern as the other session helpers (`watch:tick`, `watch:ownerFound`, `watch:error`). A failed poll is reported and the wait continues; the error is thrown only when no poll ever succeeded.

Unit tests cover the event match, the timeout, a partial grant, a grant of none, the known-owner path (never replaced by an event), a transient RPC error, an RPC endpoint that never answers, and a lapsed expiry.

Part of #697. No CLI surface changes in this PR; `login` itself comes in the next one.
