### PR TITLE
feat(cli): add login and logout commands

### DIFF
--- a/.git-heads-pin.txt
+++ b/.git-heads-pin.txt
@@ -1,0 +1,5 @@
+feat/login-watcher d2ab36b3c6d14e4d2cb123f69fba891a855931dd
+feat/login-command 244a047f95f6394804e1e1218bed174f56269364
+feat/login-autoload c5fdb9e9702ea2cb17ed817a72021ae62293f152
+feat/login-add-preflight 409bbeadb65421746de776223b19f853a9065fc0
+feat/login-balance 46db162b7b9f2001c83d3239472f586e3ccc4032

--- a/.git-heads-pin.txt
+++ b/.git-heads-pin.txt
@@ -1,5 +1,0 @@
-feat/login-watcher d2ab36b3c6d14e4d2cb123f69fba891a855931dd
-feat/login-command 244a047f95f6394804e1e1218bed174f56269364
-feat/login-autoload c5fdb9e9702ea2cb17ed817a72021ae62293f152
-feat/login-add-preflight 409bbeadb65421746de776223b19f853a9065fc0
-feat/login-balance 46db162b7b9f2001c83d3239472f586e3ccc4032

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ npm install -g filecoin-pin
 
 ```bash
 # 0. Set up authentication (choose one):
+#    Log in:        filecoin-pin login
+#                   Generates a session key for this machine and opens the Filecoin
+#                   Cloud console, where you approve it with your wallet. Saved under
+#                   the data directory (see "Default Data Directories"); `logout` removes it.
 #    Private key:   export PRIVATE_KEY=0x...
 #                   (or pass --private-key <key> to each command)
 #    Session key:   export WALLET_ADDRESS=0x... SESSION_KEY=0x...
@@ -268,6 +272,16 @@ filecoin-pin add myfile.txt
 * `--credentials-file <path>`: Load credentials (e.g. `SESSION_KEY`, `WALLET_ADDRESS`) from a dotenv-style file before other options are resolved, e.g. a downloaded credentials file. Never overrides a variable already set in the environment.
 
 Other arguments are possible for individual commands, use `--help` to find out more.
+
+### Login
+
+`filecoin-pin login` pairs this machine with a wallet without exporting a private key. It generates a session key, saves it to `session.env` in the data directory before anything else happens, prints and opens a Filecoin Cloud console link, and waits up to five minutes for the wallet owner to approve the key there. It ends with a readiness scorecard for uploads (key authorized, storage service approved, USDFC deposited) and a pre-filled console link when funding is still needed.
+
+* `--scopes <ids>`: scopes to request (default: `createDataSet,addPieces`). See [Session-Key Permissions](#session-key-permissions) for what each command needs.
+* `--fresh`: generate a new key instead of resuming the saved one.
+* Exit codes: `0` when every requested scope was granted, `2` when the wait timed out or the owner granted fewer scopes (rerun `login` to resume with the same key), `1` on an error.
+
+`filecoin-pin logout` deletes the saved session file. The on-chain grant expires on its own; the console can revoke it early.
 
 ### Session-Key Permissions
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Other arguments are possible for individual commands, use `--help` to find out m
 
 ### Login
 
-`filecoin-pin login` pairs this machine with a wallet without exporting a private key. It generates a session key, saves it to `session.env` in the data directory (owner-readable only) before anything else happens, prints a Filecoin Cloud console link on its own line, opens it in a browser on a terminal, and waits up to five minutes for the wallet owner to approve the key there. It ends with a readiness scorecard for uploads (key authorized, storage service approved, USDFC deposited) and a pre-filled console link when funding is still needed.
+`filecoin-pin login` pairs this machine with a wallet without exporting a private key. It generates a session key, saves it to `session.env` in the data directory (owner-readable only) before anything else happens, prints a Filecoin Cloud console link, opens it in a browser on a terminal, and waits up to five minutes for the wallet owner to approve the key there. It ends with a readiness scorecard for uploads (key authorized, storage service approved, USDFC deposited) and a pre-filled console link when funding is still needed.
 
 A grant lives on one chain, so the file records the network (`mainnet` or `calibration`); resuming it under another `--network` is refused. `login` works only on those two networks, which are the ones the console serves. On devnet or a custom RPC, use `session create` with the wallet key. If `PRIVATE_KEY`, `SESSION_KEY`, or `VIEW_ADDRESS` is set in the shell, `login` warns that it will take precedence over the saved key.
 

--- a/README.md
+++ b/README.md
@@ -191,15 +191,14 @@ npm install -g filecoin-pin
 #                   (or pass --private-key <key> to each command)
 #    Session key:   export WALLET_ADDRESS=0x... SESSION_KEY=0x...
 #                   WALLET_ADDRESS is the owner wallet address; SESSION_KEY is the
-#                   session key PRIVATE key (not the session address), as printed by
-#                   `filecoin-pin session create` or `filecoin-pin session generate`
+#                   session key PRIVATE key (not the session address), e.g. from a
+#                   file downloaded from the console's Session keys page
 #                   (or pass --wallet-address <addr> --session-key <private-key> to each command)
 #                   Or load both from a downloaded file: filecoin-pin add --credentials-file <path>
-#    Revoke later:  filecoin-pin session revoke <session-address>
-#    Scoped keys:   session create/authorize/revoke take --scopes <ids> to grant or
-#                   revoke a subset (default: all). Ids: createDataSet, addPieces,
+#    Advanced:      `filecoin-pin session create|authorize|revoke|generate` manage session
+#                   keys with the wallet private key (no browser). --scopes <ids> picks a
+#                   subset (default: all). Ids: createDataSet, addPieces,
 #                   schedulePieceRemovals, terminateService.
-#                   E.g. --scopes createDataSet,addPieces or --scopes schedulePieceRemovals.
 
 # 1. Configure payment permissions (one-time setup)
 filecoin-pin payments setup --auto
@@ -275,13 +274,18 @@ Other arguments are possible for individual commands, use `--help` to find out m
 
 ### Login
 
-`filecoin-pin login` pairs this machine with a wallet without exporting a private key. It generates a session key, saves it to `session.env` in the data directory before anything else happens, prints and opens a Filecoin Cloud console link, and waits up to five minutes for the wallet owner to approve the key there. It ends with a readiness scorecard for uploads (key authorized, storage service approved, USDFC deposited) and a pre-filled console link when funding is still needed.
+`filecoin-pin login` pairs this machine with a wallet without exporting a private key. It generates a session key, saves it to `session.env` in the data directory (owner-readable only) before anything else happens, prints a Filecoin Cloud console link on its own line, opens it in a browser on a terminal, and waits up to five minutes for the wallet owner to approve the key there. It ends with a readiness scorecard for uploads (key authorized, storage service approved, USDFC deposited) and a pre-filled console link when funding is still needed.
+
+A grant lives on one chain, so the file records the network (`mainnet` or `calibration`); resuming it under another `--network` is refused. `login` works only on those two networks, which are the ones the console serves. On devnet or a custom RPC, use `session create` with the wallet key. If `PRIVATE_KEY`, `SESSION_KEY`, or `VIEW_ADDRESS` is set in the shell, `login` warns that it will take precedence over the saved key.
 
 * `--scopes <ids>`: scopes to request (default: `createDataSet,addPieces`). See [Session-Key Permissions](#session-key-permissions) for what each command needs.
-* `--fresh`: generate a new key instead of resuming the saved one.
-* Exit codes: `0` when every requested scope was granted, `2` when the wait timed out or the owner granted fewer scopes (rerun `login` to resume with the same key), `1` on an error.
+* `--fresh`: generate a new key instead of resuming the saved one. A replaced key stays authorized on chain until it expires; revoke it on the console's Session keys page.
+* `--no-browser`: print the link only. `BROWSER=none` does the same for every command.
+* `--no-wait`: print the link, keep the key, and exit `2` without waiting. Rerun `login` after approving to check the grant.
+* `--timeout <seconds>`: how long to wait for the grant (default: 300).
+* Exit codes: `0` when the key can upload (every requested scope, or at least `createDataSet` and `addPieces`), `2` when the wait timed out, `--no-wait` skipped it, or the owner granted too few scopes (rerun `login` to resume with the same key), `1` on an error.
 
-`filecoin-pin logout` deletes the saved session file. The on-chain grant expires on its own; the console can revoke it early.
+`filecoin-pin logout` deletes the saved session file and prints the session address it removed. This is local only: the on-chain grant expires on its own, or revoke it early on the console's Session keys page or with `filecoin-pin session revoke <session-address>` and the wallet key.
 
 ### Session-Key Permissions
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ A grant lives on one chain, so the file records the network (`mainnet` or `calib
 * `--no-browser`: print the link only. `BROWSER=none` does the same for every command.
 * `--no-wait`: print the link, keep the key, and exit `2` without waiting. Rerun `login` after approving to check the grant.
 * `--timeout <seconds>`: how long to wait for the grant (default: 300).
-* Exit codes: `0` when the key can upload (every requested scope, or at least `createDataSet` and `addPieces`), `2` when the wait timed out, `--no-wait` skipped it, or the owner granted too few scopes (rerun `login` to resume with the same key), `1` on an error.
+* Exit codes: `0` when every requested scope was granted, `2` when the wait timed out, `--no-wait` skipped it, or the owner granted fewer scopes than requested (rerun `login` to resume with the same key, or `login --scopes` with only what you need), `1` on an error.
 
 `filecoin-pin logout` deletes the saved session file and prints the session address it removed. This is local only: the on-chain grant expires on its own, or revoke it early on the console's Session keys page or with `filecoin-pin session revoke <session-address>` and the wallet key.
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,6 +2,7 @@ import type { Command } from 'commander'
 import { addCommand } from './add.js'
 import { dataSetCommand } from './data-set.js'
 import { importCommand } from './import.js'
+import { loginCommand, logoutCommand } from './login.js'
 import { paymentsCommand } from './payments.js'
 import { providerCommand } from './provider.js'
 import { removeCommand } from './remove.js'
@@ -12,6 +13,8 @@ export {
   addCommand,
   dataSetCommand,
   importCommand,
+  loginCommand,
+  logoutCommand,
   paymentsCommand,
   providerCommand,
   removeCommand,
@@ -26,6 +29,7 @@ interface CliCommandGroup {
 
 /** Every top-level CLI command, grouped and ordered for help output. */
 export const CLI_COMMAND_GROUPS: readonly CliCommandGroup[] = [
+  { heading: 'ACCOUNT', commands: [loginCommand, logoutCommand] },
   { heading: 'UPLOAD', commands: [addCommand, importCommand] },
   { heading: 'PAYMENTS', commands: [paymentsCommand] },
   { heading: 'MANAGEMENT', commands: [dataSetCommand, providerCommand, removeCommand] },

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,0 +1,32 @@
+/**
+ * Commander wiring for `login` and `logout`.
+ *
+ * `login` pairs this machine with a wallet through the Filecoin Cloud
+ * console: it generates a scoped session key, the owner approves it in the
+ * browser, and the CLI waits for the grant on-chain. `logout` forgets the
+ * saved key.
+ */
+
+import { Command } from 'commander'
+import { runLogin, runLogout } from '../login/index.js'
+import { addNetworkOptions, rpcUrlOption, scopesOption } from '../utils/cli-options.js'
+
+export const loginCommand = new Command('login')
+  .description('Log in to your Filecoin account: approve a session key for this machine in the Filecoin Cloud console')
+  .addOption(scopesOption('Comma-separated scopes to request (default: createDataSet,addPieces)'))
+  .option('--fresh', 'Generate a new session key instead of resuming the saved one')
+  .action(async (options) => {
+    try {
+      process.exitCode = await runLogin(options)
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`)
+      process.exitCode = 1
+    }
+  })
+addNetworkOptions(loginCommand).addOption(rpcUrlOption('RPC endpoint'))
+
+export const logoutCommand = new Command('logout')
+  .description('Log out: delete the saved session key from this machine')
+  .action(() => {
+    runLogout()
+  })

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -7,14 +7,48 @@
  * saved key.
  */
 
-import { Command } from 'commander'
+import { Command, InvalidArgumentError } from 'commander'
+import pc from 'picocolors'
 import { runLogin, runLogout } from '../login/index.js'
 import { addNetworkOptions, rpcUrlOption, scopesOption } from '../utils/cli-options.js'
+
+function parseTimeoutSeconds(value: string): number {
+  const seconds = Number(value)
+  if (!Number.isInteger(seconds) || seconds <= 0) throw new InvalidArgumentError('Expected a whole number of seconds.')
+  return seconds
+}
 
 export const loginCommand = new Command('login')
   .description('Log in to your Filecoin account: approve a session key for this machine in the Filecoin Cloud console')
   .addOption(scopesOption('Comma-separated scopes to request (default: createDataSet,addPieces)'))
   .option('--fresh', 'Generate a new session key instead of resuming the saved one')
+  .option('--no-browser', 'Print the console link without opening a browser')
+  .option('--no-wait', 'Print the console link and exit 2 instead of waiting for the grant; rerun login to check')
+  .option('--timeout <seconds>', 'How long to wait for the grant (default: 300)', parseTimeoutSeconds)
+  .addHelpText(
+    'after',
+    `
+${pc.bold('EXAMPLES')}
+  $ filecoin-pin login
+  $ filecoin-pin login --network calibration
+  $ filecoin-pin login --scopes createDataSet,addPieces,schedulePieceRemovals
+  $ filecoin-pin login --no-browser --no-wait     # print the link, approve later, rerun to check
+
+${pc.bold('FILES')}
+  The session key is saved to session.env in the data directory before the
+  browser opens (owner-readable only), so an interrupted login resumes the
+  same key. \`filecoin-pin logout\` deletes it.
+
+${pc.bold('ENVIRONMENT')}
+  CONSOLE_URL   Filecoin Cloud console base URL (default: https://pay.filecoin.cloud)
+  BROWSER=none  never open a browser
+  NETWORK, RPC_URL  as --network and --rpc-url
+
+${pc.bold('EXIT CODES')}
+  0  the key can upload (createDataSet and addPieces granted, or every requested scope)
+  2  no grant seen in time, --no-wait, or fewer scopes than needed (rerun login to resume)
+  1  error, including a network the console has no pairing page for`
+  )
   .action(async (options) => {
     try {
       process.exitCode = await runLogin(options)
@@ -26,7 +60,9 @@ export const loginCommand = new Command('login')
 addNetworkOptions(loginCommand).addOption(rpcUrlOption('RPC endpoint'))
 
 export const logoutCommand = new Command('logout')
-  .description('Log out: delete the saved session key from this machine')
+  .description(
+    'Log out: delete the saved session key from this machine (local only; the on-chain grant stays until it expires)'
+  )
   .action(() => {
     runLogout()
   })

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -45,8 +45,8 @@ ${pc.bold('ENVIRONMENT')}
   NETWORK, RPC_URL  as --network and --rpc-url
 
 ${pc.bold('EXIT CODES')}
-  0  the key can upload (createDataSet and addPieces granted, or every requested scope)
-  2  no grant seen in time, --no-wait, or fewer scopes than needed (rerun login to resume)
+  0  every requested scope was granted
+  2  no grant seen in time, --no-wait, or fewer scopes than requested (rerun login to resume)
   1  error, including a network the console has no pairing page for`
   )
   .action(async (options) => {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -64,5 +64,10 @@ export const logoutCommand = new Command('logout')
     'Log out: delete the saved session key from this machine (local only; the on-chain grant stays until it expires)'
   )
   .action(() => {
-    runLogout()
+    try {
+      runLogout()
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : String(error)}`)
+      process.exitCode = 1
+    }
   })

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -9,7 +9,9 @@ import { Command } from 'commander'
 import { runSessionAuthorize, runSessionCreate, runSessionGenerate, runSessionRevoke } from '../session/index.js'
 import { addOwnerAuthOptions, scopesOption, sessionKeyOption } from '../utils/cli-options.js'
 
-export const sessionCommand = new Command('session').description('Manage session keys for delegated upload access')
+export const sessionCommand = new Command('session').description(
+  'Owner-signed session key management (advanced; needs the wallet private key). On an interactive machine, use `login` instead'
+)
 
 // session create — single-party: owner generates (or reuses) a session key and
 // authorizes it on-chain.

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,10 @@ function resolveChain(network: string | undefined, hasExplicitRpcUrl: boolean): 
   if (normalized === 'devnet' && !hasExplicitRpcUrl) return resolveDevnetConfig().chain
   return undefined
 }
+/** Per-user data directory: pinning-server state and the saved login session live here. */
+export function getDataDirectory(): string {
+  return envPaths('filecoin-pin', { suffix: '' }).data
+}
 
 /**
  * Create configuration from environment variables
@@ -26,7 +30,7 @@ function resolveChain(network: string | undefined, hasExplicitRpcUrl: boolean): 
  * - NETWORK: Filecoin network name (mainnet, calibration, devnet) — used if RPC_URL not set
  */
 export function createConfig(): Config {
-  const dataDir = envPaths('filecoin-pin', { suffix: '' }).data
+  const dataDir = getDataDirectory()
 
   // NETWORK and RPC_URL are mutually exclusive. The CLI enforces this via Commander, but library
   // consumers calling createConfig() bypass that check, so guard explicitly here as well.

--- a/src/core/session/console-url.ts
+++ b/src/core/session/console-url.ts
@@ -39,8 +39,29 @@ export function buildAuthorizeUrl(
   scopeIds: string[],
   chainId: number
 ): string {
-  const base = consoleUrl.endsWith('/') ? consoleUrl.slice(0, -1) : consoleUrl
+  const base = trimSlash(consoleUrl)
   const network = CONSOLE_NETWORK_SLUG[chainId]
   const networkParam = network ? `&network=${network}` : ''
   return `${base}/console/session-keys?authorize=${sessionAddress.toLowerCase()}&scopes=${scopeIds.join(',')}${networkParam}`
+}
+
+/** Deposit the CLI suggests when the account has no funds yet, in whole USDFC. */
+export const DEFAULT_SUGGESTED_DEPOSIT_USDFC = 2
+
+function trimSlash(consoleUrl: string): string {
+  return consoleUrl.endsWith('/') ? consoleUrl.slice(0, -1) : consoleUrl
+}
+
+/** The console home (billing) page. */
+export function buildConsoleUrl(consoleUrl: string): string {
+  return `${trimSlash(consoleUrl)}/console`
+}
+
+/**
+ * Funding deep link: the console pre-fills a deposit-and-approve dialog
+ * for the storage service with `deposit` whole USDFC, so topping up and
+ * approving the service is one wallet transaction.
+ */
+export function buildFundingUrl(consoleUrl: string, depositUsdfc: number): string {
+  return `${trimSlash(consoleUrl)}/console?deposit=${depositUsdfc}&operator=fwss`
 }

--- a/src/core/session/console-url.ts
+++ b/src/core/session/console-url.ts
@@ -40,9 +40,13 @@ export function buildAuthorizeUrl(
   chainId: number
 ): string {
   const base = trimSlash(consoleUrl)
+  return `${base}/console/session-keys?authorize=${sessionAddress.toLowerCase()}&scopes=${scopeIds.join(',')}${networkParam(chainId)}`
+}
+
+/** `&network=<slug>` for a chain the console knows, empty otherwise: the console refuses a link it cannot place. */
+function networkParam(chainId: number): string {
   const network = CONSOLE_NETWORK_SLUG[chainId]
-  const networkParam = network ? `&network=${network}` : ''
-  return `${base}/console/session-keys?authorize=${sessionAddress.toLowerCase()}&scopes=${scopeIds.join(',')}${networkParam}`
+  return network ? `&network=${network}` : ''
 }
 
 /** Deposit the CLI suggests when the account has no funds yet, in whole USDFC. */
@@ -60,8 +64,9 @@ export function buildConsoleUrl(consoleUrl: string): string {
 /**
  * Funding deep link: the console pre-fills a deposit-and-approve dialog
  * for the storage service with `deposit` whole USDFC, so topping up and
- * approving the service is one wallet transaction.
+ * approving the service is one wallet transaction. Carries the network so
+ * the console refuses to prefill a deposit for a wallet on another chain.
  */
-export function buildFundingUrl(consoleUrl: string, depositUsdfc: number): string {
-  return `${trimSlash(consoleUrl)}/console?deposit=${depositUsdfc}&operator=fwss`
+export function buildFundingUrl(consoleUrl: string, depositUsdfc: number, chainId: number): string {
+  return `${trimSlash(consoleUrl)}/console?deposit=${depositUsdfc}&operator=fwss${networkParam(chainId)}`
 }

--- a/src/core/session/console-url.ts
+++ b/src/core/session/console-url.ts
@@ -21,6 +21,11 @@ const CONSOLE_NETWORK_SLUG: Record<number, string> = {
   314159: 'calibration',
 }
 
+/** The console's name for a chain, or undefined when the console has no page for it (devnet, custom RPC). */
+export function consoleNetworkSlug(chainId: number): string | undefined {
+  return CONSOLE_NETWORK_SLUG[chainId]
+}
+
 /**
  * Build the console deep link that pre-fills the session address and the
  * scopes it needs on the session-keys authorization page. Carries the

--- a/src/login/format.ts
+++ b/src/login/format.ts
@@ -1,0 +1,19 @@
+/** Display helpers shared by the login commands. */
+
+/** `0x5929…c41a`: the first four and last four hex digits. */
+export function shortAddress(address: string): string {
+  return `${address.slice(0, 6)}…${address.slice(-4)}`
+}
+
+/** `2026-09-26` from unix seconds. */
+export function formatExpiryDate(epochSeconds: bigint): string {
+  return new Date(Number(epochSeconds) * 1000).toISOString().slice(0, 10)
+}
+
+/** `4:37` from milliseconds remaining. */
+export function formatCountdown(remainingMs: number): string {
+  const totalSeconds = Math.max(0, Math.ceil(remainingMs / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+}

--- a/src/login/index.ts
+++ b/src/login/index.ts
@@ -1,0 +1,13 @@
+export { formatCountdown, formatExpiryDate, shortAddress } from './format.js'
+export { type AccountReadiness, checkAccountReadiness, formatReadinessLines } from './readiness.js'
+export { runLogin } from './run-login.js'
+export { runLogout } from './run-logout.js'
+export {
+  deleteSessionFile,
+  getSessionFilePath,
+  readSessionFile,
+  type SavedSession,
+  SESSION_FILE_NAME,
+  writeSessionFile,
+} from './session-file.js'
+export type { LoginOptions } from './types.js'

--- a/src/login/open-browser.ts
+++ b/src/login/open-browser.ts
@@ -1,0 +1,36 @@
+/**
+ * Open a URL in the user's default browser, best effort.
+ *
+ * Only attempted on an interactive terminal: an agent or a CI job gets the
+ * printed URL and nothing else. Failures are swallowed because the URL is
+ * always printed first and the flow continues without the browser.
+ */
+
+import { spawn } from 'node:child_process'
+import { platform } from 'node:os'
+import { isTTY } from '../utils/cli-logger.js'
+
+function openerFor(url: string): { command: string; args: string[] } {
+  switch (platform()) {
+    case 'darwin':
+      return { command: 'open', args: [url] }
+    case 'win32':
+      return { command: 'cmd', args: ['/c', 'start', '', url] }
+    default:
+      return { command: 'xdg-open', args: [url] }
+  }
+}
+
+/** Returns true when a browser launch was attempted. */
+export function openBrowser(url: string): boolean {
+  if (!isTTY()) return false
+  const { command, args } = openerFor(url)
+  try {
+    const child = spawn(command, args, { detached: true, stdio: 'ignore' })
+    child.on('error', () => undefined)
+    child.unref()
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/login/open-browser.ts
+++ b/src/login/open-browser.ts
@@ -15,7 +15,9 @@ function openerFor(url: string): { command: string; args: string[] } {
     case 'darwin':
       return { command: 'open', args: [url] }
     case 'win32':
-      return { command: 'cmd', args: ['/c', 'start', '', url] }
+      // Not `cmd /c start`: cmd.exe reads `&` in the query string as a
+      // command separator. rundll32 gets the URL as one plain argument.
+      return { command: 'rundll32', args: ['url.dll,FileProtocolHandler', url] }
     default:
       return { command: 'xdg-open', args: [url] }
   }

--- a/src/login/open-browser.ts
+++ b/src/login/open-browser.ts
@@ -1,8 +1,8 @@
 /**
  * Open a URL in the user's default browser, best effort.
  *
- * Only attempted on an interactive terminal: an agent or a CI job gets the
- * printed URL and nothing else. Failures are swallowed because the URL is
+ * Only attempted on an interactive terminal, and never when `BROWSER=none`:
+ * an agent or a CI job gets the printed URL and nothing else. Failures are swallowed because the URL is
  * always printed first and the flow continues without the browser.
  */
 
@@ -25,7 +25,7 @@ function openerFor(url: string): { command: string; args: string[] } {
 
 /** Returns true when a browser launch was attempted. */
 export function openBrowser(url: string): boolean {
-  if (!isTTY()) return false
+  if (!isTTY() || process.env.BROWSER === 'none') return false
   const { command, args } = openerFor(url)
   try {
     const child = spawn(command, args, { detached: true, stdio: 'ignore' })

--- a/src/login/open-browser.ts
+++ b/src/login/open-browser.ts
@@ -23,12 +23,24 @@ function openerFor(url: string): { command: string; args: string[] } {
   }
 }
 
+/** Credentials that must not ride along into the browser's environment. */
+const SECRET_ENV_VARS = ['PRIVATE_KEY', 'SESSION_KEY', 'WALLET_ADDRESS', 'VIEW_ADDRESS'] as const
+
+/** The current environment without any credential, for child processes. */
+export function environmentWithoutSecrets(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const copy = { ...env }
+  for (const name of SECRET_ENV_VARS) delete copy[name]
+  return copy
+}
+
 /** Returns true when a browser launch was attempted. */
 export function openBrowser(url: string): boolean {
   if (!isTTY() || process.env.BROWSER === 'none') return false
   const { command, args } = openerFor(url)
   try {
-    const child = spawn(command, args, { detached: true, stdio: 'ignore' })
+    // xdg-open and friends hand the environment to the browser; a session
+    // key auto-loaded into process.env must not travel with it.
+    const child = spawn(command, args, { detached: true, stdio: 'ignore', env: environmentWithoutSecrets() })
     child.on('error', () => undefined)
     child.unref()
     return true

--- a/src/login/readiness.ts
+++ b/src/login/readiness.ts
@@ -1,0 +1,42 @@
+/**
+ * Account readiness for uploads: the three-line scorecard `login` ends
+ * with and `add` prints when it refuses an unfunded upload.
+ *
+ * Copy rule (PRD section 5): plain words only. The storage service is
+ * "approved" or "not approved yet"; the deposit is a USDFC amount.
+ */
+
+import type { Synapse } from '@filoz/synapse-sdk'
+import pc from 'picocolors'
+import { checkAllowances, getDepositedBalance } from '../core/payments/index.js'
+import { formatUSDFC } from '../core/utils/format.js'
+
+export interface AccountReadiness {
+  /** The storage service holds a usable approval on the owner's Filecoin Cloud balance. */
+  serviceApproved: boolean
+  /** USDFC deposited into Filecoin Cloud, in wei-scale units. */
+  depositUsdfc: bigint
+}
+
+/** Read the readiness of `synapse`'s account (owner address) for uploads. */
+export async function checkAccountReadiness(synapse: Synapse): Promise<AccountReadiness> {
+  const [allowances, depositUsdfc] = await Promise.all([checkAllowances(synapse), getDepositedBalance(synapse)])
+  return { serviceApproved: !allowances.needsUpdate, depositUsdfc }
+}
+
+const OK = pc.green('✓')
+const NO = pc.red('✗')
+
+/**
+ * The scorecard lines, indented for printing under a heading. The session
+ * line is always the first; the caller says whether the key is authorized.
+ */
+export function formatReadinessLines(readiness: AccountReadiness, sessionAuthorized: boolean): string[] {
+  const lines = [
+    sessionAuthorized ? `${OK} session key authorized` : `${NO} session key not authorized`,
+    readiness.serviceApproved ? `${OK} storage service approved` : `${NO} storage service not approved yet`,
+  ]
+  const deposit = `USDFC deposit — ${formatUSDFC(readiness.depositUsdfc)}`
+  lines.push(readiness.depositUsdfc > 0n ? `${OK} ${deposit}` : `${NO} ${deposit}`)
+  return lines.map((line) => `    ${line}`)
+}

--- a/src/login/readiness.ts
+++ b/src/login/readiness.ts
@@ -36,7 +36,7 @@ export function formatReadinessLines(readiness: AccountReadiness, sessionAuthori
     sessionAuthorized ? `${OK} session key authorized` : `${NO} session key not authorized`,
     readiness.serviceApproved ? `${OK} storage service approved` : `${NO} storage service not approved yet`,
   ]
-  const deposit = `USDFC deposit — ${formatUSDFC(readiness.depositUsdfc)}`
+  const deposit = `USDFC deposit — ${formatUSDFC(readiness.depositUsdfc, 2)}`
   lines.push(readiness.depositUsdfc > 0n ? `${OK} ${deposit}` : `${NO} ${deposit}`)
   return lines.map((line) => `    ${line}`)
 }

--- a/src/login/readiness.ts
+++ b/src/login/readiness.ts
@@ -2,8 +2,9 @@
  * Account readiness for uploads: the three-line scorecard `login` ends
  * with and `add` prints when it refuses an unfunded upload.
  *
- * Copy rule (PRD section 5): plain words only. The storage service is
- * "approved" or "not approved yet"; the deposit is a USDFC amount.
+ * Copy rule: plain words only. The storage service is "approved" or "not
+ * approved yet"; the deposit is a USDFC amount. No contract or operator
+ * vocabulary, since the reader may never have seen the console.
  */
 
 import type { Synapse } from '@filoz/synapse-sdk'

--- a/src/login/run-login.ts
+++ b/src/login/run-login.ts
@@ -125,10 +125,7 @@ export async function runLogin(options: LoginOptions): Promise<number> {
   if (registryAddress === undefined) {
     throw new Error(`No session key registry is configured for chain id ${chain.id}`)
   }
-  const consoleUrl = resolveConsoleUrl(chain.id)
-  if (consoleUrl === undefined) {
-    throw new Error(`No Filecoin Cloud console is known for chain id ${chain.id}. Set CONSOLE_URL to use one.`)
-  }
+  const consoleUrl = resolveConsoleUrl()
 
   const path = getSessionFilePath()
   const { session, resumed } = loadOrCreateSession(options.fresh, path)

--- a/src/login/run-login.ts
+++ b/src/login/run-login.ts
@@ -30,7 +30,11 @@ import {
   resolveConsoleUrl,
 } from '../core/session/console-url.js'
 import { generateSessionKeypair } from '../core/session/create-session-key.js'
-import { type WatchAuthorizationResult, watchAuthorization } from '../core/session/watch-authorization.js'
+import {
+  DEFAULT_WATCH_DEADLINE_MS,
+  type WatchAuthorizationResult,
+  watchAuthorization,
+} from '../core/session/watch-authorization.js'
 import { initializeSynapse } from '../core/synapse/index.js'
 import { resolveNetwork } from '../session/resolve-network.js'
 import { parseScopes, SCOPE_IDS, SCOPE_PERMISSIONS } from '../session/scopes.js'
@@ -67,7 +71,11 @@ function loadOrCreateSession(fresh: boolean | undefined, path: string): { sessio
 /** Print the requested-versus-granted diff and the exit code for a shortfall. */
 function reportPartialGrant(requested: readonly Permission[], result: WatchAuthorizationResult): void {
   const granted = new Set(result.granted)
-  log.line(`${pc.yellow('⚠')} Authorized with fewer scopes than requested`)
+  log.line(
+    result.granted.length === 0
+      ? `${pc.yellow('⚠')} Authorized with none of the requested scopes`
+      : `${pc.yellow('⚠')} Authorized with fewer scopes than requested`
+  )
   log.line(`  Requested:  ${scopeList(requested)}`)
   log.line(
     `  Granted:    ${requested
@@ -139,14 +147,16 @@ export async function runLogin(options: LoginOptions): Promise<number> {
   const spinner = createSpinner()
   const waitLine = (remainingMs: number) =>
     `Waiting for on-chain authorization… ${formatCountdown(remainingMs)} remaining (Ctrl-C safe; rerun \`login\` to resume)`
-  if (!isTTY()) log.line(`  ${waitLine(watchDeadlineMs())}`)
-  spinner.start(waitLine(watchDeadlineMs()))
+  // Registered before the spinner starts: clack installs its own SIGINT
+  // handler in start(), and the first listener to call process.exit wins.
   const onSigint = () => {
     spinner.stop(`${pc.yellow('⚠')} Login paused. Your key is saved; rerun \`filecoin-pin login\` to resume.`)
     log.flush()
     process.exit(EXIT_CODE_INCOMPLETE)
   }
   process.once('SIGINT', onSigint)
+  if (!isTTY()) log.line(`  ${waitLine(DEFAULT_WATCH_DEADLINE_MS)}`)
+  spinner.start(waitLine(DEFAULT_WATCH_DEADLINE_MS))
   let result: WatchAuthorizationResult
   try {
     result = await watchAuthorization({
@@ -156,8 +166,9 @@ export async function runLogin(options: LoginOptions): Promise<number> {
       permissions,
       fromBlock,
       ...(session.walletAddress !== undefined ? { owner: session.walletAddress } : {}),
-      deadlineMs: watchDeadlineMs(),
-      onTick: (remainingMs) => spinner.message(waitLine(remainingMs)),
+      onProgress: (event) => {
+        if (event.type === 'watch:tick') spinner.message(waitLine(event.data.remainingMs))
+      },
     })
   } finally {
     process.off('SIGINT', onSigint)
@@ -180,13 +191,13 @@ export async function runLogin(options: LoginOptions): Promise<number> {
     reportPartialGrant(permissions, result)
   }
 
-  await reportReadiness(result.owner, chain, consoleUrl)
+  // Funding never blocks login: a failed readiness read is reported, not fatal.
+  try {
+    await reportReadiness(result.owner, chain, consoleUrl)
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    log.line(`${pc.yellow('⚠')} Could not read account readiness: ${reason}. Run \`filecoin-pin balance\` to check.`)
+  }
   log.flush()
   return result.status === 'granted' ? 0 : EXIT_CODE_INCOMPLETE
-}
-
-/** Deadline for the wait; `FILECOIN_PIN_LOGIN_TIMEOUT_MS` shortens it in tests. */
-function watchDeadlineMs(): number {
-  const override = Number(process.env.FILECOIN_PIN_LOGIN_TIMEOUT_MS)
-  return Number.isFinite(override) && override > 0 ? override : 5 * 60 * 1000
 }

--- a/src/login/run-login.ts
+++ b/src/login/run-login.ts
@@ -18,7 +18,7 @@ import {
   type Permission,
   PermissionNames,
 } from '@filoz/synapse-core/session-key'
-import type { Chain } from '@filoz/synapse-sdk'
+import type { FilecoinChain } from '@filoz/synapse-sdk'
 import pc from 'picocolors'
 import { type Address, createPublicClient } from 'viem'
 import { getBlockNumber } from 'viem/actions'
@@ -94,7 +94,12 @@ function reportPartialGrant(requested: readonly Permission[], result: WatchAutho
 }
 
 /** Print the readiness scorecard for `owner` and the funding link when something is missing. */
-async function reportReadiness(owner: Address, chain: Chain, rpcUrl: string, consoleUrl: string): Promise<void> {
+async function reportReadiness(
+  owner: Address,
+  chain: FilecoinChain,
+  rpcUrl: string,
+  consoleUrl: string
+): Promise<void> {
   const synapse = await initializeSynapse({ walletAddress: owner, readOnly: true, chain, rpcUrl })
   const readiness = await checkAccountReadiness(synapse)
   log.line('')

--- a/src/login/run-login.ts
+++ b/src/login/run-login.ts
@@ -1,0 +1,192 @@
+/**
+ * Action handler for `filecoin-pin login`.
+ *
+ * Generates (or resumes) a session key, saves it before anything else
+ * happens, prints and opens the console link where the wallet owner
+ * approves the key, waits for the grant on-chain, then prints the granted
+ * scopes and the account readiness scorecard. PRD section 6 is the spec
+ * for every line printed here.
+ *
+ * Exit codes: 0 when every requested scope was granted, 2 when the wait
+ * timed out or the owner granted fewer scopes (rerun resumes the same
+ * key), 1 on an error.
+ */
+
+import {
+  AddPiecesPermission,
+  CreateDataSetPermission,
+  type Permission,
+  PermissionNames,
+} from '@filoz/synapse-core/session-key'
+import type { Chain } from '@filoz/synapse-sdk'
+import pc from 'picocolors'
+import { type Address, createPublicClient } from 'viem'
+import { getBlockNumber } from 'viem/actions'
+import { EXIT_CODE_INCOMPLETE } from '../common/cli-errors.js'
+import {
+  buildAuthorizeUrl,
+  buildFundingUrl,
+  DEFAULT_SUGGESTED_DEPOSIT_USDFC,
+  resolveConsoleUrl,
+} from '../core/session/console-url.js'
+import { generateSessionKeypair } from '../core/session/create-session-key.js'
+import { type WatchAuthorizationResult, watchAuthorization } from '../core/session/watch-authorization.js'
+import { initializeSynapse } from '../core/synapse/index.js'
+import { resolveNetwork } from '../session/resolve-network.js'
+import { parseScopes, SCOPE_IDS, SCOPE_PERMISSIONS } from '../session/scopes.js'
+import { createSpinner } from '../utils/cli-helpers.js'
+import { isTTY, log } from '../utils/cli-logger.js'
+import { formatCountdown, formatExpiryDate, shortAddress } from './format.js'
+import { openBrowser } from './open-browser.js'
+import { checkAccountReadiness, formatReadinessLines } from './readiness.js'
+import { getSessionFilePath, readSessionFile, type SavedSession, writeSessionFile } from './session-file.js'
+import type { LoginOptions } from './types.js'
+
+const DEFAULT_LOGIN_PERMISSIONS: Permission[] = [CreateDataSetPermission, AddPiecesPermission]
+
+/** Scope id (camelCase, as used in `--scopes` and console URLs) for a permission. */
+function scopeIdOf(permission: Permission): string {
+  const id = SCOPE_IDS.find((candidate) => SCOPE_PERMISSIONS[candidate] === permission)
+  return id ?? PermissionNames[permission] ?? permission
+}
+
+function scopeList(permissions: readonly Permission[]): string {
+  return permissions.map(scopeIdOf).join(', ')
+}
+
+/** Resume the saved key unless `--fresh`; otherwise generate and save a new one. */
+function loadOrCreateSession(fresh: boolean | undefined, path: string): { session: SavedSession; resumed: boolean } {
+  const saved = fresh ? undefined : readSessionFile(path)
+  if (saved !== undefined) return { session: saved, resumed: true }
+  const keypair = generateSessionKeypair()
+  const session: SavedSession = { sessionKey: keypair.privateKey, sessionAddress: keypair.address }
+  writeSessionFile(session, path)
+  return { session, resumed: false }
+}
+
+/** Print the requested-versus-granted diff and the exit code for a shortfall. */
+function reportPartialGrant(requested: readonly Permission[], result: WatchAuthorizationResult): void {
+  const granted = new Set(result.granted)
+  log.line(`${pc.yellow('⚠')} Authorized with fewer scopes than requested`)
+  log.line(`  Requested:  ${scopeList(requested)}`)
+  log.line(
+    `  Granted:    ${requested
+      .map((p) =>
+        granted.has(p) ? `${scopeIdOf(p)} ${pc.green('✓')}` : `${scopeIdOf(p)} ${pc.red('✗')} (owner declined)`
+      )
+      .join('   ')}`
+  )
+  const canUpload = granted.has(CreateDataSetPermission) && granted.has(AddPiecesPermission)
+  const missingIds = result.missing.map(scopeIdOf).join(', ')
+  log.line(
+    canUpload
+      ? `  Uploads will work. Commands needing ${missingIds} will fail until the owner grants them.`
+      : `  Commands needing ${missingIds} will fail until the owner grants them.`
+  )
+}
+
+/** Print the readiness scorecard for `owner` and the funding link when something is missing. */
+async function reportReadiness(owner: Address, chain: Chain, consoleUrl: string): Promise<void> {
+  const synapse = await initializeSynapse({ walletAddress: owner, readOnly: true, chain })
+  const readiness = await checkAccountReadiness(synapse)
+  log.line('')
+  log.line('  Account readiness for uploads:')
+  for (const line of formatReadinessLines(readiness, true)) log.line(line)
+  if (!readiness.serviceApproved || readiness.depositUsdfc === 0n) {
+    log.line('')
+    log.line('  One step fixes both (deposit & approve is a single transaction):')
+    log.line(`  ${pc.cyan(pc.underline(buildFundingUrl(consoleUrl, DEFAULT_SUGGESTED_DEPOSIT_USDFC)))}`)
+  }
+  log.line('')
+  log.line(pc.gray('  check anytime: filecoin-pin balance · top up: filecoin-pin dashboard'))
+}
+
+/**
+ * Run `login`. Returns the process exit code rather than calling
+ * `process.exit`, so the command wrapper stays in charge of flushing.
+ */
+export async function runLogin(options: LoginOptions): Promise<number> {
+  const permissions = options.scopes !== undefined ? parseScopes(options.scopes).permissions : DEFAULT_LOGIN_PERMISSIONS
+  const { chain, transport } = await resolveNetwork(options)
+  const registryAddress = chain.contracts.sessionKeyRegistry?.address
+  if (registryAddress === undefined) {
+    throw new Error(`No session key registry is configured for chain id ${chain.id}`)
+  }
+  const consoleUrl = resolveConsoleUrl(chain.id)
+  if (consoleUrl === undefined) {
+    throw new Error(`No Filecoin Cloud console is known for chain id ${chain.id}. Set CONSOLE_URL to use one.`)
+  }
+
+  const path = getSessionFilePath()
+  const { session, resumed } = loadOrCreateSession(options.fresh, path)
+  const short = shortAddress(session.sessionAddress)
+  log.line(`${pc.green('✓')} ${resumed ? 'Resuming session key' : 'Session key generated'}: ${short}`)
+  log.line(`${pc.green('✓')} Saved to ${path} (saved BEFORE the browser opens — safe to re-run)`)
+  const scopeNote = options.scopes === undefined ? ' (defaults — override with --scopes)' : ''
+  log.line(`  Requesting scopes: ${scopeList(permissions)}${scopeNote}`)
+  log.line('')
+
+  const client = createPublicClient({ chain, transport })
+  const fromBlock = await getBlockNumber(client)
+  const scopeIds = permissions.map(scopeIdOf)
+  const url = buildAuthorizeUrl(consoleUrl, session.sessionAddress, scopeIds, chain.id)
+  log.line('  Approve this key with your wallet in the Filecoin Cloud console:')
+  log.line(`  ${pc.cyan(pc.underline(url))}`)
+  log.line('')
+  log.flush()
+  openBrowser(url)
+
+  const spinner = createSpinner()
+  const waitLine = (remainingMs: number) =>
+    `Waiting for on-chain authorization… ${formatCountdown(remainingMs)} remaining (Ctrl-C safe; rerun \`login\` to resume)`
+  if (!isTTY()) log.line(`  ${waitLine(watchDeadlineMs())}`)
+  spinner.start(waitLine(watchDeadlineMs()))
+  const onSigint = () => {
+    spinner.stop(`${pc.yellow('⚠')} Login paused. Your key is saved; rerun \`filecoin-pin login\` to resume.`)
+    log.flush()
+    process.exit(EXIT_CODE_INCOMPLETE)
+  }
+  process.once('SIGINT', onSigint)
+  let result: WatchAuthorizationResult
+  try {
+    result = await watchAuthorization({
+      client,
+      sessionAddress: session.sessionAddress,
+      registryAddress,
+      permissions,
+      fromBlock,
+      ...(session.walletAddress !== undefined ? { owner: session.walletAddress } : {}),
+      deadlineMs: watchDeadlineMs(),
+      onTick: (remainingMs) => spinner.message(waitLine(remainingMs)),
+    })
+  } finally {
+    process.off('SIGINT', onSigint)
+  }
+
+  if (result.status === 'timeout' || result.owner === undefined) {
+    spinner.stop(
+      `${pc.yellow('⚠')} No authorization seen in time. Your key is saved; rerun \`filecoin-pin login\` to resume.`
+    )
+    log.flush()
+    return EXIT_CODE_INCOMPLETE
+  }
+
+  writeSessionFile({ ...session, walletAddress: result.owner }, path)
+  const expires = result.expiry !== undefined ? ` · expires ${formatExpiryDate(result.expiry)}` : ''
+  if (result.status === 'granted') {
+    spinner.stop(`${pc.green('✓')} Authorized! Granted: ${scopeList(result.granted)}${expires}`)
+  } else {
+    spinner.stop('')
+    reportPartialGrant(permissions, result)
+  }
+
+  await reportReadiness(result.owner, chain, consoleUrl)
+  log.flush()
+  return result.status === 'granted' ? 0 : EXIT_CODE_INCOMPLETE
+}
+
+/** Deadline for the wait; `FILECOIN_PIN_LOGIN_TIMEOUT_MS` shortens it in tests. */
+function watchDeadlineMs(): number {
+  const override = Number(process.env.FILECOIN_PIN_LOGIN_TIMEOUT_MS)
+  return Number.isFinite(override) && override > 0 ? override : 5 * 60 * 1000
+}

--- a/src/login/run-login.ts
+++ b/src/login/run-login.ts
@@ -108,7 +108,7 @@ async function reportReadiness(
   if (!readiness.serviceApproved || readiness.depositUsdfc === 0n) {
     log.line('')
     log.line('  One step fixes both (deposit & approve is a single transaction):')
-    log.line(`  ${pc.cyan(pc.underline(buildFundingUrl(consoleUrl, DEFAULT_SUGGESTED_DEPOSIT_USDFC)))}`)
+    log.line(`  ${pc.cyan(pc.underline(buildFundingUrl(consoleUrl, DEFAULT_SUGGESTED_DEPOSIT_USDFC, chain.id)))}`)
   }
   log.line('')
   log.line(pc.gray('  check anytime: filecoin-pin balance · top up: filecoin-pin dashboard'))

--- a/src/login/run-login.ts
+++ b/src/login/run-login.ts
@@ -94,8 +94,8 @@ function reportPartialGrant(requested: readonly Permission[], result: WatchAutho
 }
 
 /** Print the readiness scorecard for `owner` and the funding link when something is missing. */
-async function reportReadiness(owner: Address, chain: Chain, consoleUrl: string): Promise<void> {
-  const synapse = await initializeSynapse({ walletAddress: owner, readOnly: true, chain })
+async function reportReadiness(owner: Address, chain: Chain, rpcUrl: string, consoleUrl: string): Promise<void> {
+  const synapse = await initializeSynapse({ walletAddress: owner, readOnly: true, chain, rpcUrl })
   const readiness = await checkAccountReadiness(synapse)
   log.line('')
   log.line('  Account readiness for uploads:')
@@ -115,7 +115,7 @@ async function reportReadiness(owner: Address, chain: Chain, consoleUrl: string)
  */
 export async function runLogin(options: LoginOptions): Promise<number> {
   const permissions = options.scopes !== undefined ? parseScopes(options.scopes).permissions : DEFAULT_LOGIN_PERMISSIONS
-  const { chain, transport } = await resolveNetwork(options)
+  const { chain, transport, rpcUrl } = await resolveNetwork(options)
   const registryAddress = chain.contracts.sessionKeyRegistry?.address
   if (registryAddress === undefined) {
     throw new Error(`No session key registry is configured for chain id ${chain.id}`)
@@ -193,7 +193,7 @@ export async function runLogin(options: LoginOptions): Promise<number> {
 
   // Funding never blocks login: a failed readiness read is reported, not fatal.
   try {
-    await reportReadiness(result.owner, chain, consoleUrl)
+    await reportReadiness(result.owner, chain, rpcUrl, consoleUrl)
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error)
     log.line(`${pc.yellow('⚠')} Could not read account readiness: ${reason}. Run \`filecoin-pin balance\` to check.`)

--- a/src/login/run-login.ts
+++ b/src/login/run-login.ts
@@ -7,8 +7,9 @@
  * scopes and the account readiness scorecard. PRD section 6 is the spec
  * for every line printed here.
  *
- * Exit codes: 0 when every requested scope was granted, 2 when the wait
- * timed out or the owner granted fewer scopes (rerun resumes the same
+ * Exit codes: 0 when the key can upload (every requested scope, or at least
+ * createDataSet and addPieces), 2 when the wait timed out, `--no-wait`
+ * skipped it, or the owner granted too few scopes (rerun resumes the same
  * key), 1 on an error.
  */
 
@@ -26,6 +27,7 @@ import { EXIT_CODE_INCOMPLETE } from '../common/cli-errors.js'
 import {
   buildAuthorizeUrl,
   buildFundingUrl,
+  consoleNetworkSlug,
   DEFAULT_SUGGESTED_DEPOSIT_USDFC,
   resolveConsoleUrl,
 } from '../core/session/console-url.js'
@@ -58,14 +60,41 @@ function scopeList(permissions: readonly Permission[]): string {
   return permissions.map(scopeIdOf).join(', ')
 }
 
-/** Resume the saved key unless `--fresh`; otherwise generate and save a new one. */
-function loadOrCreateSession(fresh: boolean | undefined, path: string): { session: SavedSession; resumed: boolean } {
-  const saved = fresh ? undefined : readSessionFile(path)
-  if (saved !== undefined) return { session: saved, resumed: true }
+/** Credentials in the shell that would shadow the saved login for every later command. */
+const SHADOWING_ENV_VARS = ['PRIVATE_KEY', 'SESSION_KEY', 'VIEW_ADDRESS'] as const
+
+interface LoadedSession {
+  session: SavedSession
+  resumed: boolean
+  /** A previously authorized key that `--fresh` is replacing; it stays live on chain. */
+  replaced?: SavedSession
+}
+
+/**
+ * Resume the saved key unless `--fresh`; otherwise generate and save a new
+ * one for `network`. A saved key made for another network is refused: its
+ * grant lives on that chain, so resuming it here could never succeed.
+ */
+function loadOrCreateSession(fresh: boolean | undefined, network: string, path: string): LoadedSession {
+  const saved = readSessionFile(path)
+  if (saved !== undefined && !fresh) {
+    if (saved.network !== undefined && saved.network !== network) {
+      throw new Error(
+        `The saved login is for ${saved.network}, not ${network}. Pass --network ${saved.network} to resume it, or --fresh to replace it.`
+      )
+    }
+    return { session: saved.network === undefined ? { ...saved, network } : saved, resumed: true }
+  }
   const keypair = generateSessionKeypair()
-  const session: SavedSession = { sessionKey: keypair.privateKey, sessionAddress: keypair.address }
+  const session: SavedSession = { sessionKey: keypair.privateKey, sessionAddress: keypair.address, network }
   writeSessionFile(session, path)
-  return { session, resumed: false }
+  return saved?.walletAddress !== undefined ? { session, resumed: false, replaced: saved } : { session, resumed: false }
+}
+
+/** Exit 0 when the key can upload: everything asked for, or at least the two upload scopes. */
+function canUploadWith(requested: readonly Permission[], granted: readonly Permission[]): boolean {
+  const have = new Set(granted)
+  return requested.every((p) => have.has(p)) || (have.has(CreateDataSetPermission) && have.has(AddPiecesPermission))
 }
 
 /** Print the requested-versus-granted diff and the exit code for a shortfall. */
@@ -108,7 +137,7 @@ async function reportReadiness(
   if (!readiness.serviceApproved || readiness.depositUsdfc === 0n) {
     log.line('')
     log.line('  One step fixes both (deposit & approve is a single transaction):')
-    log.line(`  ${pc.cyan(pc.underline(buildFundingUrl(consoleUrl, DEFAULT_SUGGESTED_DEPOSIT_USDFC, chain.id)))}`)
+    log.line(buildFundingUrl(consoleUrl, DEFAULT_SUGGESTED_DEPOSIT_USDFC, chain.id))
   }
   log.line('')
   log.line(pc.gray('  check anytime: filecoin-pin balance · top up: filecoin-pin dashboard'))
@@ -125,13 +154,31 @@ export async function runLogin(options: LoginOptions): Promise<number> {
   if (registryAddress === undefined) {
     throw new Error(`No session key registry is configured for chain id ${chain.id}`)
   }
+  const network = consoleNetworkSlug(chain.id)
+  if (network === undefined) {
+    throw new Error(
+      `The Filecoin Cloud console has no pairing page for chain id ${chain.id}. login works on mainnet and calibration; on other networks use \`filecoin-pin session create\` with the wallet key.`
+    )
+  }
   const consoleUrl = resolveConsoleUrl()
 
   const path = getSessionFilePath()
-  const { session, resumed } = loadOrCreateSession(options.fresh, path)
+  const { session, resumed, replaced } = loadOrCreateSession(options.fresh, network, path)
   const short = shortAddress(session.sessionAddress)
-  log.line(`${pc.green('✓')} ${resumed ? 'Resuming session key' : 'Session key generated'}: ${short}`)
-  log.line(`${pc.green('✓')} Saved to ${path} (saved BEFORE the browser opens — safe to re-run)`)
+  log.line(`${pc.green('✓')} ${resumed ? 'Resuming session key' : 'Session key generated'}: ${short} (${network})`)
+  log.line(`${pc.green('✓')} Saved to ${path} (owner-readable only, saved BEFORE the browser opens — safe to re-run)`)
+  if (replaced !== undefined) {
+    log.line(
+      `${pc.yellow('⚠')} Replaced ${shortAddress(replaced.sessionAddress)}, which stays authorized on chain until it expires. Revoke it early on the console's Session keys page.`
+    )
+  }
+  for (const name of SHADOWING_ENV_VARS) {
+    if (process.env[name] !== undefined && process.env[name] !== '') {
+      log.line(
+        `${pc.yellow('⚠')} ${name} is set in this shell and takes precedence over the saved login. Unset it to use this session key.`
+      )
+    }
+  }
   const scopeNote = options.scopes === undefined ? ' (defaults — override with --scopes)' : ''
   log.line(`  Requesting scopes: ${scopeList(permissions)}${scopeNote}`)
   log.line('')
@@ -141,11 +188,21 @@ export async function runLogin(options: LoginOptions): Promise<number> {
   const scopeIds = permissions.map(scopeIdOf)
   const url = buildAuthorizeUrl(consoleUrl, session.sessionAddress, scopeIds, chain.id)
   log.line('  Approve this key with your wallet in the Filecoin Cloud console:')
-  log.line(`  ${pc.cyan(pc.underline(url))}`)
+  // The link on its own line, unstyled, so it copies and parses cleanly.
+  log.line(url)
   log.line('')
   log.flush()
-  openBrowser(url)
+  if (options.browser !== false) openBrowser(url)
 
+  if (options.wait === false) {
+    log.line(
+      `${pc.yellow('⚠')} Not waiting for the grant. Approve the key, then rerun \`filecoin-pin login\` to check it.`
+    )
+    log.flush()
+    return EXIT_CODE_INCOMPLETE
+  }
+
+  const deadlineMs = options.timeout !== undefined ? options.timeout * 1000 : DEFAULT_WATCH_DEADLINE_MS
   const spinner = createSpinner()
   const waitLine = (remainingMs: number) =>
     `Waiting for on-chain authorization… ${formatCountdown(remainingMs)} remaining (Ctrl-C safe; rerun \`login\` to resume)`
@@ -157,8 +214,8 @@ export async function runLogin(options: LoginOptions): Promise<number> {
     process.exit(EXIT_CODE_INCOMPLETE)
   }
   process.once('SIGINT', onSigint)
-  if (!isTTY()) log.line(`  ${waitLine(DEFAULT_WATCH_DEADLINE_MS)}`)
-  spinner.start(waitLine(DEFAULT_WATCH_DEADLINE_MS))
+  if (!isTTY()) log.line(`  ${waitLine(deadlineMs)}`)
+  spinner.start(waitLine(deadlineMs))
   let result: WatchAuthorizationResult
   try {
     result = await watchAuthorization({
@@ -167,6 +224,7 @@ export async function runLogin(options: LoginOptions): Promise<number> {
       registryAddress,
       permissions,
       fromBlock,
+      deadlineMs,
       ...(session.walletAddress !== undefined ? { owner: session.walletAddress } : {}),
       onProgress: (event) => {
         if (event.type === 'watch:tick') spinner.message(waitLine(event.data.remainingMs))
@@ -201,5 +259,5 @@ export async function runLogin(options: LoginOptions): Promise<number> {
     log.line(`${pc.yellow('⚠')} Could not read account readiness: ${reason}. Run \`filecoin-pin balance\` to check.`)
   }
   log.flush()
-  return result.status === 'granted' ? 0 : EXIT_CODE_INCOMPLETE
+  return canUploadWith(permissions, result.granted) ? 0 : EXIT_CODE_INCOMPLETE
 }

--- a/src/login/run-login.ts
+++ b/src/login/run-login.ts
@@ -4,8 +4,9 @@
  * Generates (or resumes) a session key, saves it before anything else
  * happens, prints and opens the console link where the wallet owner
  * approves the key, waits for the grant on-chain, then prints the granted
- * scopes and the account readiness scorecard. PRD section 6 is the spec
- * for every line printed here.
+ * scopes and the account readiness scorecard. Every printed line is part
+ * of the interface: scripts read this output as well as people, so change
+ * wording together with the tests that pin it.
  *
  * Exit codes: 0 when the key can upload (every requested scope, or at least
  * createDataSet and addPieces), 2 when the wait timed out, `--no-wait`

--- a/src/login/run-login.ts
+++ b/src/login/run-login.ts
@@ -92,10 +92,14 @@ function loadOrCreateSession(fresh: boolean | undefined, network: string, path: 
   return saved?.walletAddress !== undefined ? { session, resumed: false, replaced: saved } : { session, resumed: false }
 }
 
-/** Exit 0 when the key can upload: everything asked for, or at least the two upload scopes. */
-function canUploadWith(requested: readonly Permission[], granted: readonly Permission[]): boolean {
+/**
+ * Exit 0 only when every requested scope was granted. The caller asked for a
+ * set; a scope the owner declined is a shortfall for whatever that caller
+ * meant to run, so the exit code says so and the printed diff names it.
+ */
+function grantedEveryRequested(requested: readonly Permission[], granted: readonly Permission[]): boolean {
   const have = new Set(granted)
-  return requested.every((p) => have.has(p)) || (have.has(CreateDataSetPermission) && have.has(AddPiecesPermission))
+  return requested.every((p) => have.has(p))
 }
 
 /** Print the requested-versus-granted diff and the exit code for a shortfall. */
@@ -121,6 +125,7 @@ function reportPartialGrant(requested: readonly Permission[], result: WatchAutho
       ? `  Uploads will work. Commands needing ${missingIds} will fail until the owner grants them.`
       : `  Commands needing ${missingIds} will fail until the owner grants them.`
   )
+  log.line(`  Rerun \`filecoin-pin login\` to ask again, or \`login --scopes\` with only the scopes you need.`)
 }
 
 /** Print the readiness scorecard for `owner` and the funding link when something is missing. */
@@ -268,5 +273,5 @@ export async function runLogin(options: LoginOptions): Promise<number> {
     log.line(`${pc.yellow('⚠')} Could not read account readiness: ${reason}. Run \`filecoin-pin balance\` to check.`)
   }
   log.flush()
-  return canUploadWith(permissions, result.granted) ? 0 : EXIT_CODE_INCOMPLETE
+  return grantedEveryRequested(permissions, result.granted) ? 0 : EXIT_CODE_INCOMPLETE
 }

--- a/src/login/run-login.ts
+++ b/src/login/run-login.ts
@@ -146,7 +146,9 @@ async function reportReadiness(
 
 /**
  * Run `login`. Returns the process exit code rather than calling
- * `process.exit`, so the command wrapper stays in charge of flushing.
+ * `process.exit`, so the command wrapper stays in charge of flushing. The
+ * one exception is Ctrl-C during the wait: its handler stops the spinner
+ * and exits 2 itself, because the process is going down either way.
  */
 export async function runLogin(options: LoginOptions): Promise<number> {
   const permissions = options.scopes !== undefined ? parseScopes(options.scopes).permissions : DEFAULT_LOGIN_PERMISSIONS
@@ -184,8 +186,6 @@ export async function runLogin(options: LoginOptions): Promise<number> {
   log.line(`  Requesting scopes: ${scopeList(permissions)}${scopeNote}`)
   log.line('')
 
-  const client = createPublicClient({ chain, transport })
-  const fromBlock = await getBlockNumber(client)
   const scopeIds = permissions.map(scopeIdOf)
   const url = buildAuthorizeUrl(consoleUrl, session.sessionAddress, scopeIds, chain.id)
   log.line('  Approve this key with your wallet in the Filecoin Cloud console:')
@@ -203,6 +203,9 @@ export async function runLogin(options: LoginOptions): Promise<number> {
     return EXIT_CODE_INCOMPLETE
   }
 
+  // The link is already on screen: an RPC that is down here costs the wait, not the pairing.
+  const client = createPublicClient({ chain, transport })
+  const fromBlock = await getBlockNumber(client)
   const deadlineMs = options.timeout !== undefined ? options.timeout * 1000 : DEFAULT_WATCH_DEADLINE_MS
   const spinner = createSpinner()
   const waitLine = (remainingMs: number) =>
@@ -231,6 +234,11 @@ export async function runLogin(options: LoginOptions): Promise<number> {
         if (event.type === 'watch:tick') spinner.message(waitLine(event.data.remainingMs))
       },
     })
+  } catch (error) {
+    spinner.stop(
+      `${pc.red('✗')} Could not watch for the authorization. Your key is saved; rerun \`filecoin-pin login\` to resume.`
+    )
+    throw error
   } finally {
     process.off('SIGINT', onSigint)
   }

--- a/src/login/run-logout.ts
+++ b/src/login/run-logout.ts
@@ -1,0 +1,19 @@
+/**
+ * Action handler for `filecoin-pin logout`: deletes the saved session file.
+ * The on-chain grant expires on its own; the console can revoke it early.
+ */
+
+import pc from 'picocolors'
+import { log } from '../utils/cli-logger.js'
+import { deleteSessionFile, getSessionFilePath } from './session-file.js'
+
+export function runLogout(): void {
+  const path = getSessionFilePath()
+  if (deleteSessionFile(path)) {
+    log.line(`${pc.green('✓')} Logged out: removed ${path}`)
+  } else {
+    log.line(`${pc.gray('•')} Not logged in: no session file at ${path}`)
+  }
+  log.line(pc.gray('  The on-chain grant lapses on its own; revoke it early in the Filecoin Cloud console.'))
+  log.flush()
+}

--- a/src/login/run-logout.ts
+++ b/src/login/run-logout.ts
@@ -4,6 +4,7 @@
  */
 
 import pc from 'picocolors'
+import { buildConsoleUrl, resolveConsoleUrl } from '../core/session/console-url.js'
 import { log } from '../utils/cli-logger.js'
 import { deleteSessionFile, getSessionFilePath, readSessionFile } from './session-file.js'
 
@@ -17,9 +18,13 @@ export function runLogout(): void {
     log.line(`${pc.gray('•')} Not logged in: no session file at ${path}`)
   }
   if (session?.walletAddress !== undefined) {
-    log.line(`  The key stays authorized on chain for ${session.walletAddress} until it expires.`)
-    log.line(`  Revoke it early on the console's Session keys page, or with the wallet key:`)
-    log.line(`  filecoin-pin session revoke ${session.sessionAddress}`)
+    log.line(
+      `  The key stays authorized on chain for ${session.walletAddress} until it expires, unless it was revoked.`
+    )
+    log.line(`  Revoke it on the console's Session keys page:`)
+    // The link on its own line, unstyled, so it copies and parses cleanly.
+    log.line(`${buildConsoleUrl(resolveConsoleUrl())}/session-keys`)
+    log.line(`  or with the wallet key:  filecoin-pin session revoke ${session.sessionAddress}`)
   } else {
     log.line(pc.gray('  This only forgets the key on this machine; an on-chain grant lapses on its own.'))
   }

--- a/src/login/run-logout.ts
+++ b/src/login/run-logout.ts
@@ -5,15 +5,23 @@
 
 import pc from 'picocolors'
 import { log } from '../utils/cli-logger.js'
-import { deleteSessionFile, getSessionFilePath } from './session-file.js'
+import { deleteSessionFile, getSessionFilePath, readSessionFile } from './session-file.js'
 
 export function runLogout(): void {
   const path = getSessionFilePath()
+  const session = readSessionFile(path)
   if (deleteSessionFile(path)) {
-    log.line(`${pc.green('✓')} Logged out: removed ${path}`)
+    const key = session ? ` ${session.sessionAddress}` : ''
+    log.line(`${pc.green('✓')} Logged out: removed${key} from ${path}`)
   } else {
     log.line(`${pc.gray('•')} Not logged in: no session file at ${path}`)
   }
-  log.line(pc.gray('  The on-chain grant lapses on its own; revoke it early in the Filecoin Cloud console.'))
+  if (session?.walletAddress !== undefined) {
+    log.line(`  The key stays authorized on chain for ${session.walletAddress} until it expires.`)
+    log.line(`  Revoke it early on the console's Session keys page, or with the wallet key:`)
+    log.line(`  filecoin-pin session revoke ${session.sessionAddress}`)
+  } else {
+    log.line(pc.gray('  This only forgets the key on this machine; an on-chain grant lapses on its own.'))
+  }
   log.flush()
 }

--- a/src/login/session-file.ts
+++ b/src/login/session-file.ts
@@ -10,10 +10,11 @@
  * supply credentials (see `src/utils/credential-source.ts`).
  */
 
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { chmodSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import { parseEnv } from 'node:util'
 import type { Address, Hex } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
 import { getDataDirectory } from '../config.js'
 
 export const SESSION_FILE_NAME = 'session.env'
@@ -21,7 +22,7 @@ export const SESSION_FILE_NAME = 'session.env'
 export interface SavedSession {
   /** Session key private key. */
   sessionKey: Hex
-  /** Session key address, derived from the private key at save time. */
+  /** Session key address, derived from the private key. */
   sessionAddress: Address
   /** Owner wallet that authorized the key. Absent until the first grant is seen. */
   walletAddress?: Address
@@ -39,24 +40,34 @@ function isHex(value: string | undefined, bytes: number): value is Hex {
 /**
  * Read the saved session. Returns `undefined` when there is no file or it
  * holds no usable session key; a malformed file is treated as absent so a
- * stray edit cannot wedge every command.
+ * stray edit cannot wedge every command. The session address is derived
+ * from the key, never trusted from the file.
  */
 export function readSessionFile(path: string = getSessionFilePath()): SavedSession | undefined {
-  let contents: string
+  let parsed: ReturnType<typeof parseEnv>
   try {
-    contents = readFileSync(path, 'utf8')
+    parsed = parseEnv(readFileSync(path, 'utf8'))
   } catch {
     return undefined
   }
-  const parsed = parseEnv(contents)
   const sessionKey = parsed.SESSION_KEY
-  const sessionAddress = parsed.SESSION_ADDRESS
-  if (!isHex(sessionKey, 32) || !isHex(sessionAddress, 20)) return undefined
+  if (!isHex(sessionKey, 32)) return undefined
+  let sessionAddress: Address
+  try {
+    sessionAddress = privateKeyToAccount(sessionKey).address
+  } catch {
+    return undefined
+  }
   const walletAddress = parsed.WALLET_ADDRESS
   return isHex(walletAddress, 20) ? { sessionKey, sessionAddress, walletAddress } : { sessionKey, sessionAddress }
 }
 
-/** Write the session, replacing any previous file. Owner-readable only. */
+/**
+ * Write the session, replacing any previous file. Written to a sibling
+ * temp file and renamed into place, then set owner-readable only: Node
+ * applies `mode` only when creating a file, so a pre-existing permissive
+ * file would otherwise keep its permissions.
+ */
 export function writeSessionFile(session: SavedSession, path: string = getSessionFilePath()): void {
   const lines = [
     '# filecoin-pin login session. Delete with: filecoin-pin logout',
@@ -64,8 +75,11 @@ export function writeSessionFile(session: SavedSession, path: string = getSessio
     `SESSION_ADDRESS=${session.sessionAddress}`,
   ]
   if (session.walletAddress !== undefined) lines.push(`WALLET_ADDRESS=${session.walletAddress}`)
-  mkdirSync(join(path, '..'), { recursive: true })
-  writeFileSync(path, `${lines.join('\n')}\n`, { mode: 0o600 })
+  mkdirSync(dirname(path), { recursive: true })
+  const tmp = `${path}.${process.pid}.tmp`
+  writeFileSync(tmp, `${lines.join('\n')}\n`, { mode: 0o600 })
+  renameSync(tmp, path)
+  chmodSync(path, 0o600)
 }
 
 /** Delete the session file. Returns whether a file was removed. */

--- a/src/login/session-file.ts
+++ b/src/login/session-file.ts
@@ -10,7 +10,7 @@
  * supply credentials (see `src/utils/credential-source.ts`).
  */
 
-import { chmodSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { parseEnv } from 'node:util'
 import type { Address, Hex } from 'viem'
@@ -84,11 +84,7 @@ export function writeSessionFile(session: SavedSession, path: string = getSessio
 
 /** Delete the session file. Returns whether a file was removed. */
 export function deleteSessionFile(path: string = getSessionFilePath()): boolean {
-  try {
-    readFileSync(path)
-  } catch {
-    return false
-  }
+  if (!existsSync(path)) return false
   rmSync(path, { force: true })
   return true
 }

--- a/src/login/session-file.ts
+++ b/src/login/session-file.ts
@@ -1,0 +1,80 @@
+/**
+ * The saved login session: one dotenv-style file in the filecoin-pin data
+ * directory holding the session key and, once authorized, the owner
+ * wallet address. Exactly one credential set; every write replaces the
+ * whole file.
+ *
+ * `login` writes the key before the browser opens, so an interrupted login
+ * resumes the same key. The owner address is added once the grant is seen
+ * on-chain. Commands auto-load this file when neither flags nor env vars
+ * supply credentials (see `src/utils/credential-source.ts`).
+ */
+
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parseEnv } from 'node:util'
+import type { Address, Hex } from 'viem'
+import { getDataDirectory } from '../config.js'
+
+export const SESSION_FILE_NAME = 'session.env'
+
+export interface SavedSession {
+  /** Session key private key. */
+  sessionKey: Hex
+  /** Session key address, derived from the private key at save time. */
+  sessionAddress: Address
+  /** Owner wallet that authorized the key. Absent until the first grant is seen. */
+  walletAddress?: Address
+}
+
+/** Absolute path of the session file. */
+export function getSessionFilePath(dataDir: string = getDataDirectory()): string {
+  return join(dataDir, SESSION_FILE_NAME)
+}
+
+function isHex(value: string | undefined, bytes: number): value is Hex {
+  return value !== undefined && new RegExp(`^0x[0-9a-fA-F]{${bytes * 2}}$`).test(value)
+}
+
+/**
+ * Read the saved session. Returns `undefined` when there is no file or it
+ * holds no usable session key; a malformed file is treated as absent so a
+ * stray edit cannot wedge every command.
+ */
+export function readSessionFile(path: string = getSessionFilePath()): SavedSession | undefined {
+  let contents: string
+  try {
+    contents = readFileSync(path, 'utf8')
+  } catch {
+    return undefined
+  }
+  const parsed = parseEnv(contents)
+  const sessionKey = parsed.SESSION_KEY
+  const sessionAddress = parsed.SESSION_ADDRESS
+  if (!isHex(sessionKey, 32) || !isHex(sessionAddress, 20)) return undefined
+  const walletAddress = parsed.WALLET_ADDRESS
+  return isHex(walletAddress, 20) ? { sessionKey, sessionAddress, walletAddress } : { sessionKey, sessionAddress }
+}
+
+/** Write the session, replacing any previous file. Owner-readable only. */
+export function writeSessionFile(session: SavedSession, path: string = getSessionFilePath()): void {
+  const lines = [
+    '# filecoin-pin login session. Delete with: filecoin-pin logout',
+    `SESSION_KEY=${session.sessionKey}`,
+    `SESSION_ADDRESS=${session.sessionAddress}`,
+  ]
+  if (session.walletAddress !== undefined) lines.push(`WALLET_ADDRESS=${session.walletAddress}`)
+  mkdirSync(join(path, '..'), { recursive: true })
+  writeFileSync(path, `${lines.join('\n')}\n`, { mode: 0o600 })
+}
+
+/** Delete the session file. Returns whether a file was removed. */
+export function deleteSessionFile(path: string = getSessionFilePath()): boolean {
+  try {
+    readFileSync(path)
+  } catch {
+    return false
+  }
+  rmSync(path, { force: true })
+  return true
+}

--- a/src/login/session-file.ts
+++ b/src/login/session-file.ts
@@ -77,8 +77,12 @@ export function writeSessionFile(session: SavedSession, path: string = getSessio
   if (session.walletAddress !== undefined) lines.push(`WALLET_ADDRESS=${session.walletAddress}`)
   mkdirSync(dirname(path), { recursive: true })
   const tmp = `${path}.${process.pid}.tmp`
-  writeFileSync(tmp, `${lines.join('\n')}\n`, { mode: 0o600 })
-  renameSync(tmp, path)
+  try {
+    writeFileSync(tmp, `${lines.join('\n')}\n`, { mode: 0o600 })
+    renameSync(tmp, path)
+  } finally {
+    rmSync(tmp, { force: true })
+  }
   chmodSync(path, 0o600)
 }
 

--- a/src/login/session-file.ts
+++ b/src/login/session-file.ts
@@ -1,7 +1,7 @@
 /**
  * The saved login session: one dotenv-style file in the filecoin-pin data
- * directory holding the session key and, once authorized, the owner
- * wallet address. Exactly one credential set; every write replaces the
+ * directory holding the session key, the network it was made for and,
+ * once authorized, the owner wallet address. Exactly one credential set; every write replaces the
  * whole file.
  *
  * `login` writes the key before the browser opens, so an interrupted login
@@ -26,6 +26,8 @@ export interface SavedSession {
   sessionAddress: Address
   /** Owner wallet that authorized the key. Absent until the first grant is seen. */
   walletAddress?: Address
+  /** Console network the key was made for (mainnet, calibration). A grant lives on one chain. */
+  network?: string
 }
 
 /** Absolute path of the session file. */
@@ -58,8 +60,12 @@ export function readSessionFile(path: string = getSessionFilePath()): SavedSessi
   } catch {
     return undefined
   }
+  const session: SavedSession = { sessionKey, sessionAddress }
   const walletAddress = parsed.WALLET_ADDRESS
-  return isHex(walletAddress, 20) ? { sessionKey, sessionAddress, walletAddress } : { sessionKey, sessionAddress }
+  if (isHex(walletAddress, 20)) session.walletAddress = walletAddress
+  const network = parsed.NETWORK
+  if (network !== undefined && /^[a-z]+$/.test(network)) session.network = network
+  return session
 }
 
 /**
@@ -75,6 +81,7 @@ export function writeSessionFile(session: SavedSession, path: string = getSessio
     `SESSION_ADDRESS=${session.sessionAddress}`,
   ]
   if (session.walletAddress !== undefined) lines.push(`WALLET_ADDRESS=${session.walletAddress}`)
+  if (session.network !== undefined) lines.push(`NETWORK=${session.network}`)
   mkdirSync(dirname(path), { recursive: true })
   const tmp = `${path}.${process.pid}.tmp`
   try {

--- a/src/login/session-file.ts
+++ b/src/login/session-file.ts
@@ -1,8 +1,8 @@
 /**
  * The saved login session: one dotenv-style file in the filecoin-pin data
  * directory holding the session key, the network it was made for and,
- * once authorized, the owner wallet address. Exactly one credential set; every write replaces the
- * whole file.
+ * once authorized, the owner wallet address. Exactly one credential set;
+ * every write replaces the whole file.
  *
  * `login` writes the key before the browser opens, so an interrupted login
  * resumes the same key. The owner address is added once the grant is seen

--- a/src/login/session-file.ts
+++ b/src/login/session-file.ts
@@ -1,8 +1,8 @@
 /**
  * The saved login session: one dotenv-style file in the filecoin-pin data
- * directory holding the session key, the network it was made for and,
- * once authorized, the owner wallet address. Exactly one credential set;
- * every write replaces the whole file.
+ * directory holding the session key, its address, the network it was made
+ * for and, once authorized, the owner wallet address. Exactly one
+ * credential set; every write replaces the whole file.
  *
  * `login` writes the key before the browser opens, so an interrupted login
  * resumes the same key. The owner address is added once the grant is seen

--- a/src/login/types.ts
+++ b/src/login/types.ts
@@ -1,4 +1,4 @@
-/** CLI option shapes for `login` and `logout`. */
+/** CLI option shape for `login`. */
 
 export interface LoginOptions {
   network?: string | undefined
@@ -8,5 +8,3 @@ export interface LoginOptions {
   /** Generate a new key even when a saved one exists. */
   fresh?: boolean | undefined
 }
-
-export type LogoutOptions = Record<string, never>

--- a/src/login/types.ts
+++ b/src/login/types.ts
@@ -1,0 +1,12 @@
+/** CLI option shapes for `login` and `logout`. */
+
+export interface LoginOptions {
+  network?: string | undefined
+  rpcUrl?: string | undefined
+  /** Comma-separated scope ids; defaults to createDataSet,addPieces. */
+  scopes?: string | undefined
+  /** Generate a new key even when a saved one exists. */
+  fresh?: boolean | undefined
+}
+
+export type LogoutOptions = Record<string, never>

--- a/src/login/types.ts
+++ b/src/login/types.ts
@@ -7,4 +7,10 @@ export interface LoginOptions {
   scopes?: string | undefined
   /** Generate a new key even when a saved one exists. */
   fresh?: boolean | undefined
+  /** False (`--no-browser`) prints the link without opening it. */
+  browser?: boolean | undefined
+  /** False (`--no-wait`) exits right after printing the link instead of watching for the grant. */
+  wait?: boolean | undefined
+  /** Seconds to wait for the grant; defaults to five minutes. */
+  timeout?: number | undefined
 }

--- a/src/test/unit/console-url.test.ts
+++ b/src/test/unit/console-url.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { buildAuthorizeUrl, resolveConsoleUrl } from '../../core/session/console-url.js'
+import { buildAuthorizeUrl, buildFundingUrl, resolveConsoleUrl } from '../../core/session/console-url.js'
 
 const previousConsoleUrl = process.env.CONSOLE_URL
 
@@ -56,5 +56,14 @@ describe('buildAuthorizeUrl network param', () => {
 
   it('omits the param for an unknown chain id', () => {
     expect(buildAuthorizeUrl('https://pay.filecoin.cloud', '0xA', ['addPieces'], 1)).not.toMatch(/network=/)
+  })
+})
+
+describe('buildFundingUrl', () => {
+  it('names the deposit, the storage service, and the network', () => {
+    expect(buildFundingUrl('https://pay.filecoin.cloud/', 2, 314159)).toBe(
+      'https://pay.filecoin.cloud/console?deposit=2&operator=fwss&network=calibration'
+    )
+    expect(buildFundingUrl('https://pay.filecoin.cloud', 5, 314)).toMatch(/&network=mainnet$/)
   })
 })

--- a/src/test/unit/console-url.test.ts
+++ b/src/test/unit/console-url.test.ts
@@ -1,19 +1,23 @@
-import { afterEach, describe, expect, it } from 'vitest'
-import { buildAuthorizeUrl, buildFundingUrl, resolveConsoleUrl } from '../../core/session/console-url.js'
-
-const previousConsoleUrl = process.env.CONSOLE_URL
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildAuthorizeUrl,
+  buildFundingUrl,
+  DEFAULT_CONSOLE_URL,
+  resolveConsoleUrl,
+} from '../../core/session/console-url.js'
 
 afterEach(() => {
-  if (previousConsoleUrl == null) {
-    delete process.env.CONSOLE_URL
-  } else {
-    process.env.CONSOLE_URL = previousConsoleUrl
-  }
+  vi.unstubAllEnvs()
 })
 
 describe('resolveConsoleUrl', () => {
+  it('defaults to the production console', () => {
+    vi.stubEnv('CONSOLE_URL', undefined)
+    expect(resolveConsoleUrl()).toBe(DEFAULT_CONSOLE_URL)
+  })
+
   it('prefers CONSOLE_URL over the default', () => {
-    process.env.CONSOLE_URL = 'http://localhost:3005'
+    vi.stubEnv('CONSOLE_URL', 'http://localhost:3005')
     expect(resolveConsoleUrl()).toBe('http://localhost:3005')
   })
 })

--- a/src/test/unit/console-url.test.ts
+++ b/src/test/unit/console-url.test.ts
@@ -12,11 +12,6 @@ afterEach(() => {
 })
 
 describe('resolveConsoleUrl', () => {
-  it('defaults to the production console', () => {
-    delete process.env.CONSOLE_URL
-    expect(resolveConsoleUrl()).toBe('https://pay.filecoin.cloud')
-  })
-
   it('prefers CONSOLE_URL over the default', () => {
     process.env.CONSOLE_URL = 'http://localhost:3005'
     expect(resolveConsoleUrl()).toBe('http://localhost:3005')

--- a/src/test/unit/login-session-file.test.ts
+++ b/src/test/unit/login-session-file.test.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { formatCountdown, formatExpiryDate, shortAddress } from '../../login/format.js'
+import { deleteSessionFile, getSessionFilePath, readSessionFile, writeSessionFile } from '../../login/session-file.js'
+
+const KEY = `0x${'ab'.repeat(32)}` as const
+const SESSION = '0x00000000000000000000000000000000000000bb'
+const OWNER = '0x00000000000000000000000000000000000000aa'
+
+describe('session file', () => {
+  let dir: string
+  let path: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'login-session-'))
+    path = getSessionFilePath(dir)
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('lives in the data directory as session.env', () => {
+    expect(path).toBe(join(dir, 'session.env'))
+  })
+
+  it('reads back what it wrote, without an owner before authorization', () => {
+    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)
+    expect(readSessionFile(path)).toEqual({ sessionKey: KEY, sessionAddress: SESSION })
+  })
+
+  it('adds the owner on the second write and keeps exactly one credential set', () => {
+    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)
+    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION, walletAddress: OWNER }, path)
+    expect(readSessionFile(path)).toEqual({ sessionKey: KEY, sessionAddress: SESSION, walletAddress: OWNER })
+    expect(readFileSync(path, 'utf8').match(/SESSION_KEY=/g)).toHaveLength(1)
+  })
+
+  it('writes the file owner-readable only', () => {
+    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)
+    expect(statSync(path).mode & 0o777).toBe(0o600)
+  })
+
+  it('treats a missing or malformed file as no session', () => {
+    expect(readSessionFile(path)).toBeUndefined()
+    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)
+    writeFileSync(path, 'SESSION_KEY=not-a-key\n')
+    expect(readSessionFile(path)).toBeUndefined()
+  })
+
+  it('deleteSessionFile reports whether anything was removed', () => {
+    expect(deleteSessionFile(path)).toBe(false)
+    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)
+    expect(deleteSessionFile(path)).toBe(true)
+    expect(readSessionFile(path)).toBeUndefined()
+  })
+})
+
+describe('login format helpers', () => {
+  it('shortens addresses to 0x1234…abcd', () => {
+    expect(shortAddress('0x5929000000000000000000000000000000000c41a')).toBe('0x5929…c41a')
+  })
+
+  it('formats the expiry as a date', () => {
+    expect(formatExpiryDate(1790380800n)).toBe('2026-09-26')
+  })
+
+  it('formats the countdown as m:ss', () => {
+    expect(formatCountdown(277000)).toBe('4:37')
+    expect(formatCountdown(0)).toBe('0:00')
+    expect(formatCountdown(59500)).toBe('1:00')
+  })
+})

--- a/src/test/unit/login-session-file.test.ts
+++ b/src/test/unit/login-session-file.test.ts
@@ -39,7 +39,7 @@ describe('session file', () => {
     expect(readFileSync(path, 'utf8').match(/SESSION_KEY=/g)).toHaveLength(1)
   })
 
-  it('writes the file owner-readable only', () => {
+  it.skipIf(process.platform === 'win32')('writes the file owner-readable only', () => {
     writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)
     expect(statSync(path).mode & 0o777).toBe(0o600)
   })
@@ -59,7 +59,7 @@ describe('session file', () => {
     expect(readSessionFile(path)?.sessionAddress).toBe(SESSION)
   })
 
-  it('tightens permissions when rewriting a permissive existing file', () => {
+  it.skipIf(process.platform === 'win32')('tightens permissions when rewriting a permissive existing file', () => {
     writeFileSync(path, 'stale\n')
     chmodSync(path, 0o644)
     writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)

--- a/src/test/unit/login-session-file.test.ts
+++ b/src/test/unit/login-session-file.test.ts
@@ -1,12 +1,13 @@
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { privateKeyToAccount } from 'viem/accounts'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { formatCountdown, formatExpiryDate, shortAddress } from '../../login/format.js'
 import { deleteSessionFile, getSessionFilePath, readSessionFile, writeSessionFile } from '../../login/session-file.js'
 
 const KEY = `0x${'ab'.repeat(32)}` as const
-const SESSION = '0x00000000000000000000000000000000000000bb'
+const SESSION = privateKeyToAccount(KEY).address
 const OWNER = '0x00000000000000000000000000000000000000aa'
 
 describe('session file', () => {
@@ -45,9 +46,25 @@ describe('session file', () => {
 
   it('treats a missing or malformed file as no session', () => {
     expect(readSessionFile(path)).toBeUndefined()
-    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)
     writeFileSync(path, 'SESSION_KEY=not-a-key\n')
     expect(readSessionFile(path)).toBeUndefined()
+    writeFileSync(path, 'SESSION_KEY="unterminated\n=\n')
+    expect(readSessionFile(path)).toBeUndefined()
+    writeFileSync(path, `SESSION_KEY=0x${'0'.repeat(64)}\n`) // out of curve range
+    expect(readSessionFile(path)).toBeUndefined()
+  })
+
+  it('derives the session address from the key instead of trusting the file', () => {
+    writeFileSync(path, `SESSION_KEY=${KEY}\nSESSION_ADDRESS=0x00000000000000000000000000000000000000cc\n`)
+    expect(readSessionFile(path)?.sessionAddress).toBe(SESSION)
+  })
+
+  it('tightens permissions when rewriting a permissive existing file', () => {
+    writeFileSync(path, 'stale\n')
+    chmodSync(path, 0o644)
+    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)
+    expect(statSync(path).mode & 0o777).toBe(0o600)
+    expect(readSessionFile(path)?.sessionKey).toBe(KEY)
   })
 
   it('deleteSessionFile reports whether anything was removed', () => {

--- a/src/test/unit/login-session-file.test.ts
+++ b/src/test/unit/login-session-file.test.ts
@@ -23,10 +23,6 @@ describe('session file', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('lives in the data directory as session.env', () => {
-    expect(path).toBe(join(dir, 'session.env'))
-  })
-
   it('reads back what it wrote, without an owner before authorization', () => {
     writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)
     expect(readSessionFile(path)).toEqual({ sessionKey: KEY, sessionAddress: SESSION })

--- a/src/test/unit/login-session-file.test.ts
+++ b/src/test/unit/login-session-file.test.ts
@@ -44,6 +44,13 @@ describe('session file', () => {
     expect(statSync(path).mode & 0o777).toBe(0o600)
   })
 
+  it('keeps the network the key was made for', () => {
+    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION, network: 'calibration' }, path)
+    expect(readSessionFile(path)?.network).toBe('calibration')
+    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)
+    expect(readSessionFile(path)?.network).toBeUndefined()
+  })
+
   it('treats a missing or malformed file as no session', () => {
     expect(readSessionFile(path)).toBeUndefined()
     writeFileSync(path, 'SESSION_KEY=not-a-key\n')

--- a/src/test/unit/open-browser.test.ts
+++ b/src/test/unit/open-browser.test.ts
@@ -1,0 +1,39 @@
+import { spawn } from 'node:child_process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { environmentWithoutSecrets, openBrowser } from '../../login/open-browser.js'
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }))
+// A terminal is attached, so the BROWSER check is the only thing that can decline.
+vi.mock('../../utils/cli-logger.js', () => ({ isTTY: () => true }))
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.mocked(spawn).mockReset()
+})
+
+describe('environmentWithoutSecrets', () => {
+  it('drops every credential and keeps the rest', () => {
+    expect(environmentWithoutSecrets({ PRIVATE_KEY: 'x', SESSION_KEY: 'y', HOME: '/h' })).toEqual({ HOME: '/h' })
+  })
+})
+
+describe('openBrowser', () => {
+  it('returns false and never spawns when BROWSER=none', () => {
+    vi.stubEnv('BROWSER', 'none')
+
+    expect(openBrowser('https://console.test/console')).toBe(false)
+    expect(vi.mocked(spawn)).not.toHaveBeenCalled()
+  })
+
+  it('launches the opener without credentials in its environment', () => {
+    vi.stubEnv('BROWSER', undefined)
+    vi.stubEnv('SESSION_KEY', '0xsecret')
+    vi.mocked(spawn).mockReturnValue({ on: () => undefined, unref: () => undefined } as never)
+
+    expect(openBrowser('https://console.test/console')).toBe(true)
+
+    const [, args, options] = vi.mocked(spawn).mock.calls[0] as [string, string[], { env: NodeJS.ProcessEnv }]
+    expect(args).toContain('https://console.test/console')
+    expect(options.env).not.toHaveProperty('SESSION_KEY')
+  })
+})

--- a/src/test/unit/run-login.test.ts
+++ b/src/test/unit/run-login.test.ts
@@ -1,0 +1,166 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { AddPiecesPermission, CreateDataSetPermission } from '@filoz/synapse-core/session-key'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { loginCommand, logoutCommand } from '../../commands/login.js'
+import { watchAuthorization } from '../../core/session/watch-authorization.js'
+import { openBrowser } from '../../login/open-browser.js'
+import { checkAccountReadiness } from '../../login/readiness.js'
+import { runLogin } from '../../login/run-login.js'
+import { readSessionFile, writeSessionFile } from '../../login/session-file.js'
+import { log } from '../../utils/cli-logger.js'
+
+const OWNER = '0x00000000000000000000000000000000000000aa'
+const REGISTRY = '0x00000000000000000000000000000000000000dd'
+const FUTURE = 1790380800n
+
+let dataDir: string
+
+vi.mock('../../config.js', () => ({ getDataDirectory: () => dataDir }))
+vi.mock('../../core/session/watch-authorization.js', () => ({ watchAuthorization: vi.fn() }))
+vi.mock('../../login/open-browser.js', () => ({ openBrowser: vi.fn(() => false) }))
+vi.mock('../../login/readiness.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../login/readiness.js')>()
+  return { ...actual, checkAccountReadiness: vi.fn() }
+})
+vi.mock('../../core/synapse/index.js', () => ({ initializeSynapse: vi.fn(async () => ({})) }))
+vi.mock('../../session/resolve-network.js', () => ({
+  resolveNetwork: vi.fn(async () => ({
+    chain: { id: 314159, name: 'calibration', contracts: { sessionKeyRegistry: { address: REGISTRY } } },
+    rpcUrl: 'http://rpc.test',
+    transport: () => ({ request: vi.fn() }),
+  })),
+}))
+vi.mock('viem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem')>()
+  return { ...actual, createPublicClient: vi.fn(() => ({ request: vi.fn() })) }
+})
+vi.mock('viem/actions', () => ({ getBlockNumber: vi.fn(async () => 42n) }))
+
+function output(): string {
+  return vi
+    .mocked(log.line)
+    .mock.calls.map((call) => String(call[0]))
+    .join('\n')
+}
+
+describe('runLogin', () => {
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'login-run-'))
+    vi.spyOn(log, 'line').mockImplementation(() => undefined)
+    vi.spyOn(log, 'flush').mockImplementation(() => undefined)
+    vi.mocked(checkAccountReadiness).mockResolvedValue({ serviceApproved: false, depositUsdfc: 0n })
+    process.env.CONSOLE_URL = 'https://console.test'
+  })
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+    vi.mocked(watchAuthorization).mockReset()
+    delete process.env.CONSOLE_URL
+  })
+
+  it('saves the key before watching, prints the lowercase authorize link, and exits 0 on a full grant', async () => {
+    vi.mocked(watchAuthorization).mockImplementation(async (options) => {
+      // The file exists by the time the wait starts.
+      const saved = readSessionFile(join(dataDir, 'session.env'))
+      expect(saved?.sessionAddress).toBe(options.sessionAddress)
+      expect(saved?.walletAddress).toBeUndefined()
+      expect(options.fromBlock).toBe(42n)
+      expect(options.registryAddress).toBe(REGISTRY)
+      expect(options.permissions).toEqual([CreateDataSetPermission, AddPiecesPermission])
+      return {
+        status: 'granted',
+        owner: OWNER,
+        expiry: FUTURE,
+        granted: [CreateDataSetPermission, AddPiecesPermission],
+        missing: [],
+      }
+    })
+
+    const code = await runLogin({})
+
+    expect(code).toBe(0)
+    const saved = readSessionFile(join(dataDir, 'session.env'))
+    expect(saved?.walletAddress).toBe(OWNER)
+    const text = output()
+    expect(text).toContain('Session key generated')
+    expect(text).toContain('Requesting scopes: createDataSet, addPieces (defaults — override with --scopes)')
+    expect(text).toContain(
+      `https://console.test/console/session-keys?authorize=${saved?.sessionAddress.toLowerCase()}&scopes=createDataSet,addPieces&network=calibration`
+    )
+    expect(text).toContain('storage service not approved yet')
+    expect(text).toContain('USDFC deposit — 0.00')
+    expect(text).toContain('https://console.test/console?deposit=2&operator=fwss')
+    expect(text).not.toMatch(/FWSS operator|operator approval/i)
+    expect(vi.mocked(openBrowser)).toHaveBeenCalledOnce()
+  })
+
+  it('resumes the saved key and passes the known owner to the watcher', async () => {
+    const key = `0x${'11'.repeat(32)}` as const
+    const session = '0x00000000000000000000000000000000000000bb'
+    writeSessionFile({ sessionKey: key, sessionAddress: session, walletAddress: OWNER }, join(dataDir, 'session.env'))
+    vi.mocked(watchAuthorization).mockResolvedValue({ status: 'timeout', granted: [], missing: [] })
+
+    const code = await runLogin({})
+
+    expect(code).toBe(2)
+    expect(vi.mocked(watchAuthorization)).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionAddress: session, owner: OWNER })
+    )
+    expect(output()).toContain('Resuming session key')
+    expect(readSessionFile(join(dataDir, 'session.env'))?.sessionKey).toBe(key)
+  })
+
+  it('--fresh replaces the saved key', async () => {
+    const key = `0x${'11'.repeat(32)}` as const
+    writeSessionFile(
+      { sessionKey: key, sessionAddress: '0x00000000000000000000000000000000000000bb' },
+      join(dataDir, 'session.env')
+    )
+    vi.mocked(watchAuthorization).mockResolvedValue({ status: 'timeout', granted: [], missing: [] })
+
+    await runLogin({ fresh: true })
+
+    expect(readSessionFile(join(dataDir, 'session.env'))?.sessionKey).not.toBe(key)
+    expect(vi.mocked(watchAuthorization)).toHaveBeenCalledWith(expect.not.objectContaining({ owner: OWNER }))
+  })
+
+  it('reports a partial grant with the requested-versus-granted diff and exits 2', async () => {
+    vi.mocked(watchAuthorization).mockResolvedValue({
+      status: 'partial',
+      owner: OWNER,
+      expiry: FUTURE,
+      granted: [CreateDataSetPermission, AddPiecesPermission],
+      missing: ['0x5415701e313bb627e755b16924727217bb356574fe20e7061442c200b0822b22'],
+    })
+
+    const code = await runLogin({ scopes: 'createDataSet,addPieces,schedulePieceRemovals' })
+
+    expect(code).toBe(2)
+    const text = output()
+    expect(text).toContain('Authorized with fewer scopes than requested')
+    expect(text).toContain('Requested:  createDataSet, addPieces, schedulePieceRemovals')
+    expect(text).toContain('schedulePieceRemovals ✗ (owner declined)')
+    expect(text).toContain('Uploads will work.')
+  })
+
+  it('rejects an unknown scope before touching the network', async () => {
+    await expect(runLogin({ scopes: 'nope' })).rejects.toThrow(/Unknown scope "nope"/)
+    expect(vi.mocked(watchAuthorization)).not.toHaveBeenCalled()
+  })
+})
+
+describe('login command wiring', () => {
+  it('registers login with --scopes, --fresh, and network flags', () => {
+    const longs = loginCommand.options.map((o) => o.long)
+    expect(longs).toEqual(expect.arrayContaining(['--scopes', '--fresh', '--network', '--rpc-url']))
+    expect(loginCommand.options.some((o) => o.long === '--private-key')).toBe(false)
+  })
+
+  it('registers logout with no options', () => {
+    expect(logoutCommand.name()).toBe('logout')
+    expect(logoutCommand.options).toHaveLength(0)
+  })
+})

--- a/src/test/unit/run-login.test.ts
+++ b/src/test/unit/run-login.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { AddPiecesPermission, CreateDataSetPermission } from '@filoz/synapse-core/session-key'
+import { privateKeyToAccount } from 'viem/accounts'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { loginCommand, logoutCommand } from '../../commands/login.js'
 import { watchAuthorization } from '../../core/session/watch-authorization.js'
@@ -99,7 +100,7 @@ describe('runLogin', () => {
 
   it('resumes the saved key and passes the known owner to the watcher', async () => {
     const key = `0x${'11'.repeat(32)}` as const
-    const session = '0x00000000000000000000000000000000000000bb'
+    const session = privateKeyToAccount(key).address
     writeSessionFile({ sessionKey: key, sessionAddress: session, walletAddress: OWNER }, join(dataDir, 'session.env'))
     vi.mocked(watchAuthorization).mockResolvedValue({ status: 'timeout', granted: [], missing: [] })
 

--- a/src/test/unit/run-login.test.ts
+++ b/src/test/unit/run-login.test.ts
@@ -19,7 +19,10 @@ const FUTURE = 1790380800n
 let dataDir: string
 
 vi.mock('../../config.js', () => ({ getDataDirectory: () => dataDir }))
-vi.mock('../../core/session/watch-authorization.js', () => ({ watchAuthorization: vi.fn() }))
+vi.mock('../../core/session/watch-authorization.js', () => ({
+  watchAuthorization: vi.fn(),
+  DEFAULT_WATCH_DEADLINE_MS: 300000,
+}))
 vi.mock('../../login/open-browser.js', () => ({ openBrowser: vi.fn(() => false) }))
 vi.mock('../../login/readiness.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../login/readiness.js')>()
@@ -39,11 +42,13 @@ vi.mock('viem', async (importOriginal) => {
 })
 vi.mock('viem/actions', () => ({ getBlockNumber: vi.fn(async () => 42n) }))
 
+/** Joined log lines with ANSI colour codes stripped, since CI forces colour on. */
 function output(): string {
   return vi
     .mocked(log.line)
     .mock.calls.map((call) => String(call[0]))
     .join('\n')
+    .replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '')
 }
 
 describe('runLogin', () => {
@@ -92,10 +97,41 @@ describe('runLogin', () => {
       `https://console.test/console/session-keys?authorize=${saved?.sessionAddress.toLowerCase()}&scopes=createDataSet,addPieces&network=calibration`
     )
     expect(text).toContain('storage service not approved yet')
-    expect(text).toContain('USDFC deposit — 0.00')
+    expect(text).toMatch(/USDFC deposit — 0\.00(?!\d)/)
     expect(text).toContain('https://console.test/console?deposit=2&operator=fwss')
     expect(text).not.toMatch(/FWSS operator|operator approval/i)
     expect(vi.mocked(openBrowser)).toHaveBeenCalledOnce()
+  })
+
+  it('reports a grant of none of the requested scopes and exits 2', async () => {
+    vi.mocked(watchAuthorization).mockResolvedValue({
+      status: 'none',
+      owner: OWNER,
+      granted: [],
+      missing: [CreateDataSetPermission, AddPiecesPermission],
+    })
+
+    const code = await runLogin({})
+
+    expect(code).toBe(2)
+    expect(output()).toContain('Authorized with none of the requested scopes')
+    expect(readSessionFile(join(dataDir, 'session.env'))?.walletAddress).toBe(OWNER)
+  })
+
+  it('still exits 0 when the readiness read fails after a full grant', async () => {
+    vi.mocked(watchAuthorization).mockResolvedValue({
+      status: 'granted',
+      owner: OWNER,
+      expiry: FUTURE,
+      granted: [CreateDataSetPermission, AddPiecesPermission],
+      missing: [],
+    })
+    vi.mocked(checkAccountReadiness).mockRejectedValue(new Error('rpc down'))
+
+    const code = await runLogin({})
+
+    expect(code).toBe(0)
+    expect(output()).toContain('Could not read account readiness: rpc down')
   })
 
   it('resumes the saved key and passes the known owner to the watcher', async () => {

--- a/src/test/unit/run-login.test.ts
+++ b/src/test/unit/run-login.test.ts
@@ -99,7 +99,7 @@ describe('runLogin', () => {
     )
     expect(text).toContain('storage service not approved yet')
     expect(text).toMatch(/USDFC deposit — 0\.00(?!\d)/)
-    expect(text).toContain('https://console.test/console?deposit=2&operator=fwss')
+    expect(text).toContain('https://console.test/console?deposit=2&operator=fwss&network=calibration')
     expect(text).not.toMatch(/FWSS operator|operator approval/i)
     expect(vi.mocked(openBrowser)).toHaveBeenCalledOnce()
     // The readiness read uses the RPC the user selected, not the chain default.

--- a/src/test/unit/run-login.test.ts
+++ b/src/test/unit/run-login.test.ts
@@ -6,6 +6,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { loginCommand, logoutCommand } from '../../commands/login.js'
 import { watchAuthorization } from '../../core/session/watch-authorization.js'
+import { initializeSynapse } from '../../core/synapse/index.js'
 import { openBrowser } from '../../login/open-browser.js'
 import { checkAccountReadiness } from '../../login/readiness.js'
 import { runLogin } from '../../login/run-login.js'
@@ -101,6 +102,10 @@ describe('runLogin', () => {
     expect(text).toContain('https://console.test/console?deposit=2&operator=fwss')
     expect(text).not.toMatch(/FWSS operator|operator approval/i)
     expect(vi.mocked(openBrowser)).toHaveBeenCalledOnce()
+    // The readiness read uses the RPC the user selected, not the chain default.
+    expect(vi.mocked(initializeSynapse)).toHaveBeenCalledWith(
+      expect.objectContaining({ walletAddress: OWNER, readOnly: true, rpcUrl: 'http://rpc.test' })
+    )
   })
 
   it('reports a grant of none of the requested scopes and exits 2', async () => {

--- a/src/test/unit/run-login.test.ts
+++ b/src/test/unit/run-login.test.ts
@@ -3,9 +3,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { AddPiecesPermission, CreateDataSetPermission } from '@filoz/synapse-core/session-key'
 import { privateKeyToAccount } from 'viem/accounts'
+import { getBlockNumber } from 'viem/actions'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { loginCommand } from '../../commands/login.js'
-import { watchAuthorization } from '../../core/session/watch-authorization.js'
+import { type WatchAuthorizationResult, watchAuthorization } from '../../core/session/watch-authorization.js'
 import { initializeSynapse } from '../../core/synapse/index.js'
 import { openBrowser } from '../../login/open-browser.js'
 import { checkAccountReadiness } from '../../login/readiness.js'
@@ -17,6 +18,18 @@ import { log } from '../../utils/cli-logger.js'
 const OWNER = '0x00000000000000000000000000000000000000aa'
 const REGISTRY = '0x00000000000000000000000000000000000000dd'
 const FUTURE = 1790380800n
+const KEY = `0x${'11'.repeat(32)}` as const
+const AUTHORIZE_LINK_PREFIX = 'https://console.test/console/session-keys?authorize='
+const FUNDING_LINK = 'https://console.test/console?deposit=2&operator=fwss&network=calibration'
+
+const FULL_GRANT: WatchAuthorizationResult = {
+  status: 'granted',
+  owner: OWNER,
+  expiry: FUTURE,
+  granted: [CreateDataSetPermission, AddPiecesPermission],
+  missing: [],
+}
+const TIMED_OUT: WatchAuthorizationResult = { status: 'timeout', granted: [], missing: [] }
 
 let dataDir: string
 
@@ -28,7 +41,10 @@ vi.mock('../../core/session/watch-authorization.js', () => ({
 vi.mock('../../login/open-browser.js', () => ({ openBrowser: vi.fn(() => false) }))
 vi.mock('../../login/readiness.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../login/readiness.js')>()
-  return { ...actual, checkAccountReadiness: vi.fn() }
+  return {
+    ...actual,
+    checkAccountReadiness: vi.fn(async () => ({ serviceApproved: false, depositUsdfc: 0n })),
+  }
 })
 vi.mock('../../core/synapse/index.js', () => ({ initializeSynapse: vi.fn(async () => ({})) }))
 vi.mock('../../session/resolve-network.js', () => ({
@@ -53,55 +69,107 @@ function output(): string {
     .replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '')
 }
 
+function sessionPath(): string {
+  return join(dataDir, 'session.env')
+}
+
+/** A resolveNetwork result for a chain other than the default calibration one. */
+function networkFor(chainId: number, name: string, rpcUrl = 'http://rpc.test') {
+  return {
+    chain: { id: chainId, name, contracts: { sessionKeyRegistry: { address: REGISTRY } } },
+    rpcUrl,
+    transport: () => ({ request: vi.fn() }),
+  } as never
+}
+
 describe('runLogin', () => {
   beforeEach(() => {
     dataDir = mkdtempSync(join(tmpdir(), 'login-run-'))
     vi.spyOn(log, 'line').mockImplementation(() => undefined)
     vi.spyOn(log, 'flush').mockImplementation(() => undefined)
-    vi.mocked(checkAccountReadiness).mockResolvedValue({ serviceApproved: false, depositUsdfc: 0n })
-    process.env.CONSOLE_URL = 'https://console.test'
+    vi.stubEnv('CONSOLE_URL', 'https://console.test')
   })
 
   afterEach(() => {
     rmSync(dataDir, { recursive: true, force: true })
     vi.restoreAllMocks()
-    vi.mocked(watchAuthorization).mockReset()
-    delete process.env.CONSOLE_URL
+    vi.unstubAllEnvs()
+    // Module mocks survive restoreAllMocks; reset each one so call counts
+    // and per-test return values never reach the next test.
+    for (const fn of [
+      openBrowser,
+      initializeSynapse,
+      resolveNetwork,
+      getBlockNumber,
+      checkAccountReadiness,
+      watchAuthorization,
+    ]) {
+      vi.mocked(fn).mockReset()
+    }
   })
 
-  it('saves the key before watching, prints the lowercase authorize link, and exits 0 on a full grant', async () => {
+  it('writes the session file before the wait starts', async () => {
     vi.mocked(watchAuthorization).mockImplementation(async (options) => {
       // The file exists by the time the wait starts.
-      const saved = readSessionFile(join(dataDir, 'session.env'))
+      const saved = readSessionFile(sessionPath())
       expect(saved?.sessionAddress).toBe(options.sessionAddress)
       expect(saved?.walletAddress).toBeUndefined()
       expect(options.fromBlock).toBe(42n)
       expect(options.registryAddress).toBe(REGISTRY)
       expect(options.permissions).toEqual([CreateDataSetPermission, AddPiecesPermission])
-      return {
-        status: 'granted',
-        owner: OWNER,
-        expiry: FUTURE,
-        granted: [CreateDataSetPermission, AddPiecesPermission],
-        missing: [],
-      }
+      return FULL_GRANT
     })
 
     const code = await runLogin({})
 
     expect(code).toBe(0)
-    const saved = readSessionFile(join(dataDir, 'session.env'))
-    expect(saved?.walletAddress).toBe(OWNER)
+    expect(vi.mocked(watchAuthorization)).toHaveBeenCalledOnce()
+  })
+
+  it('prints the lowercase authorize link and opens it in the browser', async () => {
+    vi.mocked(watchAuthorization).mockResolvedValue(FULL_GRANT)
+
+    await runLogin({})
+
+    const saved = readSessionFile(sessionPath())
+    const url = `${AUTHORIZE_LINK_PREFIX}${saved?.sessionAddress.toLowerCase()}&scopes=createDataSet,addPieces&network=calibration`
+    expect(output()).toContain(url)
+    expect(vi.mocked(openBrowser)).toHaveBeenCalledExactlyOnceWith(url)
+  })
+
+  it('prints the funding link when the storage service is not approved and nothing is deposited', async () => {
+    vi.mocked(watchAuthorization).mockResolvedValue(FULL_GRANT)
+    vi.mocked(checkAccountReadiness).mockResolvedValue({ serviceApproved: false, depositUsdfc: 0n })
+
+    await runLogin({})
+
     const text = output()
-    expect(text).toContain('Session key generated')
-    expect(text).toContain(
-      `https://console.test/console/session-keys?authorize=${saved?.sessionAddress.toLowerCase()}&scopes=createDataSet,addPieces&network=calibration`
-    )
-    expect(text).toContain('https://console.test/console?deposit=2&operator=fwss&network=calibration')
-    expect(vi.mocked(openBrowser)).toHaveBeenCalledOnce()
-    // The readiness read uses the RPC the user selected, not the chain default.
-    expect(vi.mocked(initializeSynapse)).toHaveBeenCalledWith(
-      expect.objectContaining({ walletAddress: OWNER, readOnly: true, rpcUrl: 'http://rpc.test' })
+    expect(text).toContain('storage service not approved yet')
+    expect(text).toContain(FUNDING_LINK)
+  })
+
+  it('prints the approved scorecard and no funding link when the account is funded', async () => {
+    vi.mocked(watchAuthorization).mockResolvedValue(FULL_GRANT)
+    vi.mocked(checkAccountReadiness).mockResolvedValue({
+      serviceApproved: true,
+      depositUsdfc: 5_000_000_000_000_000_000n,
+    })
+
+    await runLogin({})
+
+    const text = output()
+    expect(text).toContain('✓ storage service approved')
+    expect(text).not.toContain('operator=fwss')
+  })
+
+  it('reads account readiness over the RPC the user selected', async () => {
+    vi.mocked(resolveNetwork).mockResolvedValue(networkFor(314159, 'calibration', 'http://rpc.selected'))
+    vi.mocked(watchAuthorization).mockResolvedValue(FULL_GRANT)
+
+    await runLogin({})
+
+    expect(vi.mocked(initializeSynapse)).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ walletAddress: OWNER, readOnly: true, rpcUrl: 'http://rpc.selected' })
     )
   })
 
@@ -117,17 +185,11 @@ describe('runLogin', () => {
 
     expect(code).toBe(2)
     expect(output()).toContain('Authorized with none of the requested scopes')
-    expect(readSessionFile(join(dataDir, 'session.env'))?.walletAddress).toBe(OWNER)
+    expect(readSessionFile(sessionPath())?.walletAddress).toBe(OWNER)
   })
 
   it('still exits 0 when the readiness read fails after a full grant', async () => {
-    vi.mocked(watchAuthorization).mockResolvedValue({
-      status: 'granted',
-      owner: OWNER,
-      expiry: FUTURE,
-      granted: [CreateDataSetPermission, AddPiecesPermission],
-      missing: [],
-    })
+    vi.mocked(watchAuthorization).mockResolvedValue(FULL_GRANT)
     vi.mocked(checkAccountReadiness).mockRejectedValue(new Error('rpc down'))
 
     const code = await runLogin({})
@@ -137,10 +199,9 @@ describe('runLogin', () => {
   })
 
   it('resumes the saved key and passes the known owner to the watcher', async () => {
-    const key = `0x${'11'.repeat(32)}` as const
-    const session = privateKeyToAccount(key).address
-    writeSessionFile({ sessionKey: key, sessionAddress: session, walletAddress: OWNER }, join(dataDir, 'session.env'))
-    vi.mocked(watchAuthorization).mockResolvedValue({ status: 'timeout', granted: [], missing: [] })
+    const session = privateKeyToAccount(KEY).address
+    writeSessionFile({ sessionKey: KEY, sessionAddress: session, walletAddress: OWNER }, sessionPath())
+    vi.mocked(watchAuthorization).mockResolvedValue(TIMED_OUT)
 
     const code = await runLogin({})
 
@@ -149,21 +210,21 @@ describe('runLogin', () => {
       expect.objectContaining({ sessionAddress: session, owner: OWNER })
     )
     expect(output()).toContain('Resuming session key')
-    expect(readSessionFile(join(dataDir, 'session.env'))?.sessionKey).toBe(key)
+    expect(readSessionFile(sessionPath())?.sessionKey).toBe(KEY)
   })
 
-  it('--fresh replaces the saved key', async () => {
-    const key = `0x${'11'.repeat(32)}` as const
-    writeSessionFile(
-      { sessionKey: key, sessionAddress: '0x00000000000000000000000000000000000000bb' },
-      join(dataDir, 'session.env')
-    )
-    vi.mocked(watchAuthorization).mockResolvedValue({ status: 'timeout', granted: [], missing: [] })
+  it('--fresh replaces an authorized key and warns that it stays live on chain', async () => {
+    const replaced = privateKeyToAccount(KEY).address
+    writeSessionFile({ sessionKey: KEY, sessionAddress: replaced, walletAddress: OWNER }, sessionPath())
+    vi.mocked(watchAuthorization).mockResolvedValue(TIMED_OUT)
 
     await runLogin({ fresh: true })
 
-    expect(readSessionFile(join(dataDir, 'session.env'))?.sessionKey).not.toBe(key)
-    expect(vi.mocked(watchAuthorization)).toHaveBeenCalledWith(expect.not.objectContaining({ owner: OWNER }))
+    const saved = readSessionFile(sessionPath())
+    expect(saved?.sessionKey).not.toBe(KEY)
+    expect(saved?.walletAddress).toBeUndefined()
+    expect(vi.mocked(watchAuthorization)).toHaveBeenCalledExactlyOnceWith(expect.not.objectContaining({ owner: OWNER }))
+    expect(output()).toContain('stays authorized on chain')
   })
 
   it('reports a partial grant with the requested-versus-granted diff and exits 2 even though uploads work', async () => {
@@ -189,30 +250,30 @@ describe('runLogin', () => {
     expect(vi.mocked(watchAuthorization)).not.toHaveBeenCalled()
   })
 
-  it('records the network in the session file and refuses to resume a key made for another one', async () => {
-    vi.mocked(watchAuthorization).mockResolvedValue({ status: 'timeout', granted: [], missing: [] })
-    await runLogin({})
-    expect(readSessionFile(join(dataDir, 'session.env'))?.network).toBe('calibration')
+  it('records the network in the session file', async () => {
+    vi.mocked(watchAuthorization).mockResolvedValue(TIMED_OUT)
 
-    vi.mocked(resolveNetwork).mockResolvedValueOnce({
-      chain: { id: 314, name: 'mainnet', contracts: { sessionKeyRegistry: { address: REGISTRY } } },
-      rpcUrl: 'http://rpc.test',
-      transport: () => ({ request: vi.fn() }),
-    } as never)
+    await runLogin({})
+
+    expect(readSessionFile(sessionPath())?.network).toBe('calibration')
+  })
+
+  it('refuses to resume a key made for another network', async () => {
+    writeSessionFile(
+      { sessionKey: KEY, sessionAddress: privateKeyToAccount(KEY).address, network: 'calibration' },
+      sessionPath()
+    )
+    vi.mocked(resolveNetwork).mockResolvedValue(networkFor(314, 'mainnet'))
+
     await expect(runLogin({})).rejects.toThrow(/saved login is for calibration, not mainnet/)
-    expect(vi.mocked(watchAuthorization)).toHaveBeenCalledOnce()
+    expect(vi.mocked(watchAuthorization)).not.toHaveBeenCalled()
   })
 
   it('refuses a chain the console has no page for before saving anything', async () => {
-    vi.mocked(openBrowser).mockClear()
-    vi.mocked(resolveNetwork).mockResolvedValueOnce({
-      chain: { id: 31415926, name: 'devnet', contracts: { sessionKeyRegistry: { address: REGISTRY } } },
-      rpcUrl: 'http://rpc.test',
-      transport: () => ({ request: vi.fn() }),
-    } as never)
+    vi.mocked(resolveNetwork).mockResolvedValue(networkFor(31415926, 'devnet'))
 
     await expect(runLogin({})).rejects.toThrow(/no pairing page for chain id 31415926/)
-    expect(readSessionFile(join(dataDir, 'session.env'))).toBeUndefined()
+    expect(readSessionFile(sessionPath())).toBeUndefined()
     expect(vi.mocked(openBrowser)).not.toHaveBeenCalled()
   })
 
@@ -221,58 +282,57 @@ describe('runLogin', () => {
 
     expect(code).toBe(2)
     expect(vi.mocked(watchAuthorization)).not.toHaveBeenCalled()
-    const saved = readSessionFile(join(dataDir, 'session.env'))
+    const saved = readSessionFile(sessionPath())
     expect(saved?.sessionAddress).toBeDefined()
     const lines = vi.mocked(log.line).mock.calls.map((call) => String(call[0]))
     expect(lines).toContain(
-      `https://console.test/console/session-keys?authorize=${saved?.sessionAddress.toLowerCase()}&scopes=createDataSet,addPieces&network=calibration`
+      `${AUTHORIZE_LINK_PREFIX}${saved?.sessionAddress.toLowerCase()}&scopes=createDataSet,addPieces&network=calibration`
     )
   })
 
-  it('--no-browser keeps the browser closed and --timeout shortens the wait', async () => {
-    vi.mocked(openBrowser).mockClear()
-    vi.mocked(watchAuthorization).mockResolvedValue({ status: 'timeout', granted: [], missing: [] })
+  it('--no-browser keeps the browser closed', async () => {
+    vi.mocked(watchAuthorization).mockResolvedValue(TIMED_OUT)
+
+    await runLogin({ browser: false })
+
+    expect(vi.mocked(openBrowser)).not.toHaveBeenCalled()
+  })
+
+  it('--timeout shortens the wait and the Ctrl-C handler is removed after a timeout', async () => {
+    vi.mocked(watchAuthorization).mockResolvedValue(TIMED_OUT)
+    const sigintListeners = process.listenerCount('SIGINT')
 
     await runLogin({ browser: false, timeout: 30 })
 
-    expect(vi.mocked(openBrowser)).not.toHaveBeenCalled()
     expect(vi.mocked(watchAuthorization)).toHaveBeenCalledWith(expect.objectContaining({ deadlineMs: 30000 }))
+    expect(process.listenerCount('SIGINT')).toBe(sigintListeners)
   })
 
   it('prints the link before touching the RPC, so a dead endpoint still pairs', async () => {
-    const { getBlockNumber } = await import('viem/actions')
-    vi.mocked(getBlockNumber).mockRejectedValueOnce(new Error('rpc down'))
+    vi.mocked(getBlockNumber).mockRejectedValue(new Error('rpc down'))
 
     await expect(runLogin({ network: 'calibration', browser: false })).rejects.toThrow('rpc down')
-    expect(output()).toContain('https://console.test/console/session-keys?authorize=')
+    expect(output()).toContain(AUTHORIZE_LINK_PREFIX)
   })
 
   it('stops the spinner with a resume hint when the watch itself fails', async () => {
     // Outside a TTY the spinner's stop line goes through log.message, not log.line.
     const message = vi.spyOn(log, 'message').mockImplementation(() => undefined)
-    vi.mocked(watchAuthorization).mockRejectedValueOnce(new Error('endpoint failed 3 polls in a row'))
+    vi.mocked(watchAuthorization).mockRejectedValue(new Error('endpoint failed 3 polls in a row'))
+    const sigintListeners = process.listenerCount('SIGINT')
 
     await expect(runLogin({ network: 'calibration', browser: false })).rejects.toThrow('3 polls in a row')
     expect(message).toHaveBeenCalledWith(expect.stringContaining('Could not watch for the authorization'))
+    expect(process.listenerCount('SIGINT')).toBe(sigintListeners)
   })
 
-  it('warns when a shell credential will shadow the saved login and when --fresh orphans a live key', async () => {
-    const key = `0x${'11'.repeat(32)}` as const
-    writeSessionFile(
-      { sessionKey: key, sessionAddress: privateKeyToAccount(key).address, walletAddress: OWNER },
-      join(dataDir, 'session.env')
-    )
-    vi.mocked(watchAuthorization).mockResolvedValue({ status: 'timeout', granted: [], missing: [] })
-    process.env.SESSION_KEY = key
-    try {
-      await runLogin({ fresh: true })
-    } finally {
-      delete process.env.SESSION_KEY
-    }
+  it('warns when a shell credential will shadow the saved login', async () => {
+    vi.mocked(watchAuthorization).mockResolvedValue(TIMED_OUT)
+    vi.stubEnv('SESSION_KEY', KEY)
 
-    const text = output()
-    expect(text).toContain('SESSION_KEY is set')
-    expect(text).toContain('stays authorized on chain')
+    await runLogin({})
+
+    expect(output()).toContain('SESSION_KEY is set')
   })
 })
 

--- a/src/test/unit/run-login.test.ts
+++ b/src/test/unit/run-login.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { AddPiecesPermission, CreateDataSetPermission } from '@filoz/synapse-core/session-key'
 import { privateKeyToAccount } from 'viem/accounts'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { loginCommand, logoutCommand } from '../../commands/login.js'
+import { loginCommand } from '../../commands/login.js'
 import { watchAuthorization } from '../../core/session/watch-authorization.js'
 import { initializeSynapse } from '../../core/synapse/index.js'
 import { openBrowser } from '../../login/open-browser.js'
@@ -94,14 +94,10 @@ describe('runLogin', () => {
     expect(saved?.walletAddress).toBe(OWNER)
     const text = output()
     expect(text).toContain('Session key generated')
-    expect(text).toContain('Requesting scopes: createDataSet, addPieces (defaults — override with --scopes)')
     expect(text).toContain(
       `https://console.test/console/session-keys?authorize=${saved?.sessionAddress.toLowerCase()}&scopes=createDataSet,addPieces&network=calibration`
     )
-    expect(text).toContain('storage service not approved yet')
-    expect(text).toMatch(/USDFC deposit — 0\.00(?!\d)/)
     expect(text).toContain('https://console.test/console?deposit=2&operator=fwss&network=calibration')
-    expect(text).not.toMatch(/FWSS operator|operator approval/i)
     expect(vi.mocked(openBrowser)).toHaveBeenCalledOnce()
     // The readiness read uses the RPC the user selected, not the chain default.
     expect(vi.mocked(initializeSynapse)).toHaveBeenCalledWith(
@@ -183,10 +179,8 @@ describe('runLogin', () => {
 
     expect(code).toBe(0)
     const text = output()
-    expect(text).toContain('Authorized with fewer scopes than requested')
     expect(text).toContain('Requested:  createDataSet, addPieces, schedulePieceRemovals')
-    expect(text).toContain('schedulePieceRemovals ✗ (owner declined)')
-    expect(text).toContain('Uploads will work.')
+    expect(text).toContain('schedulePieceRemovals ✗')
   })
 
   it('rejects an unknown scope before touching the network', async () => {
@@ -232,7 +226,6 @@ describe('runLogin', () => {
     expect(lines).toContain(
       `https://console.test/console/session-keys?authorize=${saved?.sessionAddress.toLowerCase()}&scopes=createDataSet,addPieces&network=calibration`
     )
-    expect(output()).toContain('rerun `filecoin-pin login` to check it')
   })
 
   it('--no-browser keeps the browser closed and --timeout shortens the wait', async () => {
@@ -260,30 +253,13 @@ describe('runLogin', () => {
     }
 
     const text = output()
-    expect(text).toContain('SESSION_KEY is set in this shell and takes precedence over the saved login')
-    expect(text).toContain('stays authorized on chain until it expires')
+    expect(text).toContain('SESSION_KEY is set')
+    expect(text).toContain('stays authorized on chain')
   })
 })
 
 describe('login command wiring', () => {
-  it('registers login with --scopes, --fresh, and network flags', () => {
-    const longs = loginCommand.options.map((o) => o.long)
-    expect(longs).toEqual(
-      expect.arrayContaining([
-        '--scopes',
-        '--fresh',
-        '--no-browser',
-        '--no-wait',
-        '--timeout',
-        '--network',
-        '--rpc-url',
-      ])
-    )
+  it('never accepts the owner private key', () => {
     expect(loginCommand.options.some((o) => o.long === '--private-key')).toBe(false)
-  })
-
-  it('registers logout with no options', () => {
-    expect(logoutCommand.name()).toBe('logout')
-    expect(logoutCommand.options).toHaveLength(0)
   })
 })

--- a/src/test/unit/run-login.test.ts
+++ b/src/test/unit/run-login.test.ts
@@ -166,7 +166,7 @@ describe('runLogin', () => {
     expect(vi.mocked(watchAuthorization)).toHaveBeenCalledWith(expect.not.objectContaining({ owner: OWNER }))
   })
 
-  it('reports a partial grant with the requested-versus-granted diff and exits 0 when uploads still work', async () => {
+  it('reports a partial grant with the requested-versus-granted diff and exits 2 even though uploads work', async () => {
     vi.mocked(watchAuthorization).mockResolvedValue({
       status: 'partial',
       owner: OWNER,
@@ -177,10 +177,11 @@ describe('runLogin', () => {
 
     const code = await runLogin({ scopes: 'createDataSet,addPieces,schedulePieceRemovals' })
 
-    expect(code).toBe(0)
+    expect(code).toBe(2)
     const text = output()
     expect(text).toContain('Requested:  createDataSet, addPieces, schedulePieceRemovals')
     expect(text).toContain('schedulePieceRemovals ✗')
+    expect(text).toContain('Uploads will work.')
   })
 
   it('rejects an unknown scope before touching the network', async () => {

--- a/src/test/unit/run-login.test.ts
+++ b/src/test/unit/run-login.test.ts
@@ -11,6 +11,7 @@ import { openBrowser } from '../../login/open-browser.js'
 import { checkAccountReadiness } from '../../login/readiness.js'
 import { runLogin } from '../../login/run-login.js'
 import { readSessionFile, writeSessionFile } from '../../login/session-file.js'
+import { resolveNetwork } from '../../session/resolve-network.js'
 import { log } from '../../utils/cli-logger.js'
 
 const OWNER = '0x00000000000000000000000000000000000000aa'
@@ -169,7 +170,7 @@ describe('runLogin', () => {
     expect(vi.mocked(watchAuthorization)).toHaveBeenCalledWith(expect.not.objectContaining({ owner: OWNER }))
   })
 
-  it('reports a partial grant with the requested-versus-granted diff and exits 2', async () => {
+  it('reports a partial grant with the requested-versus-granted diff and exits 0 when uploads still work', async () => {
     vi.mocked(watchAuthorization).mockResolvedValue({
       status: 'partial',
       owner: OWNER,
@@ -180,7 +181,7 @@ describe('runLogin', () => {
 
     const code = await runLogin({ scopes: 'createDataSet,addPieces,schedulePieceRemovals' })
 
-    expect(code).toBe(2)
+    expect(code).toBe(0)
     const text = output()
     expect(text).toContain('Authorized with fewer scopes than requested')
     expect(text).toContain('Requested:  createDataSet, addPieces, schedulePieceRemovals')
@@ -192,12 +193,92 @@ describe('runLogin', () => {
     await expect(runLogin({ scopes: 'nope' })).rejects.toThrow(/Unknown scope "nope"/)
     expect(vi.mocked(watchAuthorization)).not.toHaveBeenCalled()
   })
+
+  it('records the network in the session file and refuses to resume a key made for another one', async () => {
+    vi.mocked(watchAuthorization).mockResolvedValue({ status: 'timeout', granted: [], missing: [] })
+    await runLogin({})
+    expect(readSessionFile(join(dataDir, 'session.env'))?.network).toBe('calibration')
+
+    vi.mocked(resolveNetwork).mockResolvedValueOnce({
+      chain: { id: 314, name: 'mainnet', contracts: { sessionKeyRegistry: { address: REGISTRY } } },
+      rpcUrl: 'http://rpc.test',
+      transport: () => ({ request: vi.fn() }),
+    } as never)
+    await expect(runLogin({})).rejects.toThrow(/saved login is for calibration, not mainnet/)
+    expect(vi.mocked(watchAuthorization)).toHaveBeenCalledOnce()
+  })
+
+  it('refuses a chain the console has no page for before saving anything', async () => {
+    vi.mocked(openBrowser).mockClear()
+    vi.mocked(resolveNetwork).mockResolvedValueOnce({
+      chain: { id: 31415926, name: 'devnet', contracts: { sessionKeyRegistry: { address: REGISTRY } } },
+      rpcUrl: 'http://rpc.test',
+      transport: () => ({ request: vi.fn() }),
+    } as never)
+
+    await expect(runLogin({})).rejects.toThrow(/no pairing page for chain id 31415926/)
+    expect(readSessionFile(join(dataDir, 'session.env'))).toBeUndefined()
+    expect(vi.mocked(openBrowser)).not.toHaveBeenCalled()
+  })
+
+  it('--no-wait saves the key, prints the bare link, and exits 2 without watching', async () => {
+    const code = await runLogin({ wait: false })
+
+    expect(code).toBe(2)
+    expect(vi.mocked(watchAuthorization)).not.toHaveBeenCalled()
+    const saved = readSessionFile(join(dataDir, 'session.env'))
+    expect(saved?.sessionAddress).toBeDefined()
+    const lines = vi.mocked(log.line).mock.calls.map((call) => String(call[0]))
+    expect(lines).toContain(
+      `https://console.test/console/session-keys?authorize=${saved?.sessionAddress.toLowerCase()}&scopes=createDataSet,addPieces&network=calibration`
+    )
+    expect(output()).toContain('rerun `filecoin-pin login` to check it')
+  })
+
+  it('--no-browser keeps the browser closed and --timeout shortens the wait', async () => {
+    vi.mocked(openBrowser).mockClear()
+    vi.mocked(watchAuthorization).mockResolvedValue({ status: 'timeout', granted: [], missing: [] })
+
+    await runLogin({ browser: false, timeout: 30 })
+
+    expect(vi.mocked(openBrowser)).not.toHaveBeenCalled()
+    expect(vi.mocked(watchAuthorization)).toHaveBeenCalledWith(expect.objectContaining({ deadlineMs: 30000 }))
+  })
+
+  it('warns when a shell credential will shadow the saved login and when --fresh orphans a live key', async () => {
+    const key = `0x${'11'.repeat(32)}` as const
+    writeSessionFile(
+      { sessionKey: key, sessionAddress: privateKeyToAccount(key).address, walletAddress: OWNER },
+      join(dataDir, 'session.env')
+    )
+    vi.mocked(watchAuthorization).mockResolvedValue({ status: 'timeout', granted: [], missing: [] })
+    process.env.SESSION_KEY = key
+    try {
+      await runLogin({ fresh: true })
+    } finally {
+      delete process.env.SESSION_KEY
+    }
+
+    const text = output()
+    expect(text).toContain('SESSION_KEY is set in this shell and takes precedence over the saved login')
+    expect(text).toContain('stays authorized on chain until it expires')
+  })
 })
 
 describe('login command wiring', () => {
   it('registers login with --scopes, --fresh, and network flags', () => {
     const longs = loginCommand.options.map((o) => o.long)
-    expect(longs).toEqual(expect.arrayContaining(['--scopes', '--fresh', '--network', '--rpc-url']))
+    expect(longs).toEqual(
+      expect.arrayContaining([
+        '--scopes',
+        '--fresh',
+        '--no-browser',
+        '--no-wait',
+        '--timeout',
+        '--network',
+        '--rpc-url',
+      ])
+    )
     expect(loginCommand.options.some((o) => o.long === '--private-key')).toBe(false)
   })
 

--- a/src/test/unit/run-login.test.ts
+++ b/src/test/unit/run-login.test.ts
@@ -238,6 +238,21 @@ describe('runLogin', () => {
     expect(vi.mocked(watchAuthorization)).toHaveBeenCalledWith(expect.objectContaining({ deadlineMs: 30000 }))
   })
 
+  it('prints the link before touching the RPC, so a dead endpoint still pairs', async () => {
+    const { getBlockNumber } = await import('viem/actions')
+    vi.mocked(getBlockNumber).mockRejectedValueOnce(new Error('rpc down'))
+
+    await expect(runLogin({ network: 'calibration', browser: false })).rejects.toThrow('rpc down')
+    expect(output()).toContain('https://console.test/console/session-keys?authorize=')
+  })
+
+  it('stops the spinner with a resume hint when the watch itself fails', async () => {
+    vi.mocked(watchAuthorization).mockRejectedValueOnce(new Error('endpoint failed 3 polls in a row'))
+
+    await expect(runLogin({ network: 'calibration', browser: false })).rejects.toThrow('3 polls in a row')
+    expect(output()).toContain('Could not watch for the authorization')
+  })
+
   it('warns when a shell credential will shadow the saved login and when --fresh orphans a live key', async () => {
     const key = `0x${'11'.repeat(32)}` as const
     writeSessionFile(

--- a/src/test/unit/run-login.test.ts
+++ b/src/test/unit/run-login.test.ts
@@ -247,10 +247,12 @@ describe('runLogin', () => {
   })
 
   it('stops the spinner with a resume hint when the watch itself fails', async () => {
+    // Outside a TTY the spinner's stop line goes through log.message, not log.line.
+    const message = vi.spyOn(log, 'message').mockImplementation(() => undefined)
     vi.mocked(watchAuthorization).mockRejectedValueOnce(new Error('endpoint failed 3 polls in a row'))
 
     await expect(runLogin({ network: 'calibration', browser: false })).rejects.toThrow('3 polls in a row')
-    expect(output()).toContain('Could not watch for the authorization')
+    expect(message).toHaveBeenCalledWith(expect.stringContaining('Could not watch for the authorization'))
   })
 
   it('warns when a shell credential will shadow the saved login and when --fresh orphans a live key', async () => {

--- a/src/test/unit/run-logout.test.ts
+++ b/src/test/unit/run-logout.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runLogout } from '../../login/run-logout.js'
+import { deleteSessionFile, readSessionFile } from '../../login/session-file.js'
+import { log } from '../../utils/cli-logger.js'
+
+vi.mock('../../login/session-file.js', () => ({
+  getSessionFilePath: () => '/data/session.env',
+  readSessionFile: vi.fn(),
+  deleteSessionFile: vi.fn(),
+}))
+
+const SESSION = '0x00000000000000000000000000000000000000bb'
+const OWNER = '0x00000000000000000000000000000000000000aa'
+
+describe('runLogout', () => {
+  beforeEach(() => {
+    vi.spyOn(log, 'line').mockImplementation(() => undefined)
+    vi.spyOn(log, 'flush').mockImplementation(() => undefined)
+    process.env.CONSOLE_URL = 'https://console.test'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.mocked(readSessionFile).mockReset()
+    vi.mocked(deleteSessionFile).mockReset()
+    delete process.env.CONSOLE_URL
+  })
+
+  const lines = () => vi.mocked(log.line).mock.calls.map((c) => String(c[0]))
+
+  it('prints the console session-keys link on its own line for an authorized key', () => {
+    vi.mocked(readSessionFile).mockReturnValue({
+      sessionKey: '0xsecret',
+      sessionAddress: SESSION,
+      walletAddress: OWNER,
+      network: 'calibration',
+    })
+    vi.mocked(deleteSessionFile).mockReturnValue(true)
+
+    runLogout()
+
+    expect(lines()).toContain('https://console.test/console/session-keys')
+    expect(lines().join('\n')).toContain(`session revoke ${SESSION}`)
+  })
+
+  it('says nothing about revoking when the key was never authorized', () => {
+    vi.mocked(readSessionFile).mockReturnValue({
+      sessionKey: '0xsecret',
+      sessionAddress: SESSION,
+      network: 'calibration',
+    })
+    vi.mocked(deleteSessionFile).mockReturnValue(true)
+
+    runLogout()
+
+    expect(lines().join('\n')).not.toContain('session-keys')
+  })
+})

--- a/src/test/unit/run-logout.test.ts
+++ b/src/test/unit/run-logout.test.ts
@@ -12,21 +12,26 @@ vi.mock('../../login/session-file.js', () => ({
 const SESSION = '0x00000000000000000000000000000000000000bb'
 const OWNER = '0x00000000000000000000000000000000000000aa'
 
+/** Each log line with ANSI colour codes stripped, since CI forces colour on. */
+function lines(): string[] {
+  return vi
+    .mocked(log.line)
+    .mock.calls.map((call) => String(call[0]).replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), ''))
+}
+
 describe('runLogout', () => {
   beforeEach(() => {
     vi.spyOn(log, 'line').mockImplementation(() => undefined)
     vi.spyOn(log, 'flush').mockImplementation(() => undefined)
-    process.env.CONSOLE_URL = 'https://console.test'
+    vi.stubEnv('CONSOLE_URL', 'https://console.test')
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllEnvs()
     vi.mocked(readSessionFile).mockReset()
     vi.mocked(deleteSessionFile).mockReset()
-    delete process.env.CONSOLE_URL
   })
-
-  const lines = () => vi.mocked(log.line).mock.calls.map((c) => String(c[0]))
 
   it('prints the console session-keys link on its own line for an authorized key', () => {
     vi.mocked(readSessionFile).mockReturnValue({
@@ -43,7 +48,7 @@ describe('runLogout', () => {
     expect(lines().join('\n')).toContain(`session revoke ${SESSION}`)
   })
 
-  it('says nothing about revoking when the key was never authorized', () => {
+  it('says the key was only forgotten locally when it was never authorized', () => {
     vi.mocked(readSessionFile).mockReturnValue({
       sessionKey: '0xsecret',
       sessionAddress: SESSION,
@@ -53,6 +58,21 @@ describe('runLogout', () => {
 
     runLogout()
 
-    expect(lines().join('\n')).not.toContain('session-keys')
+    const text = lines().join('\n')
+    expect(text).toContain(`Logged out: removed ${SESSION} from /data/session.env`)
+    expect(text).toContain('only forgets the key on this machine')
+    expect(text).not.toContain('session-keys')
+  })
+
+  it('says it was not logged in when there is no session file', () => {
+    vi.mocked(readSessionFile).mockReturnValue(undefined)
+    vi.mocked(deleteSessionFile).mockReturnValue(false)
+
+    runLogout()
+
+    const text = lines().join('\n')
+    expect(text).toContain('Not logged in: no session file at /data/session.env')
+    expect(text).not.toContain('Logged out')
+    expect(text).not.toContain('session-keys')
   })
 })


### PR DESCRIPTION
Stacked on #699 (`feat/login-watcher`).

Adds `filecoin-pin login` and `filecoin-pin logout`, the `login` and `logout` rows of PRD section 5 and the login mocks in section 6.

`login` generates a session key or resumes the saved one, writes `session.env` (key, address, network) under the data directory with mode 0600 before the browser opens, prints the console pairing link on its own line (`/console/session-keys?authorize=<lowercase addr>&scopes=a,b&network=<mainnet|calibration>`), opens it on a TTY unless `--no-browser` or `BROWSER=none`, waits for the grant with a countdown, then prints the granted scopes and the readiness scorecard with a funding link when something is missing. `--scopes` (default `createDataSet,addPieces`), `--fresh`, `--no-wait` (print the link and exit 2), `--timeout <seconds>`. Exit 0 when the key can upload (every requested scope, or at least createDataSet and addPieces), 2 when incomplete, 1 on error.

Refused up front: a chain the console has no page for (devnet, custom RPC), and resuming a key made for another network. `login` warns when `PRIVATE_KEY`, `SESSION_KEY`, or `VIEW_ADDRESS` is set in the shell, since they shadow the saved key, and when `--fresh` replaces a key that stays live on chain. The browser opener spawns without credential variables in its environment.

`logout` deletes the file, prints the address it removed, and how to revoke it on chain. The `session` group's help now says it is the owner-signed, advanced path. `login --help` has examples, files, environment, and exit codes.

Tests: session file round trip, permissions, and network; the login runner (file before the wait, link contents, partial grant, resume, `--fresh`, `--no-wait`, `--no-browser`, `--timeout`, refused chain, network mismatch, shadow warnings); command wiring.

Part of #697.
