### PR TITLE
feat(cli): auto-load the login session and add the no-credentials error

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,9 @@ A grant lives on one chain, so the file records the network (`mainnet` or `calib
 
 `filecoin-pin logout` deletes the saved session file and prints the session address it removed. This is local only: the on-chain grant expires on its own, or revoke it early on the console's Session keys page or with `filecoin-pin session revoke <session-address>` and the wallet key.
 
-Every command resolves credentials in this order: explicit flags, then environment variables (`PRIVATE_KEY`, or `SESSION_KEY` and `WALLET_ADDRESS`), then the saved session file, and otherwise fails with `No credentials found` and a pointer to `login`. `login`, `logout`, and `server` never read the session file. Whenever a session credential is used, the command prints a `Using session …` line naming the key, where it came from, and the owner. Expired grants fail with `Session expired`; rerun `login` to renew the same key.
+Every command resolves credentials in this order: explicit flags, then environment variables (`PRIVATE_KEY`, or `SESSION_KEY` and `WALLET_ADDRESS`), then `--credentials-file`, then the saved session file, and otherwise fails with `No credentials found` and a pointer to `login`. `VIEW_ADDRESS` forces read-only mode and skips the saved login (the command says so). `login`, `logout`, and `server` never read the session file. When the saved login is used and neither `--network` nor `NETWORK` chose a network, the key's own network applies; using it under another network prints a warning. Whenever a session credential is used, the command prints a `Using session …` line naming the key, where it came from, the owner, and the network. Expired grants fail with `Session expired`; rerun `login` to renew the same key.
+
+CI and shared runners: set `PRIVATE_KEY` or `SESSION_KEY` and `WALLET_ADDRESS` explicitly, so a session file left in the runner's home directory is never picked up.
 
 ### Session-Key Permissions
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ filecoin-pin add myfile.txt
 * `--session-key`: Session key mode: the session key's **private key** (printed as `SESSION_KEY` by `filecoin-pin session create` / `session generate`), not the session address. Each command checks only the permissions it needs; see [Session-Key Permissions](#session-key-permissions) below.
 * `--network`: Filecoin network to use: `mainnet`, `calibration`, or `devnet` (default: `mainnet`). Mutually exclusive with `--rpc-url`.
 * `--rpc-url`: Filecoin RPC endpoint. Filecoin Pin probes its `eth_chainId` to derive the chain. Mutually exclusive with `--network`.
-* `--credentials-file <path>`: Load credentials (e.g. `SESSION_KEY`, `WALLET_ADDRESS`) from a dotenv-style file before other options are resolved, e.g. a downloaded credentials file. Never overrides a variable already set in the environment.
+* `--credentials-file <path>`: Load credentials (e.g. `SESSION_KEY`, `WALLET_ADDRESS`) from a dotenv-style file, e.g. a downloaded credentials file. Flags and environment variables always win over the file, across auth modes too: `PRIVATE_KEY` in the shell beats a session key pair in the file.
 
 Other arguments are possible for individual commands, use `--help` to find out more.
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ A grant lives on one chain, so the file records the network (`mainnet` or `calib
 
 `filecoin-pin logout` deletes the saved session file and prints the session address it removed. This is local only: the on-chain grant expires on its own, or revoke it early on the console's Session keys page or with `filecoin-pin session revoke <session-address>` and the wallet key.
 
+Every command resolves credentials in this order: explicit flags, then environment variables (`PRIVATE_KEY`, or `SESSION_KEY` and `WALLET_ADDRESS`), then the saved session file, and otherwise fails with `No credentials found` and a pointer to `login`. Whenever a session credential is used, the command prints a `Using session …` line naming the key, where it came from, and the owner. Expired grants fail with `Session expired`; rerun `login` to renew the same key.
+
 ### Session-Key Permissions
 
 In session-key mode, each command checks only the on-chain permissions it needs — a delegate does not need every storage-service permission to run a scoped subset of commands.

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ A grant lives on one chain, so the file records the network (`mainnet` or `calib
 
 `filecoin-pin logout` deletes the saved session file and prints the session address it removed. This is local only: the on-chain grant expires on its own, or revoke it early on the console's Session keys page or with `filecoin-pin session revoke <session-address>` and the wallet key.
 
-Every command resolves credentials in this order: explicit flags, then environment variables (`PRIVATE_KEY`, or `SESSION_KEY` and `WALLET_ADDRESS`), then the saved session file, and otherwise fails with `No credentials found` and a pointer to `login`. Whenever a session credential is used, the command prints a `Using session …` line naming the key, where it came from, and the owner. Expired grants fail with `Session expired`; rerun `login` to renew the same key.
+Every command resolves credentials in this order: explicit flags, then environment variables (`PRIVATE_KEY`, or `SESSION_KEY` and `WALLET_ADDRESS`), then the saved session file, and otherwise fails with `No credentials found` and a pointer to `login`. `login`, `logout`, and `server` never read the session file. Whenever a session credential is used, the command prints a `Using session …` line naming the key, where it came from, and the owner. Expired grants fail with `Session expired`; rerun `login` to renew the same key.
 
 ### Session-Key Permissions
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,18 +10,21 @@ import { version as packageVersion } from './core/utils/version.js'
 import { readTelemetryConfigFromEnv } from './read-telemetry-config-from-env.js'
 import { applyVerboseLogLevel } from './utils/cli-logger.js'
 import { credentialsFileOption } from './utils/cli-options.js'
+import { applySessionFileCredentials } from './utils/credential-source.js'
 import { applyCredentialsFileArg } from './utils/credentials-file.js'
 
-// Load --credentials-file (if present) into process.env before anything else reads
-// env vars, so it can supply e.g. SESSION_KEY/WALLET_ADDRESS or telemetry
-// opt-out vars. Values already present in the environment are never
-// overridden by the file.
+// Credential precedence: flags, then env vars, then --credentials-file, then
+// the session file `login` wrote. The credentials file loads into process.env
+// first and never overrides values already present; the session file loads
+// after it and only when no flag and no env var supplied a credential, so
+// Commander's flag-over-env precedence still holds for everything else.
 try {
   applyCredentialsFileArg()
 } catch (error) {
   console.error('Error:', error instanceof Error ? error.message : error)
   process.exit(1)
 }
+applySessionFileCredentials()
 
 // Apply CLI env vars to the telemetry library before any subcommand runs.
 configureTelemetry({ ...readTelemetryConfigFromEnv(), affordance: 'CLI' })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,21 +10,7 @@ import { version as packageVersion } from './core/utils/version.js'
 import { readTelemetryConfigFromEnv } from './read-telemetry-config-from-env.js'
 import { applyVerboseLogLevel } from './utils/cli-logger.js'
 import { credentialsFileOption } from './utils/cli-options.js'
-import { applySessionFileCredentials } from './utils/credential-source.js'
-import { applyCredentialsFileArg } from './utils/credentials-file.js'
-
-// Credential precedence: flags, then env vars, then --credentials-file, then
-// the session file `login` wrote. The credentials file loads into process.env
-// first and never overrides values already present; the session file loads
-// after it and only when no flag and no env var supplied a credential, so
-// Commander's flag-over-env precedence still holds for everything else.
-try {
-  applyCredentialsFileArg()
-} catch (error) {
-  console.error('Error:', error instanceof Error ? error.message : error)
-  process.exit(1)
-}
-applySessionFileCredentials()
+import { applyCredentialsFile } from './utils/credentials-file.js'
 
 // Apply CLI env vars to the telemetry library before any subcommand runs.
 configureTelemetry({ ...readTelemetryConfigFromEnv(), affordance: 'CLI' })
@@ -86,9 +72,9 @@ const program = new Command()
   .optionsGroup('OPTIONS')
   .version(packageVersion)
   // Registered at the root so the flag is accepted in any position:
-  // Commander propagates parent options to subcommands. The bound value is
-  // never read here; the pre-parse loader is the consumer. Subcommand
-  // registrations exist for per-command help visibility.
+  // Commander propagates parent options to subcommands. The preAction hook
+  // below is the consumer. Subcommand registrations exist for per-command
+  // help visibility.
   .addOption(credentialsFileOption())
   .option('-v, --verbose', 'enable debug-level logging (sets LOG_LEVEL=debug)')
   .option('--no-update-check', 'skip check for updates')
@@ -132,6 +118,15 @@ for (const { heading, commands } of CLI_COMMAND_GROUPS) {
 // Default action - show help if no command specified
 program.action(() => {
   program.help()
+})
+
+// Credential precedence: flags, then env vars, then --credentials-file, then
+// the session file `login` wrote. Flags and env vars are resolved by parsing;
+// this hook supplies the credentials file next, and the addAuthOptions hook
+// (root hooks run first) supplies the saved login last. A bad file surfaces
+// through parseAsync's catch below.
+program.hook('preAction', (_thisCommand, actionCommand) => {
+  applyCredentialsFile(actionCommand)
 })
 
 // Wire the global `-v/--verbose` flag to the log level before each action runs.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,6 +106,11 @@ ${pc.bold('EXAMPLES')}
   $ filecoin-pin import ./archive.car
   $ filecoin-pin dataset ls
 
+${pc.bold('CREDENTIALS')}
+  Resolved in this order: flags, then PRIVATE_KEY or SESSION_KEY + WALLET_ADDRESS
+  in the environment, then --credentials-file, then the login session saved by
+  \`filecoin-pin login\`. VIEW_ADDRESS forces read-only mode and skips the saved login.
+
 ${pc.bold('EXIT CODES')}
   0  success
   1  error (the operation failed)

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -151,29 +151,21 @@ export function assertSessionKeyPrivateKey(value: string): asserts value is Hex 
 }
 
 /**
- * First line of the preflight error. Three shapes: nothing ever granted,
- * every needed grant lapsed (the session expired: renew it with `login`),
- * or a live key that lacks a scope.
+ * What the on-chain expirations say about a key that lacks a needed scope:
+ * nothing was ever granted, every grant lapsed (the session expired), or
+ * some grant is live but not the one this operation needs.
  */
-function describeProblem(
-  key: SessionKey<'Secp256k1'>,
-  ownerAddress: string,
-  scopeLabels: string,
-  networkName: string,
-  now: bigint
-): string {
+function classifyAuthorization(key: SessionKey<'Secp256k1'>, now: bigint): 'never' | 'expired' | 'missing' {
   const allExpirations = Object.values(key.expirations)
-  const neverAuthorized = allExpirations.length > 0 && allExpirations.every((expiry) => expiry === 0n)
-  if (neverAuthorized) {
-    return `Session key ${key.address} isn't authorized for account ${ownerAddress} on ${networkName} — never authorized, expired/revoked, or the key is for a different network (check --network).`
-  }
-  // No live grant at all, but at least one past grant: the session ran out.
-  if (allExpirations.every((expiry) => expiry <= now)) {
-    const latest = allExpirations.reduce((a, b) => (a > b ? a : b), 0n)
-    const date = new Date(Number(latest) * 1000).toISOString().slice(0, 10)
-    return `Session expired (key ${key.address}, grants lapsed ${date})\n  Renew it:  filecoin-pin login`
-  }
-  return `Session key ${key.address} lacks ${scopeLabels} for this operation on ${networkName}.`
+  if (allExpirations.length > 0 && allExpirations.every((expiry) => expiry === 0n)) return 'never'
+  if (allExpirations.every((expiry) => expiry <= now)) return 'expired'
+  return 'missing'
+}
+
+/** Latest expiry among the key's grants, as a date. */
+function latestExpiryDate(key: SessionKey<'Secp256k1'>): string {
+  const latest = Object.values(key.expirations).reduce((a, b) => (a > b ? a : b), 0n)
+  return new Date(Number(latest) * 1000).toISOString().slice(0, 10)
 }
 
 /**
@@ -198,6 +190,17 @@ function checkSessionKeyPermissions(
   const missing = required.filter((p) => !key.hasPermission(p))
   if (missing.length === 0) return
 
+  const now = BigInt(Math.floor(Date.now() / 1000))
+  const state = classifyAuthorization(key, now)
+  // The wall from PRD section 6: two lines, one remedy. Scope details and
+  // console links would only compete with "run login".
+  if (state === 'expired') {
+    throw new Error(
+      `Session expired (key ${key.address}, grants lapsed ${latestExpiryDate(key)})\n  Renew it:  filecoin-pin login`
+    )
+  }
+  const neverAuthorized = state === 'never'
+
   const scopeIds = missing.map(scopeIdOf)
   const scopeLabels = missing.map((p) => PermissionNames[p] ?? p).join(', ')
   const scopesArg = scopeIds.join(',')
@@ -205,7 +208,6 @@ function checkSessionKeyPermissions(
   // Per-scope detail preserves the expired-at vs never-granted distinction
   // the on-chain expirations carry — an expired grant points at renewal,
   // a never-granted scope points at a fresh authorization.
-  const now = BigInt(Math.floor(Date.now() / 1000))
   const scopeDetails = missing.map((p) => {
     const name = PermissionNames[p] ?? p
     const expiry = key.expirations[p] ?? 0n
@@ -215,7 +217,9 @@ function checkSessionKeyPermissions(
     return `  • ${name}: never granted`
   })
 
-  const problem = describeProblem(key, ownerAddress, scopeLabels, networkName, now)
+  const problem = neverAuthorized
+    ? `Session key ${key.address} isn't authorized for account ${ownerAddress} on ${networkName} — never authorized, expired/revoked, or the key is for a different network (check --network).`
+    : `Session key ${key.address} lacks ${scopeLabels} for this operation on ${networkName}.`
 
   const lines = [problem, ...scopeDetails, '']
   lines.push('Recommended — approve in the browser with the owner wallet:')

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -157,7 +157,8 @@ export function assertSessionKeyPrivateKey(value: string): asserts value is Hex 
  */
 function classifyAuthorization(key: SessionKey<'Secp256k1'>, now: bigint): 'never' | 'expired' | 'missing' {
   const allExpirations = Object.values(key.expirations)
-  if (allExpirations.length > 0 && allExpirations.every((expiry) => expiry === 0n)) return 'never'
+  // No entries reads as never granted, not as lapsed in 1970.
+  if (allExpirations.every((expiry) => expiry === 0n)) return 'never'
   if (allExpirations.every((expiry) => expiry <= now)) return 'expired'
   return 'missing'
 }

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -192,8 +192,8 @@ function checkSessionKeyPermissions(
 
   const now = BigInt(Math.floor(Date.now() / 1000))
   const state = classifyAuthorization(key, now)
-  // The wall from PRD section 6: two lines, one remedy. Scope details and
-  // console links would only compete with "run login".
+  // One remedy on purpose. A scope list or a console link here would
+  // compete with the only fix that works for an expired key: run login.
   if (state === 'expired') {
     throw new Error(
       `Session expired (key ${key.address}, grants lapsed ${latestExpiryDate(key)})\n  Renew it:  filecoin-pin login`

--- a/src/core/synapse/index.ts
+++ b/src/core/synapse/index.ts
@@ -151,6 +151,32 @@ export function assertSessionKeyPrivateKey(value: string): asserts value is Hex 
 }
 
 /**
+ * First line of the preflight error. Three shapes: nothing ever granted,
+ * every needed grant lapsed (the session expired: renew it with `login`),
+ * or a live key that lacks a scope.
+ */
+function describeProblem(
+  key: SessionKey<'Secp256k1'>,
+  ownerAddress: string,
+  scopeLabels: string,
+  networkName: string,
+  now: bigint
+): string {
+  const allExpirations = Object.values(key.expirations)
+  const neverAuthorized = allExpirations.length > 0 && allExpirations.every((expiry) => expiry === 0n)
+  if (neverAuthorized) {
+    return `Session key ${key.address} isn't authorized for account ${ownerAddress} on ${networkName} — never authorized, expired/revoked, or the key is for a different network (check --network).`
+  }
+  // No live grant at all, but at least one past grant: the session ran out.
+  if (allExpirations.every((expiry) => expiry <= now)) {
+    const latest = allExpirations.reduce((a, b) => (a > b ? a : b), 0n)
+    const date = new Date(Number(latest) * 1000).toISOString().slice(0, 10)
+    return `Session expired (key ${key.address}, grants lapsed ${date})\n  Renew it:  filecoin-pin login`
+  }
+  return `Session key ${key.address} lacks ${scopeLabels} for this operation on ${networkName}.`
+}
+
+/**
  * Preflight a session key against the permissions an operation needs.
  *
  * Two failure shapes, both console-first (spec: problem -> console
@@ -172,9 +198,6 @@ function checkSessionKeyPermissions(
   const missing = required.filter((p) => !key.hasPermission(p))
   if (missing.length === 0) return
 
-  const allExpirations = Object.values(key.expirations)
-  const neverAuthorized = allExpirations.length > 0 && allExpirations.every((expiry) => expiry === 0n)
-
   const scopeIds = missing.map(scopeIdOf)
   const scopeLabels = missing.map((p) => PermissionNames[p] ?? p).join(', ')
   const scopesArg = scopeIds.join(',')
@@ -192,9 +215,7 @@ function checkSessionKeyPermissions(
     return `  • ${name}: never granted`
   })
 
-  const problem = neverAuthorized
-    ? `Session key ${key.address} isn't authorized for account ${ownerAddress} on ${networkName} — never authorized, expired/revoked, or the key is for a different network (check --network).`
-    : `Session key ${key.address} lacks ${scopeLabels} for this operation on ${networkName}.`
+  const problem = describeProblem(key, ownerAddress, scopeLabels, networkName, now)
 
   const lines = [problem, ...scopeDetails, '']
   lines.push('Recommended — approve in the browser with the owner wallet:')
@@ -290,8 +311,9 @@ export async function initializeSynapse(config: SynapseSetupConfig, logger?: Log
       )
     }
     throw new Error(
-      'No authentication provided. Supply a private key (--private-key / PRIVATE_KEY), ' +
-        'or a wallet address (--wallet-address / WALLET_ADDRESS) with a session key (--session-key / SESSION_KEY).'
+      'No credentials found.\n' +
+        '  Log in to your Filecoin account:  filecoin-pin login\n' +
+        '  (or supply --private-key / PRIVATE_KEY, or --wallet-address + --session-key / WALLET_ADDRESS + SESSION_KEY)'
     )
   }
 

--- a/src/test/smoke/cli-error-scenarios.test.ts
+++ b/src/test/smoke/cli-error-scenarios.test.ts
@@ -77,7 +77,7 @@ describe('add', () => {
   it('no auth — valid path, PRIVATE_KEY absent', T, async () => {
     const result = await runCli(['add', 'package.json'])
     expect(result.exitCode).toBe(1)
-    expect(result.combined).toContain('No authentication provided')
+    expect(result.combined).toContain('No credentials found')
   })
 })
 
@@ -123,7 +123,7 @@ describe('payments status', () => {
   it('no auth', T, async () => {
     const result = await runCli(['payments', 'status'])
     expect(result.exitCode).toBe(1)
-    expect(result.combined).toContain('No authentication provided')
+    expect(result.combined).toContain('No credentials found')
   })
 })
 
@@ -173,7 +173,7 @@ describe('data-set show', () => {
   it('no auth', T, async () => {
     const result = await runCli(['data-set', 'show', '42'])
     expect(result.exitCode).toBe(1)
-    expect(result.combined).toContain('No authentication provided')
+    expect(result.combined).toContain('No credentials found')
   })
 
   it('non-numeric dataSetId', T, async () => {
@@ -206,7 +206,7 @@ describe('data-set list', () => {
   it('no auth', T, async () => {
     const result = await runCli(['data-set', 'list'])
     expect(result.exitCode).toBe(1)
-    expect(result.combined).toContain('No authentication provided')
+    expect(result.combined).toContain('No credentials found')
   })
 })
 
@@ -220,7 +220,7 @@ describe('data-set terminate', () => {
   it('no auth', T, async () => {
     const result = await runCli(['data-set', 'terminate', '42'])
     expect(result.exitCode).toBe(1)
-    expect(result.combined).toContain('No authentication provided')
+    expect(result.combined).toContain('No credentials found')
   })
 
   it('non-numeric dataSetId is rejected', T, async () => {
@@ -240,7 +240,7 @@ describe('data-set piece-status', () => {
   it('no auth', T, async () => {
     const result = await runCli(['data-set', 'piece-status', '42'])
     expect(result.exitCode).toBe(1)
-    expect(result.combined).toContain('No authentication provided')
+    expect(result.combined).toContain('No credentials found')
   })
 
   it('non-numeric dataSetId is rejected', T, async () => {

--- a/src/test/smoke/utils.ts
+++ b/src/test/smoke/utils.ts
@@ -1,4 +1,6 @@
 import { spawn } from 'node:child_process'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -19,6 +21,11 @@ export interface CliRunResult {
 // before spawning so every test is hermetic regardless of where it runs.
 const STRIP_AUTH = ['PRIVATE_KEY', 'SESSION_KEY', 'WALLET_ADDRESS'] as const
 
+// A session file written by `filecoin-pin login` on the developer's machine
+// would be auto-loaded through the data directory, so every run gets an
+// empty one. Exported so a test can seed it.
+export const SMOKE_DATA_DIR = mkdtempSync(join(tmpdir(), 'filecoin-pin-smoke-'))
+
 export async function runCli(args: string[] = [], env: Record<string, string> = {}): Promise<CliRunResult> {
   return new Promise((resolve, reject) => {
     // Inherit the process env so the CLI can initialize correctly (HOME,
@@ -32,6 +39,9 @@ export async function runCli(args: string[] = [], env: Record<string, string> = 
     for (const key of STRIP_AUTH) {
       delete baseEnv[key]
     }
+    baseEnv.XDG_DATA_HOME = SMOKE_DATA_DIR
+    baseEnv.APPDATA = SMOKE_DATA_DIR
+    baseEnv.HOME = SMOKE_DATA_DIR
 
     const child = spawn('node', [CLI_PATH, '--no-update-check', ...args], {
       cwd: PROJECT_ROOT,

--- a/src/test/smoke/utils.ts
+++ b/src/test/smoke/utils.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { mkdtempSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -25,6 +25,7 @@ const STRIP_AUTH = ['PRIVATE_KEY', 'SESSION_KEY', 'WALLET_ADDRESS'] as const
 // would be auto-loaded through the data directory, so every run gets an
 // empty one. Exported so a test can seed it.
 export const SMOKE_DATA_DIR = mkdtempSync(join(tmpdir(), 'filecoin-pin-smoke-'))
+process.on('exit', () => rmSync(SMOKE_DATA_DIR, { recursive: true, force: true }))
 
 export async function runCli(args: string[] = [], env: Record<string, string> = {}): Promise<CliRunResult> {
   return new Promise((resolve, reject) => {

--- a/src/test/unit/cli-validation.test.ts
+++ b/src/test/unit/cli-validation.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { assertOwnerAuth, parseCLIAuth, parseContextSelectionOptions } from '../../utils/cli-auth.js'
+import { log } from '../../utils/cli-logger.js'
 
 describe('parseContextSelectionOptions empty-list regression', () => {
   const originalEnv = { ...process.env }
@@ -95,5 +96,38 @@ describe('assertOwnerAuth', () => {
   it('refuses a view-only address, which cannot sign', () => {
     const config = parseCLIAuth({ viewAddress: '0x0000000000000000000000000000000000000002' })
     expect(() => assertOwnerAuth(config, 'payments withdraw')).toThrow(/view-only address can't sign/)
+  })
+})
+
+describe('parseCLIAuth session line', () => {
+  const sessionOptions = {
+    walletAddress: '0xffd6000000000000000000000000000000000666E',
+    sessionKey: `0x${'11'.repeat(32)}`,
+  }
+
+  beforeEach(() => {
+    vi.spyOn(log, 'line').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const lines = () =>
+    vi
+      .mocked(log.line)
+      .mock.calls.map((c) => String(c[0]))
+      .join('\n')
+
+  it('names the session and owner when a session credential is used', () => {
+    parseCLIAuth(sessionOptions)
+    expect(lines()).toMatch(/Using session 0x[0-9a-fA-F]{4}…[0-9a-fA-F]{4} · owner 0xffd6…666E/)
+    expect(lines()).not.toContain('(from ')
+  })
+
+  it('stays quiet for private-key and view-only auth', () => {
+    parseCLIAuth({ privateKey: `0x${'11'.repeat(32)}` })
+    parseCLIAuth({ viewAddress: '0x0000000000000000000000000000000000000002' })
+    expect(lines()).toBe('')
   })
 })

--- a/src/test/unit/cli-validation.test.ts
+++ b/src/test/unit/cli-validation.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { assertOwnerAuth, parseCLIAuth, parseContextSelectionOptions } from '../../utils/cli-auth.js'
 import { log } from '../../utils/cli-logger.js'
-import { getSessionCredentialNetwork } from '../../utils/credential-source.js'
+import {
+  getSessionCredentialNetwork,
+  getSessionCredentialSource,
+  wasSessionSkippedForViewAddress,
+} from '../../utils/credential-source.js'
 
 vi.mock('../../utils/credential-source.js', () => ({
-  getSessionCredentialSource: () => undefined,
+  getSessionCredentialSource: vi.fn(() => undefined),
   getSessionCredentialNetwork: vi.fn(() => undefined),
-  wasSessionSkippedForViewAddress: () => false,
+  wasSessionSkippedForViewAddress: vi.fn(() => false),
 }))
 
 describe('parseContextSelectionOptions empty-list regression', () => {
@@ -108,7 +112,7 @@ describe('assertOwnerAuth', () => {
 
 describe('parseCLIAuth session line', () => {
   const sessionOptions = {
-    walletAddress: '0xffd6000000000000000000000000000000000666E',
+    walletAddress: '0xffd6000000000000000000000000000000000666',
     sessionKey: `0x${'11'.repeat(32)}`,
   }
 
@@ -118,6 +122,9 @@ describe('parseCLIAuth session line', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.mocked(getSessionCredentialSource).mockReset()
+    vi.mocked(getSessionCredentialNetwork).mockReset()
+    vi.mocked(wasSessionSkippedForViewAddress).mockReset()
   })
 
   const lines = () =>
@@ -129,25 +136,41 @@ describe('parseCLIAuth session line', () => {
   it('names the session and owner when a session credential is used', () => {
     parseCLIAuth(sessionOptions)
     expect(lines()).toContain('Using session')
-    expect(lines()).toContain('666E')
+    expect(lines()).toContain('0666')
     expect(lines()).not.toContain('(from ')
   })
 
-  it('names the saved login network and warns when the command runs on another', () => {
+  it('names the file the credentials came from when auto-loaded', () => {
+    vi.mocked(getSessionCredentialSource).mockReturnValue('/data/session.env')
+    parseCLIAuth(sessionOptions)
+    expect(lines()).toContain('(from /data/session.env)')
+  })
+
+  it('names the saved login network', () => {
     vi.mocked(getSessionCredentialNetwork).mockReturnValue('calibration')
     parseCLIAuth({ ...sessionOptions, network: 'calibration' })
     expect(lines()).toContain('calibration')
     expect(lines()).not.toContain('saved login is for')
+  })
 
-    vi.mocked(log.line).mockClear()
+  it('warns when the command runs on a network other than the saved login', () => {
+    vi.mocked(getSessionCredentialNetwork).mockReturnValue('calibration')
     parseCLIAuth({ ...sessionOptions, network: 'mainnet' })
     expect(lines()).toContain('saved login is for calibration')
     expect(lines()).toContain('mainnet')
   })
 
-  it('stays quiet for private-key and view-only auth', () => {
-    parseCLIAuth({ privateKey: `0x${'11'.repeat(32)}` })
+  it('says when VIEW_ADDRESS kept a saved login out', () => {
+    vi.mocked(wasSessionSkippedForViewAddress).mockReturnValue(true)
     parseCLIAuth({ viewAddress: '0x0000000000000000000000000000000000000002' })
+    expect(lines()).toContain('Saved login ignored')
+  })
+
+  it.each([
+    ['a private key', { privateKey: `0x${'11'.repeat(32)}` }],
+    ['a view-only address', { viewAddress: '0x0000000000000000000000000000000000000002' }],
+  ])('stays quiet for %s', (_label, options) => {
+    parseCLIAuth(options)
     expect(lines()).toBe('')
   })
 })

--- a/src/test/unit/cli-validation.test.ts
+++ b/src/test/unit/cli-validation.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { assertOwnerAuth, parseCLIAuth, parseContextSelectionOptions } from '../../utils/cli-auth.js'
 import { log } from '../../utils/cli-logger.js'
+import { getSessionCredentialNetwork } from '../../utils/credential-source.js'
+
+vi.mock('../../utils/credential-source.js', () => ({
+  getSessionCredentialSource: () => undefined,
+  getSessionCredentialNetwork: vi.fn(() => undefined),
+  wasSessionSkippedForViewAddress: () => false,
+}))
 
 describe('parseContextSelectionOptions empty-list regression', () => {
   const originalEnv = { ...process.env }
@@ -121,8 +128,21 @@ describe('parseCLIAuth session line', () => {
 
   it('names the session and owner when a session credential is used', () => {
     parseCLIAuth(sessionOptions)
-    expect(lines()).toMatch(/Using session 0x[0-9a-fA-F]{4}…[0-9a-fA-F]{4} · owner 0xffd6…666E/)
+    expect(lines()).toContain('Using session')
+    expect(lines()).toContain('666E')
     expect(lines()).not.toContain('(from ')
+  })
+
+  it('names the saved login network and warns when the command runs on another', () => {
+    vi.mocked(getSessionCredentialNetwork).mockReturnValue('calibration')
+    parseCLIAuth({ ...sessionOptions, network: 'calibration' })
+    expect(lines()).toContain('calibration')
+    expect(lines()).not.toContain('saved login is for')
+
+    vi.mocked(log.line).mockClear()
+    parseCLIAuth({ ...sessionOptions, network: 'mainnet' })
+    expect(lines()).toContain('saved login is for calibration')
+    expect(lines()).toContain('mainnet')
   })
 
   it('stays quiet for private-key and view-only auth', () => {

--- a/src/test/unit/cli-validation.test.ts
+++ b/src/test/unit/cli-validation.test.ts
@@ -169,6 +169,7 @@ describe('parseCLIAuth session line', () => {
   it.each([
     ['a private key', { privateKey: `0x${'11'.repeat(32)}` }],
     ['a view-only address', { viewAddress: '0x0000000000000000000000000000000000000002' }],
+    ['a malformed session key', { ...sessionOptions, sessionKey: '0xnothex' }],
   ])('stays quiet for %s', (_label, options) => {
     parseCLIAuth(options)
     expect(lines()).toBe('')

--- a/src/test/unit/credential-precedence.test.ts
+++ b/src/test/unit/credential-precedence.test.ts
@@ -29,7 +29,7 @@ import { serverCommand } from '../../commands/server.js'
 import { writeSessionFile } from '../../login/session-file.js'
 import { type CLIAuthOptions, parseCLIAuth } from '../../utils/cli-auth.js'
 import { log } from '../../utils/cli-logger.js'
-import { addAuthOptions, credentialsFileOption } from '../../utils/cli-options.js'
+import { addAuthOptions, addAutoFundOptions, credentialsFileOption } from '../../utils/cli-options.js'
 import { applySessionFileCredentials, getSessionCredentialSource } from '../../utils/credential-source.js'
 import { applyCredentialsFile } from '../../utils/credentials-file.js'
 
@@ -78,7 +78,7 @@ async function run(args: string[]): Promise<ReturnType<typeof parseCLIAuth>> {
     .action((_file, options: CLIAuthOptions) => {
       resolved = parseCLIAuth(options)
     })
-  addAuthOptions(add)
+  addAutoFundOptions(addAuthOptions(add))
   program.addCommand(add)
   await program.parseAsync(['add', 'f', ...args], { from: 'user' })
   if (resolved === undefined) throw new Error('action did not run')
@@ -137,6 +137,13 @@ describe('credential precedence, end to end', () => {
     saveLogin()
     expect(await run(['--private-key', FLAG_KEY])).toMatchObject({ privateKey: FLAG_KEY })
     expect(getSessionCredentialSource()).toBeUndefined()
+  })
+
+  it('a file value still trips the conflicts Commander checked before the hook ran', async () => {
+    const file = writeCredentials([`VIEW_ADDRESS=${FILE_OWNER}`])
+    await expect(run(['--credentials-file', file, '--auto-fund'])).rejects.toThrow(
+      "option '--auto-fund' cannot be used with VIEW_ADDRESS from the credentials file"
+    )
   })
 
   it('VIEW_ADDRESS in the environment forces read-only and skips the saved login', async () => {

--- a/src/test/unit/credential-precedence.test.ts
+++ b/src/test/unit/credential-precedence.test.ts
@@ -1,0 +1,213 @@
+/**
+ * The documented credential order, end to end: flags, then env vars, then
+ * --credentials-file, then the saved login. Drives a real Commander program
+ * wired like src/cli.ts (root credentials-file hook, addAuthOptions on the
+ * subcommand), with real files on disk, and asserts which mode parseCLIAuth
+ * picks and which network survives. Every layer here must beat the one
+ * below it and never conflict with the one above it.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Command } from 'commander'
+import { privateKeyToAccount } from 'viem/accounts'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../utils/cli-logger.js', () => ({
+  isTTY: vi.fn(() => true),
+  log: { warn: vi.fn(), line: vi.fn(), flush: vi.fn(), indent: vi.fn() },
+}))
+
+const state = vi.hoisted(() => ({ sessionPath: '' }))
+vi.mock('../../login/session-file.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../login/session-file.js')>()
+  return { ...actual, getSessionFilePath: () => state.sessionPath }
+})
+
+import { loginCommand, logoutCommand } from '../../commands/login.js'
+import { serverCommand } from '../../commands/server.js'
+import { writeSessionFile } from '../../login/session-file.js'
+import { type CLIAuthOptions, parseCLIAuth } from '../../utils/cli-auth.js'
+import { log } from '../../utils/cli-logger.js'
+import { addAuthOptions, credentialsFileOption } from '../../utils/cli-options.js'
+import { applySessionFileCredentials, getSessionCredentialSource } from '../../utils/credential-source.js'
+import { applyCredentialsFile } from '../../utils/credentials-file.js'
+
+const FLAG_KEY = `0x${'11'.repeat(32)}`
+const ENV_KEY = `0x${'22'.repeat(32)}`
+const FILE_KEY = `0x${'33'.repeat(32)}`
+const SAVED_KEY = `0x${'44'.repeat(32)}` as const
+const FILE_OWNER = '0x00000000000000000000000000000000000000f1'
+const SAVED_OWNER = '0x00000000000000000000000000000000000000a1' as const
+const AUTH_ENV = ['PRIVATE_KEY', 'SESSION_KEY', 'WALLET_ADDRESS', 'VIEW_ADDRESS', 'NETWORK', 'RPC_URL', 'CI']
+
+let dir: string
+let credentialsPath: string
+const saved: Record<string, string | undefined> = {}
+
+function setEnv(env: Record<string, string>): void {
+  for (const name of AUTH_ENV) delete process.env[name]
+  Object.assign(process.env, env)
+}
+
+function saveLogin(network = 'calibration'): void {
+  writeSessionFile(
+    {
+      sessionKey: SAVED_KEY,
+      sessionAddress: privateKeyToAccount(SAVED_KEY).address,
+      walletAddress: SAVED_OWNER,
+      network,
+    },
+    state.sessionPath
+  )
+}
+
+function writeCredentials(lines: string[]): string {
+  writeFileSync(credentialsPath, `${lines.join('\n')}\n`)
+  return credentialsPath
+}
+
+/** Run `add` through a program wired like cli.ts and return what parseCLIAuth resolved. */
+async function run(args: string[]): Promise<ReturnType<typeof parseCLIAuth>> {
+  let resolved: ReturnType<typeof parseCLIAuth> | undefined
+  const program = new Command().exitOverride().addOption(credentialsFileOption())
+  program.hook('preAction', (_thisCommand, actionCommand) => applyCredentialsFile(actionCommand))
+  const add = new Command('add')
+    .exitOverride()
+    .argument('<file>')
+    .action((_file, options: CLIAuthOptions) => {
+      resolved = parseCLIAuth(options)
+    })
+  addAuthOptions(add)
+  program.addCommand(add)
+  await program.parseAsync(['add', 'f', ...args], { from: 'user' })
+  if (resolved === undefined) throw new Error('action did not run')
+  return resolved
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'credential-precedence-'))
+  credentialsPath = join(dir, 'credentials.env')
+  state.sessionPath = join(dir, 'session.env')
+  for (const name of AUTH_ENV) saved[name] = process.env[name]
+  setEnv({})
+})
+
+afterEach(() => {
+  for (const name of AUTH_ENV) {
+    if (saved[name] === undefined) delete process.env[name]
+    else process.env[name] = saved[name]
+  }
+  rmSync(dir, { recursive: true, force: true })
+  vi.clearAllMocks()
+})
+
+describe('credential precedence, end to end', () => {
+  it('the environment beats the credentials file, even across auth modes', async () => {
+    setEnv({ PRIVATE_KEY: ENV_KEY })
+    const file = writeCredentials([`SESSION_KEY=${FILE_KEY}`, `WALLET_ADDRESS=${FILE_OWNER}`])
+    const config = await run(['--credentials-file', file])
+    expect(config).toMatchObject({ privateKey: ENV_KEY })
+    expect(config).not.toHaveProperty('sessionKey')
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('ignoring --wallet-address/--session-key'))
+  })
+
+  it('the credentials file beats the saved login', async () => {
+    saveLogin()
+    const file = writeCredentials([`SESSION_KEY=${FILE_KEY}`, `WALLET_ADDRESS=${FILE_OWNER}`])
+    const config = await run(['--credentials-file', file])
+    expect(config).toMatchObject({ sessionKey: FILE_KEY, walletAddress: FILE_OWNER })
+    expect(getSessionCredentialSource()).toBeUndefined()
+  })
+
+  it('the credentials file fills in only what the environment left unset', async () => {
+    setEnv({ WALLET_ADDRESS: SAVED_OWNER })
+    const file = writeCredentials([`SESSION_KEY=${FILE_KEY}`, `WALLET_ADDRESS=${FILE_OWNER}`])
+    expect(await run(['--credentials-file', file])).toMatchObject({ sessionKey: FILE_KEY, walletAddress: SAVED_OWNER })
+  })
+
+  it('the saved login is used when nothing else supplies a credential', async () => {
+    saveLogin()
+    const config = await run([])
+    expect(config).toMatchObject({ sessionKey: SAVED_KEY, walletAddress: SAVED_OWNER })
+    expect(getSessionCredentialSource()).toBe(state.sessionPath)
+  })
+
+  it('a flag beats the saved login', async () => {
+    saveLogin()
+    expect(await run(['--private-key', FLAG_KEY])).toMatchObject({ privateKey: FLAG_KEY })
+    expect(getSessionCredentialSource()).toBeUndefined()
+  })
+
+  it('VIEW_ADDRESS in the environment forces read-only and skips the saved login', async () => {
+    saveLogin()
+    setEnv({ VIEW_ADDRESS: FILE_OWNER })
+    expect(await run([])).toMatchObject({ readOnly: true, walletAddress: FILE_OWNER })
+    expect(log.line).toHaveBeenCalledWith(expect.stringContaining('Saved login ignored because VIEW_ADDRESS is set'))
+  })
+})
+
+describe('network precedence with a saved login', () => {
+  it("applies the login's network when nothing chose one", async () => {
+    saveLogin('calibration')
+    const config = await run([])
+    expect(config.chain?.id).toBe(314159)
+    expect(process.env.NETWORK).toBe('calibration')
+  })
+
+  it('RPC_URL in the environment wins without a conflict', async () => {
+    saveLogin('calibration')
+    setEnv({ RPC_URL: 'http://rpc.example' })
+    const config = await run([])
+    expect(config).toMatchObject({ sessionKey: SAVED_KEY, rpcUrl: 'http://rpc.example' })
+    expect(config.chain).toBeUndefined()
+    expect(process.env.NETWORK).toBeUndefined()
+  })
+
+  it('--rpc-url wins without a conflict', async () => {
+    saveLogin('calibration')
+    const config = await run(['--rpc-url', 'http://rpc.example'])
+    expect(config).toMatchObject({ rpcUrl: 'http://rpc.example' })
+    expect(process.env.NETWORK).toBeUndefined()
+  })
+
+  it('NETWORK in the environment wins over the saved network', async () => {
+    saveLogin('calibration')
+    setEnv({ NETWORK: 'mainnet' })
+    expect((await run([])).chain?.id).toBe(314)
+  })
+
+  it('RPC_URL in the environment wins over NETWORK in the credentials file', async () => {
+    setEnv({ RPC_URL: 'http://rpc.example' })
+    const file = writeCredentials([`PRIVATE_KEY=${FILE_KEY}`, 'NETWORK=calibration'])
+    const config = await run(['--credentials-file', file])
+    expect(config).toMatchObject({ privateKey: FILE_KEY, rpcUrl: 'http://rpc.example' })
+    expect(process.env.NETWORK).toBeUndefined()
+  })
+})
+
+describe('session loading is structural', () => {
+  it.each([
+    ['login', loginCommand],
+    ['logout', logoutCommand],
+    ['server', serverCommand],
+  ])('never loads the saved login for the real %s command', async (_name, command) => {
+    saveLogin()
+    // The real action would open a browser or start the daemon; swap it for a
+    // no-op so only the option wiring and hooks run.
+    command.action(() => undefined).exitOverride()
+    const program = new Command().exitOverride().addCommand(command)
+    await program.parseAsync([command.name()], { from: 'user' })
+    expect(command.getOptionValue('sessionKey')).toBeUndefined()
+    expect(process.env.SESSION_KEY).toBeUndefined()
+    expect(getSessionCredentialSource()).toBeUndefined()
+  })
+
+  it('can be invoked directly for a command that declares the options', () => {
+    saveLogin()
+    const command = addAuthOptions(new Command('add').exitOverride())
+    command.parse([], { from: 'user' })
+    expect(applySessionFileCredentials(command)).toBe(state.sessionPath)
+    expect(command.getOptionValueSource('sessionKey')).toBe('session')
+  })
+})

--- a/src/test/unit/credential-source.test.ts
+++ b/src/test/unit/credential-source.test.ts
@@ -50,8 +50,18 @@ describe('applySessionFileCredentials', () => {
       ['node', 'cli.js', 'add', '--session-key', '0xflag', '--wallet-address', '0xflag', 'f'],
       ['node', 'cli.js', 'add', '--view-address', '0xflag', 'f'],
     ]) {
+      for (const preset of [{}, { PRIVATE_KEY: '0xenv' }]) {
+        const env: NodeJS.ProcessEnv = { ...preset }
+        expect(applySessionFileCredentials(argv, env, path)).toBeUndefined()
+        expect(env).toEqual(preset)
+      }
+    }
+  })
+
+  it('never loads for login, logout, or server', () => {
+    for (const command of ['login', 'logout', 'server']) {
       const env: NodeJS.ProcessEnv = {}
-      expect(applySessionFileCredentials(argv, env, path)).toBeUndefined()
+      expect(applySessionFileCredentials(['node', 'cli.js', '--verbose', command], env, path)).toBeUndefined()
       expect(env).toEqual({})
     }
   })

--- a/src/test/unit/credential-source.test.ts
+++ b/src/test/unit/credential-source.test.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { writeSessionFile } from '../../login/session-file.js'
+import { applySessionFileCredentials } from '../../utils/credential-source.js'
+
+const KEY = `0x${'ab'.repeat(32)}` as const
+const SESSION = '0x00000000000000000000000000000000000000bb'
+const OWNER = '0x00000000000000000000000000000000000000aa'
+const ARGV = ['node', 'cli.js', 'add', 'file.txt']
+
+describe('applySessionFileCredentials', () => {
+  let dir: string
+  let path: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'credential-source-'))
+    path = join(dir, 'session.env')
+    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION, walletAddress: OWNER }, path)
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('loads the session file when nothing else supplies a credential', () => {
+    const env: NodeJS.ProcessEnv = {}
+    expect(applySessionFileCredentials(ARGV, env, path)).toBe(path)
+    expect(env).toEqual({ SESSION_KEY: KEY, WALLET_ADDRESS: OWNER })
+  })
+
+  it('env vars beat the file', () => {
+    for (const preset of [
+      { PRIVATE_KEY: '0xenv' },
+      { SESSION_KEY: '0xenv', WALLET_ADDRESS: '0xenv' },
+      { SESSION_KEY: '0xenv' },
+      { VIEW_ADDRESS: '0xenv' },
+    ]) {
+      const env: NodeJS.ProcessEnv = { ...preset }
+      expect(applySessionFileCredentials(ARGV, env, path)).toBeUndefined()
+      expect(env).toEqual(preset)
+    }
+  })
+
+  it('flags beat both the env and the file', () => {
+    for (const argv of [
+      ['node', 'cli.js', 'add', '--private-key', '0xflag', 'f'],
+      ['node', 'cli.js', 'add', '--private-key=0xflag', 'f'],
+      ['node', 'cli.js', 'add', '--session-key', '0xflag', '--wallet-address', '0xflag', 'f'],
+      ['node', 'cli.js', 'add', '--view-address', '0xflag', 'f'],
+    ]) {
+      const env: NodeJS.ProcessEnv = {}
+      expect(applySessionFileCredentials(argv, env, path)).toBeUndefined()
+      expect(env).toEqual({})
+    }
+  })
+
+  it('ignores a file whose login never completed (no owner yet)', () => {
+    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)
+    const env: NodeJS.ProcessEnv = {}
+    expect(applySessionFileCredentials(ARGV, env, path)).toBeUndefined()
+    expect(env).toEqual({})
+  })
+
+  it('is a no-op without a file', () => {
+    const env: NodeJS.ProcessEnv = {}
+    expect(applySessionFileCredentials(ARGV, env, join(dir, 'missing.env'))).toBeUndefined()
+    expect(env).toEqual({})
+  })
+})

--- a/src/test/unit/credential-source.test.ts
+++ b/src/test/unit/credential-source.test.ts
@@ -1,5 +1,7 @@
+import { Command } from 'commander'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { readSessionFile } from '../../login/session-file.js'
+import { addAuthOptions } from '../../utils/cli-options.js'
 import {
   applySessionFileCredentials,
   getSessionCredentialNetwork,
@@ -16,7 +18,6 @@ const KEY = `0x${'ab'.repeat(32)}` as const
 const SESSION = '0x00000000000000000000000000000000000000bb' as const
 const OWNER = '0x00000000000000000000000000000000000000aa' as const
 const PATH = 'session.env'
-const ARGV = ['node', 'cli.js', 'add', 'file.txt']
 const AUTHORIZED = { sessionKey: KEY, sessionAddress: SESSION, walletAddress: OWNER }
 
 function savedSession(session: Partial<typeof AUTHORIZED> & { network?: string } = AUTHORIZED) {
@@ -25,6 +26,20 @@ function savedSession(session: Partial<typeof AUTHORIZED> & { network?: string }
 
 function noSession() {
   vi.mocked(readSessionFile).mockReturnValue(undefined)
+}
+
+/** An `add`-like command after Commander parsed `flags`, with env-backed options bound from `env`. */
+function parsed(flags: string[] = [], env: NodeJS.ProcessEnv = {}): Command {
+  const command = addAuthOptions(new Command('add').exitOverride())
+  const previous = { ...process.env }
+  Object.assign(process.env, env)
+  try {
+    command.parse(flags, { from: 'user' })
+  } finally {
+    for (const name of Object.keys(env)) delete process.env[name]
+    Object.assign(process.env, previous)
+  }
+  return command
 }
 
 describe('applySessionFileCredentials', () => {
@@ -36,8 +51,11 @@ describe('applySessionFileCredentials', () => {
   it('loads the session file when nothing else supplies a credential', () => {
     savedSession()
     const env: NodeJS.ProcessEnv = {}
-    expect(applySessionFileCredentials(ARGV, env, PATH)).toBe(PATH)
+    const command = parsed()
+    expect(applySessionFileCredentials(command, env, PATH)).toBe(PATH)
     expect(env).toEqual({ SESSION_KEY: KEY, WALLET_ADDRESS: OWNER })
+    expect(command.opts()).toMatchObject({ sessionKey: KEY, walletAddress: OWNER })
+    expect(command.getOptionValueSource('sessionKey')).toBe('session')
     expect(getSessionCredentialSource()).toBe(PATH)
   })
 
@@ -49,7 +67,7 @@ describe('applySessionFileCredentials', () => {
   ])('env %o beats the file', (preset) => {
     savedSession()
     const env: NodeJS.ProcessEnv = { ...preset }
-    expect(applySessionFileCredentials(ARGV, env, PATH)).toBeUndefined()
+    expect(applySessionFileCredentials(parsed([], env), env, PATH)).toBeUndefined()
     expect(env).toEqual(preset)
   })
 
@@ -61,95 +79,89 @@ describe('applySessionFileCredentials', () => {
   ])('flags %j beat the env and the file', (flags, preset) => {
     savedSession()
     const env: NodeJS.ProcessEnv = { ...preset }
-    expect(applySessionFileCredentials(['node', 'cli.js', 'add', ...flags, 'f'], env, PATH)).toBeUndefined()
+    expect(applySessionFileCredentials(parsed(flags, env), env, PATH)).toBeUndefined()
     expect(env).toEqual(preset)
-  })
-
-  it.each(['login', 'logout', 'dashboard', 'server'])('never loads for %s', (command) => {
-    savedSession()
-    const env: NodeJS.ProcessEnv = {}
-    expect(applySessionFileCredentials(['node', 'cli.js', '--verbose', command], env, PATH)).toBeUndefined()
-    expect(env).toEqual({})
-  })
-
-  it('still sees the command when --credentials-file <path> comes first', () => {
-    savedSession()
-    const env: NodeJS.ProcessEnv = {}
-    const argv = ['node', 'cli.js', '--credentials-file', 'creds.env', 'server']
-    expect(applySessionFileCredentials(argv, env, PATH)).toBeUndefined()
-    expect(env).toEqual({})
   })
 
   it('ignores a file whose login never completed (no owner yet)', () => {
     savedSession({ sessionKey: KEY, sessionAddress: SESSION })
     const env: NodeJS.ProcessEnv = {}
-    expect(applySessionFileCredentials(ARGV, env, PATH)).toBeUndefined()
+    expect(applySessionFileCredentials(parsed(), env, PATH)).toBeUndefined()
     expect(env).toEqual({})
   })
 
   it('exports the saved network when nothing chose one', () => {
     savedSession({ ...AUTHORIZED, network: 'calibration' })
     const env: NodeJS.ProcessEnv = {}
-    applySessionFileCredentials(ARGV, env, PATH)
+    const command = parsed()
+    applySessionFileCredentials(command, env, PATH)
     expect(env.NETWORK).toBe('calibration')
+    expect(command.opts().network).toBe('calibration')
     expect(getSessionCredentialNetwork()).toBe('calibration')
   })
 
   it.each([
-    ['NETWORK in the env', ARGV, { NETWORK: 'mainnet' }, 'mainnet'],
-    ['--network with a space', [...ARGV, '--network', 'mainnet'], {}, undefined],
-    ['--network with an equals sign', [...ARGV, '--network=mainnet'], {}, undefined],
-    ['--rpc-url', [...ARGV, '--rpc-url', 'http://rpc'], {}, undefined],
-  ])('does not export the saved network over %s', (_label, argv, preset, expected) => {
+    ['NETWORK in the env', [], { NETWORK: 'mainnet' }, 'mainnet'],
+    ['RPC_URL in the env', [], { RPC_URL: 'http://rpc' }, undefined],
+    ['--network with a space', ['--network', 'mainnet'], {}, undefined],
+    ['--network with an equals sign', ['--network=mainnet'], {}, undefined],
+    ['--rpc-url', ['--rpc-url', 'http://rpc'], {}, undefined],
+  ])('does not export the saved network over %s', (_label, flags, preset, expected) => {
     savedSession({ ...AUTHORIZED, network: 'calibration' })
     const env: NodeJS.ProcessEnv = { ...preset }
-    applySessionFileCredentials(argv, env, PATH)
+    const command = parsed(flags, env)
+    applySessionFileCredentials(command, env, PATH)
     expect(env.NETWORK).toBe(expected)
+    expect(command.getOptionValueSource('network')).not.toBe('session')
     expect(env.SESSION_KEY).toBe(KEY)
   })
 
   it('records when only VIEW_ADDRESS kept a usable login out', () => {
     savedSession()
-    expect(applySessionFileCredentials(ARGV, { VIEW_ADDRESS: OWNER }, PATH)).toBeUndefined()
+    const env = { VIEW_ADDRESS: OWNER }
+    expect(applySessionFileCredentials(parsed([], env), env, PATH)).toBeUndefined()
     expect(wasSessionSkippedForViewAddress()).toBe(true)
   })
 
   it('does not blame VIEW_ADDRESS when another credential is also set', () => {
     savedSession()
-    applySessionFileCredentials(ARGV, { VIEW_ADDRESS: OWNER, PRIVATE_KEY: '0xenv' }, PATH)
+    const env = { VIEW_ADDRESS: OWNER, PRIVATE_KEY: '0xenv' }
+    applySessionFileCredentials(parsed([], env), env, PATH)
     expect(wasSessionSkippedForViewAddress()).toBe(false)
   })
 
   it('does not blame VIEW_ADDRESS when there is no session file', () => {
     noSession()
-    applySessionFileCredentials(ARGV, { VIEW_ADDRESS: OWNER }, PATH)
+    const env = { VIEW_ADDRESS: OWNER }
+    applySessionFileCredentials(parsed([], env), env, PATH)
     expect(wasSessionSkippedForViewAddress()).toBe(false)
   })
 
   it('does not blame VIEW_ADDRESS when the session file has no owner yet', () => {
     savedSession({ sessionKey: KEY, sessionAddress: SESSION })
-    applySessionFileCredentials(ARGV, { VIEW_ADDRESS: OWNER }, PATH)
+    const env = { VIEW_ADDRESS: OWNER }
+    applySessionFileCredentials(parsed([], env), env, PATH)
     expect(wasSessionSkippedForViewAddress()).toBe(false)
   })
 
   it('warns when CI is set and the saved login was used', () => {
     savedSession()
     const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    applySessionFileCredentials(ARGV, { CI: 'true' }, PATH)
+    applySessionFileCredentials(parsed(), { CI: 'true' }, PATH)
     expect(errors).toHaveBeenCalledWith(expect.stringContaining('CI is set and credentials came from the saved login'))
   })
 
   it('stays quiet outside CI', () => {
     savedSession()
     const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    applySessionFileCredentials(ARGV, {}, PATH)
+    applySessionFileCredentials(parsed(), {}, PATH)
     expect(errors).not.toHaveBeenCalled()
   })
 
   it('is a no-op without a file', () => {
     noSession()
     const env: NodeJS.ProcessEnv = {}
-    expect(applySessionFileCredentials(ARGV, env, PATH)).toBeUndefined()
+    expect(applySessionFileCredentials(parsed(), env, PATH)).toBeUndefined()
     expect(env).toEqual({})
   })
 })

--- a/src/test/unit/credential-source.test.ts
+++ b/src/test/unit/credential-source.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { readSessionFile } from '../../login/session-file.js'
-import { applySessionFileCredentials, wasSessionSkippedForViewAddress } from '../../utils/credential-source.js'
+import {
+  applySessionFileCredentials,
+  getSessionCredentialNetwork,
+  getSessionCredentialSource,
+  wasSessionSkippedForViewAddress,
+} from '../../utils/credential-source.js'
 
 vi.mock('../../login/session-file.js', () => ({
   readSessionFile: vi.fn(),
@@ -24,6 +29,7 @@ function noSession() {
 
 describe('applySessionFileCredentials', () => {
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.mocked(readSessionFile).mockReset()
   })
 
@@ -32,6 +38,7 @@ describe('applySessionFileCredentials', () => {
     const env: NodeJS.ProcessEnv = {}
     expect(applySessionFileCredentials(ARGV, env, PATH)).toBe(PATH)
     expect(env).toEqual({ SESSION_KEY: KEY, WALLET_ADDRESS: OWNER })
+    expect(getSessionCredentialSource()).toBe(PATH)
   })
 
   it.each([
@@ -85,6 +92,7 @@ describe('applySessionFileCredentials', () => {
     const env: NodeJS.ProcessEnv = {}
     applySessionFileCredentials(ARGV, env, PATH)
     expect(env.NETWORK).toBe('calibration')
+    expect(getSessionCredentialNetwork()).toBe('calibration')
   })
 
   it.each([
@@ -112,12 +120,23 @@ describe('applySessionFileCredentials', () => {
     expect(wasSessionSkippedForViewAddress()).toBe(false)
   })
 
+  it('does not blame VIEW_ADDRESS when there is no session file', () => {
+    noSession()
+    applySessionFileCredentials(ARGV, { VIEW_ADDRESS: OWNER }, PATH)
+    expect(wasSessionSkippedForViewAddress()).toBe(false)
+  })
+
+  it('does not blame VIEW_ADDRESS when the session file has no owner yet', () => {
+    savedSession({ sessionKey: KEY, sessionAddress: SESSION })
+    applySessionFileCredentials(ARGV, { VIEW_ADDRESS: OWNER }, PATH)
+    expect(wasSessionSkippedForViewAddress()).toBe(false)
+  })
+
   it('warns when CI is set and the saved login was used', () => {
     savedSession()
     const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     applySessionFileCredentials(ARGV, { CI: 'true' }, PATH)
     expect(errors).toHaveBeenCalledWith(expect.stringContaining('CI is set and credentials came from the saved login'))
-    errors.mockRestore()
   })
 
   it('stays quiet outside CI', () => {
@@ -125,7 +144,6 @@ describe('applySessionFileCredentials', () => {
     const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     applySessionFileCredentials(ARGV, {}, PATH)
     expect(errors).not.toHaveBeenCalled()
-    errors.mockRestore()
   })
 
   it('is a no-op without a file', () => {

--- a/src/test/unit/credential-source.test.ts
+++ b/src/test/unit/credential-source.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { writeSessionFile } from '../../login/session-file.js'
-import { applySessionFileCredentials } from '../../utils/credential-source.js'
+import { applySessionFileCredentials, wasSessionSkippedForViewAddress } from '../../utils/credential-source.js'
 
 const KEY = `0x${'ab'.repeat(32)}` as const
 const SESSION = '0x00000000000000000000000000000000000000bb'
@@ -71,6 +71,30 @@ describe('applySessionFileCredentials', () => {
     const env: NodeJS.ProcessEnv = {}
     expect(applySessionFileCredentials(ARGV, env, path)).toBeUndefined()
     expect(env).toEqual({})
+  })
+
+  it('exports the saved network unless a flag or the env already chose one', () => {
+    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION, walletAddress: OWNER, network: 'calibration' }, path)
+    const env: NodeJS.ProcessEnv = {}
+    applySessionFileCredentials(ARGV, env, path)
+    expect(env.NETWORK).toBe('calibration')
+
+    const preset: NodeJS.ProcessEnv = { NETWORK: 'mainnet' }
+    applySessionFileCredentials(ARGV, preset, path)
+    expect(preset.NETWORK).toBe('mainnet')
+
+    const flagged: NodeJS.ProcessEnv = {}
+    applySessionFileCredentials([...ARGV, '--network', 'mainnet'], flagged, path)
+    expect(flagged.NETWORK).toBeUndefined()
+    expect(flagged.SESSION_KEY).toBe(KEY)
+  })
+
+  it('records when only VIEW_ADDRESS kept a usable login out', () => {
+    const env: NodeJS.ProcessEnv = { VIEW_ADDRESS: OWNER }
+    expect(applySessionFileCredentials(ARGV, env, path)).toBeUndefined()
+    expect(wasSessionSkippedForViewAddress()).toBe(true)
+    applySessionFileCredentials(ARGV, { VIEW_ADDRESS: OWNER, PRIVATE_KEY: '0xenv' }, path)
+    expect(wasSessionSkippedForViewAddress()).toBe(false)
   })
 
   it('is a no-op without a file', () => {

--- a/src/test/unit/credential-source.test.ts
+++ b/src/test/unit/credential-source.test.ts
@@ -1,115 +1,129 @@
-import { mkdtempSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { writeSessionFile } from '../../login/session-file.js'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readSessionFile } from '../../login/session-file.js'
 import { applySessionFileCredentials, wasSessionSkippedForViewAddress } from '../../utils/credential-source.js'
 
+vi.mock('../../login/session-file.js', () => ({
+  readSessionFile: vi.fn(),
+  getSessionFilePath: () => 'session.env',
+}))
+
 const KEY = `0x${'ab'.repeat(32)}` as const
-const SESSION = '0x00000000000000000000000000000000000000bb'
-const OWNER = '0x00000000000000000000000000000000000000aa'
+const SESSION = '0x00000000000000000000000000000000000000bb' as const
+const OWNER = '0x00000000000000000000000000000000000000aa' as const
+const PATH = 'session.env'
 const ARGV = ['node', 'cli.js', 'add', 'file.txt']
+const AUTHORIZED = { sessionKey: KEY, sessionAddress: SESSION, walletAddress: OWNER }
+
+function savedSession(session: Partial<typeof AUTHORIZED> & { network?: string } = AUTHORIZED) {
+  vi.mocked(readSessionFile).mockReturnValue(session as ReturnType<typeof readSessionFile>)
+}
+
+function noSession() {
+  vi.mocked(readSessionFile).mockReturnValue(undefined)
+}
 
 describe('applySessionFileCredentials', () => {
-  let dir: string
-  let path: string
-
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), 'credential-source-'))
-    path = join(dir, 'session.env')
-    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION, walletAddress: OWNER }, path)
-  })
-
   afterEach(() => {
-    rmSync(dir, { recursive: true, force: true })
+    vi.mocked(readSessionFile).mockReset()
   })
 
   it('loads the session file when nothing else supplies a credential', () => {
+    savedSession()
     const env: NodeJS.ProcessEnv = {}
-    expect(applySessionFileCredentials(ARGV, env, path)).toBe(path)
+    expect(applySessionFileCredentials(ARGV, env, PATH)).toBe(PATH)
     expect(env).toEqual({ SESSION_KEY: KEY, WALLET_ADDRESS: OWNER })
   })
 
-  it('env vars beat the file', () => {
-    for (const preset of [
-      { PRIVATE_KEY: '0xenv' },
-      { SESSION_KEY: '0xenv', WALLET_ADDRESS: '0xenv' },
-      { SESSION_KEY: '0xenv' },
-      { VIEW_ADDRESS: '0xenv' },
-    ]) {
-      const env: NodeJS.ProcessEnv = { ...preset }
-      expect(applySessionFileCredentials(ARGV, env, path)).toBeUndefined()
-      expect(env).toEqual(preset)
-    }
+  it.each([
+    [{ PRIVATE_KEY: '0xenv' }],
+    [{ SESSION_KEY: '0xenv', WALLET_ADDRESS: '0xenv' }],
+    [{ SESSION_KEY: '0xenv' }],
+    [{ VIEW_ADDRESS: '0xenv' }],
+  ])('env %o beats the file', (preset) => {
+    savedSession()
+    const env: NodeJS.ProcessEnv = { ...preset }
+    expect(applySessionFileCredentials(ARGV, env, PATH)).toBeUndefined()
+    expect(env).toEqual(preset)
   })
 
-  it('flags beat both the env and the file', () => {
-    for (const argv of [
-      ['node', 'cli.js', 'add', '--private-key', '0xflag', 'f'],
-      ['node', 'cli.js', 'add', '--private-key=0xflag', 'f'],
-      ['node', 'cli.js', 'add', '--session-key', '0xflag', '--wallet-address', '0xflag', 'f'],
-      ['node', 'cli.js', 'add', '--view-address', '0xflag', 'f'],
-    ]) {
-      for (const preset of [{}, { PRIVATE_KEY: '0xenv' }]) {
-        const env: NodeJS.ProcessEnv = { ...preset }
-        expect(applySessionFileCredentials(argv, env, path)).toBeUndefined()
-        expect(env).toEqual(preset)
-      }
-    }
+  it.each([
+    [['--private-key', '0xflag'], {}],
+    [['--private-key=0xflag'], { PRIVATE_KEY: '0xenv' }],
+    [['--session-key', '0xflag', '--wallet-address', '0xflag'], {}],
+    [['--view-address', '0xflag'], {}],
+  ])('flags %j beat the env and the file', (flags, preset) => {
+    savedSession()
+    const env: NodeJS.ProcessEnv = { ...preset }
+    expect(applySessionFileCredentials(['node', 'cli.js', 'add', ...flags, 'f'], env, PATH)).toBeUndefined()
+    expect(env).toEqual(preset)
   })
 
-  it('never loads for login, logout, dashboard, or server', () => {
-    for (const command of ['login', 'logout', 'dashboard', 'server']) {
-      const env: NodeJS.ProcessEnv = {}
-      expect(applySessionFileCredentials(['node', 'cli.js', '--verbose', command], env, path)).toBeUndefined()
-      expect(env).toEqual({})
-    }
-  })
-
-  it('ignores a file whose login never completed (no owner yet)', () => {
-    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION }, path)
+  it.each(['login', 'logout', 'dashboard', 'server'])('never loads for %s', (command) => {
+    savedSession()
     const env: NodeJS.ProcessEnv = {}
-    expect(applySessionFileCredentials(ARGV, env, path)).toBeUndefined()
+    expect(applySessionFileCredentials(['node', 'cli.js', '--verbose', command], env, PATH)).toBeUndefined()
     expect(env).toEqual({})
   })
 
-  it('exports the saved network unless a flag or the env already chose one', () => {
-    writeSessionFile({ sessionKey: KEY, sessionAddress: SESSION, walletAddress: OWNER, network: 'calibration' }, path)
+  it('ignores a file whose login never completed (no owner yet)', () => {
+    savedSession({ sessionKey: KEY, sessionAddress: SESSION })
     const env: NodeJS.ProcessEnv = {}
-    applySessionFileCredentials(ARGV, env, path)
+    expect(applySessionFileCredentials(ARGV, env, PATH)).toBeUndefined()
+    expect(env).toEqual({})
+  })
+
+  it('exports the saved network when nothing chose one', () => {
+    savedSession({ ...AUTHORIZED, network: 'calibration' })
+    const env: NodeJS.ProcessEnv = {}
+    applySessionFileCredentials(ARGV, env, PATH)
     expect(env.NETWORK).toBe('calibration')
+  })
 
-    const preset: NodeJS.ProcessEnv = { NETWORK: 'mainnet' }
-    applySessionFileCredentials(ARGV, preset, path)
-    expect(preset.NETWORK).toBe('mainnet')
-
-    const flagged: NodeJS.ProcessEnv = {}
-    applySessionFileCredentials([...ARGV, '--network', 'mainnet'], flagged, path)
-    expect(flagged.NETWORK).toBeUndefined()
-    expect(flagged.SESSION_KEY).toBe(KEY)
+  it.each([
+    ['NETWORK in the env', ARGV, { NETWORK: 'mainnet' }, 'mainnet'],
+    ['--network with a space', [...ARGV, '--network', 'mainnet'], {}, undefined],
+    ['--network with an equals sign', [...ARGV, '--network=mainnet'], {}, undefined],
+    ['--rpc-url', [...ARGV, '--rpc-url', 'http://rpc'], {}, undefined],
+  ])('does not export the saved network over %s', (_label, argv, preset, expected) => {
+    savedSession({ ...AUTHORIZED, network: 'calibration' })
+    const env: NodeJS.ProcessEnv = { ...preset }
+    applySessionFileCredentials(argv, env, PATH)
+    expect(env.NETWORK).toBe(expected)
+    expect(env.SESSION_KEY).toBe(KEY)
   })
 
   it('records when only VIEW_ADDRESS kept a usable login out', () => {
-    const env: NodeJS.ProcessEnv = { VIEW_ADDRESS: OWNER }
-    expect(applySessionFileCredentials(ARGV, env, path)).toBeUndefined()
+    savedSession()
+    expect(applySessionFileCredentials(ARGV, { VIEW_ADDRESS: OWNER }, PATH)).toBeUndefined()
     expect(wasSessionSkippedForViewAddress()).toBe(true)
-    applySessionFileCredentials(ARGV, { VIEW_ADDRESS: OWNER, PRIVATE_KEY: '0xenv' }, path)
+  })
+
+  it('does not blame VIEW_ADDRESS when another credential is also set', () => {
+    savedSession()
+    applySessionFileCredentials(ARGV, { VIEW_ADDRESS: OWNER, PRIVATE_KEY: '0xenv' }, PATH)
     expect(wasSessionSkippedForViewAddress()).toBe(false)
   })
 
   it('warns when CI is set and the saved login was used', () => {
+    savedSession()
     const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    applySessionFileCredentials(ARGV, { CI: 'true' }, path)
+    applySessionFileCredentials(ARGV, { CI: 'true' }, PATH)
     expect(errors).toHaveBeenCalledWith(expect.stringContaining('CI is set and credentials came from the saved login'))
-    errors.mockClear()
-    applySessionFileCredentials(ARGV, {}, path)
+    errors.mockRestore()
+  })
+
+  it('stays quiet outside CI', () => {
+    savedSession()
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    applySessionFileCredentials(ARGV, {}, PATH)
     expect(errors).not.toHaveBeenCalled()
     errors.mockRestore()
   })
 
   it('is a no-op without a file', () => {
+    noSession()
     const env: NodeJS.ProcessEnv = {}
-    expect(applySessionFileCredentials(ARGV, env, join(dir, 'missing.env'))).toBeUndefined()
+    expect(applySessionFileCredentials(ARGV, env, PATH)).toBeUndefined()
     expect(env).toEqual({})
   })
 })

--- a/src/test/unit/credential-source.test.ts
+++ b/src/test/unit/credential-source.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { writeSessionFile } from '../../login/session-file.js'
 import { applySessionFileCredentials, wasSessionSkippedForViewAddress } from '../../utils/credential-source.js'
 
@@ -95,6 +95,16 @@ describe('applySessionFileCredentials', () => {
     expect(wasSessionSkippedForViewAddress()).toBe(true)
     applySessionFileCredentials(ARGV, { VIEW_ADDRESS: OWNER, PRIVATE_KEY: '0xenv' }, path)
     expect(wasSessionSkippedForViewAddress()).toBe(false)
+  })
+
+  it('warns when CI is set and the saved login was used', () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    applySessionFileCredentials(ARGV, { CI: 'true' }, path)
+    expect(errors).toHaveBeenCalledWith(expect.stringContaining('CI is set and credentials came from the saved login'))
+    errors.mockClear()
+    applySessionFileCredentials(ARGV, {}, path)
+    expect(errors).not.toHaveBeenCalled()
+    errors.mockRestore()
   })
 
   it('is a no-op without a file', () => {

--- a/src/test/unit/credential-source.test.ts
+++ b/src/test/unit/credential-source.test.ts
@@ -58,8 +58,8 @@ describe('applySessionFileCredentials', () => {
     }
   })
 
-  it('never loads for login, logout, or server', () => {
-    for (const command of ['login', 'logout', 'server']) {
+  it('never loads for login, logout, dashboard, or server', () => {
+    for (const command of ['login', 'logout', 'dashboard', 'server']) {
       const env: NodeJS.ProcessEnv = {}
       expect(applySessionFileCredentials(['node', 'cli.js', '--verbose', command], env, path)).toBeUndefined()
       expect(env).toEqual({})

--- a/src/test/unit/credential-source.test.ts
+++ b/src/test/unit/credential-source.test.ts
@@ -65,6 +65,14 @@ describe('applySessionFileCredentials', () => {
     expect(env).toEqual({})
   })
 
+  it('still sees the command when --credentials-file <path> comes first', () => {
+    savedSession()
+    const env: NodeJS.ProcessEnv = {}
+    const argv = ['node', 'cli.js', '--credentials-file', 'creds.env', 'server']
+    expect(applySessionFileCredentials(argv, env, PATH)).toBeUndefined()
+    expect(env).toEqual({})
+  })
+
   it('ignores a file whose login never completed (no owner yet)', () => {
     savedSession({ sessionKey: KEY, sessionAddress: SESSION })
     const env: NodeJS.ProcessEnv = {}

--- a/src/test/unit/credentials-file.test.ts
+++ b/src/test/unit/credentials-file.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Command } from 'commander'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { addSigningAuthOptions } from '../../utils/cli-options.js'
 import { applyCredentialsFileArg, findCredentialsFileArg, loadCredentialsFile } from '../../utils/credentials-file.js'
 
@@ -26,6 +26,19 @@ describe('loadCredentialsFile', () => {
 
     expect(env.SESSION_KEY).toBe('0xabc')
     expect(env.WALLET_ADDRESS).toBe('0xdef')
+  })
+
+  it('ignores anything that is not a credential, so a file cannot redirect the console or the RPC', () => {
+    const path = join(dir, '.env')
+    writeFileSync(path, 'SESSION_KEY=0xabc\nCONSOLE_URL=https://evil.example\nRPC_URL=https://evil.example/rpc\n')
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const env: NodeJS.ProcessEnv = {}
+    loadCredentialsFile(path, env)
+
+    expect(env).toEqual({ SESSION_KEY: '0xabc' })
+    expect(errors).toHaveBeenCalledWith(expect.stringContaining('ignored CONSOLE_URL, RPC_URL'))
+    errors.mockRestore()
   })
 
   it('does not override a variable already set in the environment', () => {

--- a/src/test/unit/credentials-file.test.ts
+++ b/src/test/unit/credentials-file.test.ts
@@ -41,6 +41,16 @@ describe('loadCredentialsFile', () => {
     errors.mockRestore()
   })
 
+  it('fails on a file that holds nothing but ignored keys, instead of loading nothing silently', () => {
+    const path = join(dir, '.env')
+    writeFileSync(path, 'CONSOLE_URL=https://evil.example\n')
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    expect(() => loadCredentialsFile(path, {})).toThrow(/no usable entries/)
+    expect(errors).toHaveBeenCalledWith(expect.stringContaining('ignored CONSOLE_URL'))
+    errors.mockRestore()
+  })
+
   it('does not override a variable already set in the environment', () => {
     const path = join(dir, '.env')
     writeFileSync(path, 'SESSION_KEY=from-file\n')

--- a/src/test/unit/credentials-file.test.ts
+++ b/src/test/unit/credentials-file.test.ts
@@ -14,6 +14,7 @@ describe('loadCredentialsFile', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     rmSync(dir, { recursive: true, force: true })
   })
 
@@ -38,7 +39,16 @@ describe('loadCredentialsFile', () => {
 
     expect(env).toEqual({ SESSION_KEY: '0xabc' })
     expect(errors).toHaveBeenCalledWith(expect.stringContaining('ignored CONSOLE_URL, RPC_URL'))
-    errors.mockRestore()
+  })
+
+  it.each(['PRIVATE_KEY', 'VIEW_ADDRESS', 'NETWORK'])('reads %s from the file', (name) => {
+    const path = join(dir, '.env')
+    writeFileSync(path, `${name}=x\n`)
+
+    const env: NodeJS.ProcessEnv = {}
+    loadCredentialsFile(path, env)
+
+    expect(env).toEqual({ [name]: 'x' })
   })
 
   it('fails on a file that holds nothing but ignored keys, instead of loading nothing silently', () => {
@@ -48,7 +58,6 @@ describe('loadCredentialsFile', () => {
 
     expect(() => loadCredentialsFile(path, {})).toThrow(/no usable entries/)
     expect(errors).toHaveBeenCalledWith(expect.stringContaining('ignored CONSOLE_URL'))
-    errors.mockRestore()
   })
 
   it('does not override a variable already set in the environment', () => {

--- a/src/test/unit/credentials-file.test.ts
+++ b/src/test/unit/credentials-file.test.ts
@@ -3,10 +3,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { addSigningAuthOptions } from '../../utils/cli-options.js'
-import { applyCredentialsFileArg, findCredentialsFileArg, loadCredentialsFile } from '../../utils/credentials-file.js'
+import { addSigningAuthOptions, credentialsFileOption } from '../../utils/cli-options.js'
+import { applyCredentialsFile, readCredentialsFile } from '../../utils/credentials-file.js'
 
-describe('loadCredentialsFile', () => {
+describe('readCredentialsFile', () => {
   let dir: string
 
   beforeEach(() => {
@@ -18,15 +18,11 @@ describe('loadCredentialsFile', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('sets process.env-style variables from the file', () => {
+  it('reads the credential variables from the file', () => {
     const path = join(dir, '.env')
     writeFileSync(path, 'SESSION_KEY=0xabc\nWALLET_ADDRESS=0xdef\n')
 
-    const env: NodeJS.ProcessEnv = {}
-    loadCredentialsFile(path, env)
-
-    expect(env.SESSION_KEY).toBe('0xabc')
-    expect(env.WALLET_ADDRESS).toBe('0xdef')
+    expect(readCredentialsFile(path)).toEqual({ SESSION_KEY: '0xabc', WALLET_ADDRESS: '0xdef' })
   })
 
   it('ignores anything that is not a credential, so a file cannot redirect the console or the RPC', () => {
@@ -34,10 +30,7 @@ describe('loadCredentialsFile', () => {
     writeFileSync(path, 'SESSION_KEY=0xabc\nCONSOLE_URL=https://evil.example\nRPC_URL=https://evil.example/rpc\n')
     const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
-    const env: NodeJS.ProcessEnv = {}
-    loadCredentialsFile(path, env)
-
-    expect(env).toEqual({ SESSION_KEY: '0xabc' })
+    expect(readCredentialsFile(path)).toEqual({ SESSION_KEY: '0xabc' })
     expect(errors).toHaveBeenCalledWith(expect.stringContaining('ignored CONSOLE_URL, RPC_URL'))
   })
 
@@ -45,10 +38,7 @@ describe('loadCredentialsFile', () => {
     const path = join(dir, '.env')
     writeFileSync(path, `${name}=x\n`)
 
-    const env: NodeJS.ProcessEnv = {}
-    loadCredentialsFile(path, env)
-
-    expect(env).toEqual({ [name]: 'x' })
+    expect(readCredentialsFile(path)).toEqual({ [name]: 'x' })
   })
 
   it('fails on a file that holds nothing but ignored keys, instead of loading nothing silently', () => {
@@ -56,71 +46,25 @@ describe('loadCredentialsFile', () => {
     writeFileSync(path, 'CONSOLE_URL=https://evil.example\n')
     const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
-    expect(() => loadCredentialsFile(path, {})).toThrow(/no usable entries/)
+    expect(() => readCredentialsFile(path)).toThrow(/no usable entries/)
     expect(errors).toHaveBeenCalledWith(expect.stringContaining('ignored CONSOLE_URL'))
-  })
-
-  it('does not override a variable already set in the environment', () => {
-    const path = join(dir, '.env')
-    writeFileSync(path, 'SESSION_KEY=from-file\n')
-
-    const env: NodeJS.ProcessEnv = { SESSION_KEY: 'from-real-env' }
-    loadCredentialsFile(path, env)
-
-    expect(env.SESSION_KEY).toBe('from-real-env')
   })
 
   it('throws a clear error naming the path when the file is missing', () => {
     const path = join(dir, 'does-not-exist.env')
 
-    expect(() => loadCredentialsFile(path, {})).toThrow(`could not read "${path}": file not found`)
+    expect(() => readCredentialsFile(path)).toThrow(`could not read "${path}": file not found`)
   })
 
   it('fails on a file with no entries, naming the path and the expected format', () => {
     const path = join(dir, 'empty.env')
     writeFileSync(path, '# only comments\n\n')
 
-    expect(() => loadCredentialsFile(path, {})).toThrow(/no usable entries.*Expected dotenv-style/s)
-  })
-
-  it('a flag still beats a value the file loaded into the environment', () => {
-    const path = join(dir, '.env')
-    writeFileSync(path, 'SESSION_KEY=from-file\n')
-    const env: NodeJS.ProcessEnv = {}
-    loadCredentialsFile(path, env)
-
-    const command = addSigningAuthOptions(new Command()).exitOverride()
-    const previous = process.env.SESSION_KEY
-    process.env.SESSION_KEY = env.SESSION_KEY
-    try {
-      command.parse(['--session-key', 'from-flag'], { from: 'user' })
-      expect(command.opts().sessionKey).toBe('from-flag')
-      command.parse([], { from: 'user' })
-      expect(command.opts().sessionKey).toBe('from-file')
-    } finally {
-      if (previous === undefined) delete process.env.SESSION_KEY
-      else process.env.SESSION_KEY = previous
-    }
+    expect(() => readCredentialsFile(path)).toThrow(/no usable entries.*Expected dotenv-style/s)
   })
 })
 
-describe('findCredentialsFileArg', () => {
-  it('finds a space-separated --credentials-file <path> anywhere in argv', () => {
-    expect(findCredentialsFileArg(['node', 'cli.js', 'add', '--credentials-file', '/tmp/x.env', 'file.txt'])).toBe(
-      '/tmp/x.env'
-    )
-  })
-
-  it('finds an --credentials-file=<path> form', () => {
-    expect(findCredentialsFileArg(['node', 'cli.js', 'add', '--credentials-file=/tmp/x.env'])).toBe('/tmp/x.env')
-  })
-
-  it('returns undefined when not present', () => {
-    expect(findCredentialsFileArg(['node', 'cli.js', 'add', 'file.txt'])).toBeUndefined()
-  })
-})
-
-describe('applyCredentialsFileArg', () => {
+describe('applyCredentialsFile', () => {
   let dir: string
 
   beforeEach(() => {
@@ -131,19 +75,67 @@ describe('applyCredentialsFileArg', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('is a no-op when --credentials-file is absent', () => {
+  /** A root program declaring `--credentials-file`, with a signing subcommand, parsed and hooked like cli.ts. */
+  async function parse(args: string[], env: NodeJS.ProcessEnv): Promise<Command> {
+    const program = new Command().exitOverride().addOption(credentialsFileOption())
+    let action: Command | undefined
+    const add = addSigningAuthOptions(new Command('add').exitOverride()).action(function (this: Command) {
+      action = this
+    })
+    program.addCommand(add)
+    program.hook('preAction', (_thisCommand, actionCommand) => applyCredentialsFile(actionCommand, env))
+    await program.parseAsync(args, { from: 'user' })
+    if (action === undefined) throw new Error('action did not run')
+    return action
+  }
+
+  it('is a no-op when --credentials-file is absent', async () => {
     const env: NodeJS.ProcessEnv = {}
-    applyCredentialsFileArg(['node', 'cli.js', 'add', 'file.txt'], env)
+    const command = await parse(['add'], env)
     expect(env).toEqual({})
+    expect(command.opts()).toEqual({})
   })
 
-  it('loads the file named by --credentials-file before other resolution', () => {
+  it.each([
+    ['before the subcommand', (path: string) => ['--credentials-file', path, 'add']],
+    ['after the subcommand', (path: string) => ['add', '--credentials-file', path]],
+    ['with an equals sign', (path: string) => ['add', `--credentials-file=${path}`]],
+  ])('supplies the file %s, recorded as the file source', async (_label, argv) => {
     const path = join(dir, '.env')
     writeFileSync(path, 'SESSION_KEY=0xabc\n')
 
     const env: NodeJS.ProcessEnv = {}
-    applyCredentialsFileArg(['node', 'cli.js', 'add', '--credentials-file', path], env)
+    const command = await parse(argv(path), env)
 
     expect(env.SESSION_KEY).toBe('0xabc')
+    expect(command.opts().sessionKey).toBe('0xabc')
+    expect(command.getOptionValueSource('sessionKey')).toBe('file')
+  })
+
+  it('does not override a variable already set in the environment', async () => {
+    const path = join(dir, '.env')
+    writeFileSync(path, 'SESSION_KEY=from-file\n')
+
+    const env: NodeJS.ProcessEnv = { SESSION_KEY: 'from-real-env' }
+    await parse(['add', '--credentials-file', path], env)
+
+    expect(env.SESSION_KEY).toBe('from-real-env')
+  })
+
+  it('a flag still beats the file', async () => {
+    const path = join(dir, '.env')
+    writeFileSync(path, 'SESSION_KEY=from-file\n')
+
+    const env: NodeJS.ProcessEnv = {}
+    const command = await parse(['add', '--credentials-file', path, '--session-key', 'from-flag'], env)
+
+    expect(command.opts().sessionKey).toBe('from-flag')
+    expect(command.getOptionValueSource('sessionKey')).toBe('cli')
+    expect(env.SESSION_KEY).toBeUndefined()
+  })
+
+  it('surfaces a missing file through the parse, naming the path', async () => {
+    const path = join(dir, 'does-not-exist.env')
+    await expect(parse(['add', '--credentials-file', path], {})).rejects.toThrow(`could not read "${path}"`)
   })
 })

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -203,6 +203,31 @@ describe('synapse-service', () => {
       expect(error?.message).not.toContain('never granted')
     })
 
+    it('should say the session expired, with the lapse date, when every needed grant has lapsed', async () => {
+      mockSessionKeyOnce(() => false, {
+        [CreateDataSetPermission]: 1000n,
+        [AddPiecesPermission]: 2000n, // 1970-01-01, unambiguously past
+        [SchedulePieceRemovalsPermission]: 0n,
+        [TerminateServicePermission]: 0n,
+      })
+
+      const config: SynapseSetupConfig = {
+        walletAddress: '0x0000000000000000000000000000000000000002',
+        sessionKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        rpcUrl: 'wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1',
+        requiredPermissions: [CreateDataSetPermission, AddPiecesPermission],
+      }
+
+      const error = await initializeSynapse(config, logger).then(
+        () => null,
+        (e: unknown) => e as Error
+      )
+      expect(error?.message).toContain(
+        'Session expired (key 0x0000000000000000000000000000000000000001, grants lapsed 1970-01-01)'
+      )
+      expect(error?.message).toContain('Renew it:  filecoin-pin login')
+    })
+
     it("should use the 'never authorized, or expired/revoked' wording when the key holds no live grant", async () => {
       mockSessionKeyOnce(() => false, {
         [CreateDataSetPermission]: 0n,
@@ -268,7 +293,7 @@ describe('synapse-service', () => {
       // AccountConfig with null account satisfies the type but triggers the no-auth branch
       const config = { rpcUrl: 'wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1' } as any
 
-      await expect(initializeSynapse(config, logger)).rejects.toThrow('No authentication provided')
+      await expect(initializeSynapse(config, logger)).rejects.toThrow('No credentials found')
     })
 
     it('should throw when walletAddress is provided without sessionKey', async () => {

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -226,6 +226,9 @@ describe('synapse-service', () => {
         'Session expired (key 0x0000000000000000000000000000000000000001, grants lapsed 1970-01-01)'
       )
       expect(error?.message).toContain('Renew it:  filecoin-pin login')
+      // One remedy only: no console link and no owner CLI hints on the expired wall.
+      expect(error?.message).not.toContain('console')
+      expect(error?.message).not.toContain('session authorize')
     })
 
     it("should use the 'never authorized, or expired/revoked' wording when the key holds no live grant", async () => {

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -205,8 +205,8 @@ describe('synapse-service', () => {
 
     it('should say the session expired, with the lapse date, when every needed grant has lapsed', async () => {
       mockSessionKeyOnce(() => false, {
-        [CreateDataSetPermission]: 1000n,
-        [AddPiecesPermission]: 2000n, // 1970-01-01, unambiguously past
+        [CreateDataSetPermission]: 1000n, // 1970-01-01
+        [AddPiecesPermission]: 86400n, // 1970-01-02: the later one must be the one reported
         [SchedulePieceRemovalsPermission]: 0n,
         [TerminateServicePermission]: 0n,
       })
@@ -223,7 +223,7 @@ describe('synapse-service', () => {
         (e: unknown) => e as Error
       )
       expect(error?.message).toContain('Session expired')
-      expect(error?.message).toContain('1970-01-01')
+      expect(error?.message).toContain('1970-01-02')
       expect(error?.message).toContain('filecoin-pin login')
       // One remedy only: no console link and no owner CLI hints on the expired wall.
       expect(error?.message).not.toContain('console')

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -225,7 +225,8 @@ describe('synapse-service', () => {
       expect(error?.message).toContain('Session expired')
       expect(error?.message).toContain('1970-01-02')
       expect(error?.message).toContain('filecoin-pin login')
-      // One remedy only: no console link and no owner CLI hints on the expired wall.
+      // An expired key is renewed by rerunning login, so that is the only remedy offered:
+      // the console link and the owner-side session commands belong to the never-authorized error.
       expect(error?.message).not.toContain('console')
       expect(error?.message).not.toContain('session authorize')
     })

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -222,10 +222,9 @@ describe('synapse-service', () => {
         () => null,
         (e: unknown) => e as Error
       )
-      expect(error?.message).toContain(
-        'Session expired (key 0x0000000000000000000000000000000000000001, grants lapsed 1970-01-01)'
-      )
-      expect(error?.message).toContain('Renew it:  filecoin-pin login')
+      expect(error?.message).toContain('Session expired')
+      expect(error?.message).toContain('1970-01-01')
+      expect(error?.message).toContain('filecoin-pin login')
       // One remedy only: no console link and no owner CLI hints on the expired wall.
       expect(error?.message).not.toContain('console')
       expect(error?.message).not.toContain('session authorize')

--- a/src/test/unit/synapse-service.test.ts
+++ b/src/test/unit/synapse-service.test.ts
@@ -40,6 +40,7 @@ describe('synapse-service', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    vi.useRealTimers()
   })
 
   describe('initializeSynapse', () => {
@@ -204,6 +205,8 @@ describe('synapse-service', () => {
     })
 
     it('should say the session expired, with the lapse date, when every needed grant has lapsed', async () => {
+      // Now equals the latest expiry exactly: a grant whose expiry is the current second is lapsed.
+      vi.useFakeTimers({ now: 86_400_000 })
       mockSessionKeyOnce(() => false, {
         [CreateDataSetPermission]: 1000n, // 1970-01-01
         [AddPiecesPermission]: 86400n, // 1970-01-02: the later one must be the one reported

--- a/src/utils/cli-auth.ts
+++ b/src/utils/cli-auth.ts
@@ -22,11 +22,26 @@ import {
 } from './credential-source.js'
 
 /**
- * Where a resolved auth option value came from. Mirrors Commander's
- * `getOptionValueSource()`, narrowed to the two sources we distinguish for
- * precedence: an explicit command-line flag versus an environment variable.
+ * Where a resolved auth option value came from, in precedence order: an
+ * explicit command-line flag, an environment variable, `--credentials-file`,
+ * or the saved login. The first two are Commander's own
+ * `getOptionValueSource()` values; the file sources are recorded by the
+ * preAction loaders (see credential-source.ts).
  */
-export type AuthOptionSource = 'cli' | 'env'
+export const AUTH_OPTION_SOURCES = ['cli', 'env', 'file', 'session'] as const
+export type AuthOptionSource = (typeof AUTH_OPTION_SOURCES)[number]
+
+const SOURCE_LABELS: Record<AuthOptionSource, string> = {
+  cli: 'the command line',
+  env: 'the environment',
+  file: 'the credentials file',
+  session: 'the saved login',
+}
+
+/** Precedence rank of a source: lower wins. */
+function rankOf(source: AuthOptionSource): number {
+  return AUTH_OPTION_SOURCES.indexOf(source)
+}
 
 /**
  * Per-option provenance for the mutually exclusive auth flags, keyed by the
@@ -80,10 +95,10 @@ export interface CLIAuthOptions {
 }
 
 /**
- * The mutually exclusive authentication modes, in precedence order. An explicit
- * flag always wins over an environment variable; when every supplied mode came
- * from the environment, the first one in this order wins and the rest are
- * reported as ignored (see {@link resolveAuthMode}).
+ * The mutually exclusive authentication modes, in precedence order. A mode
+ * from a higher-ranked source always wins; among modes from the same source,
+ * the first one in this order wins and the rest are reported as ignored (see
+ * {@link resolveAuthMode}).
  *
  * 1. `readOnly`   - `--view-address` / `VIEW_ADDRESS` (query only, never signs)
  * 2. `sessionKey` - `--wallet-address` + `--session-key` (delegated signer)
@@ -104,13 +119,16 @@ interface AuthModeCandidate {
 /**
  * Resolve which single auth mode to use from the modes that were supplied.
  *
- * Rules (see {@link AuthMode} for the mode list):
- * - An explicit command-line flag always beats an environment variable, so a
- *   flag disambiguates against any env-sourced mode.
+ * Rules (see {@link AuthMode} for the mode list and {@link AuthOptionSource}
+ * for the source order):
+ * - The mode from the highest-ranked source wins: a flag beats an env var,
+ *   which beats the credentials file, which beats the saved login. That is
+ *   how `PRIVATE_KEY` in the shell keeps beating a session key pair in a
+ *   `--credentials-file`.
  * - Two or more modes from explicit flags is a hard error (contradictory args).
- * - With no explicit flag, the highest-precedence env-sourced mode wins and a
- *   warning names the env vars that were ignored. A shell that exports both
- *   `PRIVATE_KEY` and session-key credentials keeps working, as it always has.
+ * - Otherwise canonical order breaks a tie within one source, and a warning
+ *   names every mode that lost. A shell that exports both `PRIVATE_KEY` and
+ *   session-key credentials keeps working, as it always has.
  * - Exactly one supplied mode wins; none supplied returns `undefined` (caller
  *   applies the devnet fallback or lets initializeSynapse report missing auth).
  *
@@ -125,16 +143,14 @@ function resolveAuthMode(candidates: AuthModeCandidate[]): AuthMode | undefined 
     const labels = explicit.map((c) => c.label).join(' and ')
     throw new Error(`Conflicting authentication options: ${labels}. Provide exactly one authentication mode.`)
   }
-  const [singleExplicit] = explicit
-  if (singleExplicit) return singleExplicit.mode
-
-  // No explicit flag: every remaining candidate is env-sourced. Canonical
-  // order breaks the tie, loudly, so a stale export never silently changes
-  // which key signs.
-  const [winner, ...ignored] = candidates
+  // Stable sort: source rank first, canonical order within a source, so a
+  // stale export never silently changes which key signs.
+  const [winner, ...ignored] = [...candidates].sort((a, b) => rankOf(a.source) - rankOf(b.source))
   if (winner && ignored.length > 0) {
     const ignoredLabels = ignored.map((c) => c.label).join(', ')
-    log.warn(`Using ${winner.label} from the environment; ignoring ${ignoredLabels}. Pass a flag to choose explicitly.`)
+    log.warn(
+      `Using ${winner.label} from ${SOURCE_LABELS[winner.source]}; ignoring ${ignoredLabels}. Pass a flag to choose explicitly.`
+    )
   }
   return winner?.mode
 }
@@ -171,7 +187,7 @@ export function parseCLIAuth(options: CLIAuthOptions): SynapseSetupConfig {
   // A mode spanning several options takes the strongest source among them: a
   // single explicit flag makes the whole mode explicit.
   const strongest = (...srcs: Array<AuthOptionSource | undefined>): AuthOptionSource | undefined =>
-    srcs.includes('cli') ? 'cli' : srcs.includes('env') ? 'env' : undefined
+    srcs.filter((src): src is AuthOptionSource => src !== undefined).sort((a, b) => rankOf(a) - rankOf(b))[0]
 
   // Build the candidate list in canonical priority order (see AuthMode).
   const candidates: AuthModeCandidate[] = []

--- a/src/utils/cli-auth.ts
+++ b/src/utils/cli-auth.ts
@@ -257,8 +257,8 @@ export function parseCLIAuth(options: CLIAuthOptions): SynapseSetupConfig {
 }
 
 /**
- * One gray line naming the session credential a command runs with (PRD
- * section 5): the session address, where it came from when auto-loaded,
+ * One gray line naming the session credential a command runs with: the
+ * session address, where it came from when auto-loaded,
  * the owner, and the network the key was made for. Skipped when the key
  * is malformed; initializeSynapse reports that with the right flag name.
  * A saved login used on another network gets a warning: the grant cannot

--- a/src/utils/cli-auth.ts
+++ b/src/utils/cli-auth.ts
@@ -7,11 +7,15 @@
 
 import type { Permission } from '@filoz/synapse-core/session-key'
 import type { FilecoinChain, Synapse } from '@filoz/synapse-sdk'
+import pc from 'picocolors'
+import { privateKeyToAccount } from 'viem/accounts'
 import { getRpcUrl, NETWORK_CHAINS, resolveDevnetConfig } from '../common/get-rpc-url.js'
 import type { SynapseSetupConfig } from '../core/synapse/index.js'
 import { initializeSynapse, isReadOnlyConfig, isSessionKeyConfig } from '../core/synapse/index.js'
 import { createLogger } from '../logger.js'
+import { shortAddress } from '../login/format.js'
 import { log } from './cli-logger.js'
+import { getSessionCredentialSource } from './credential-source.js'
 
 /**
  * Where a resolved auth option value came from. Mirrors Commander's
@@ -239,7 +243,28 @@ export function parseCLIAuth(options: CLIAuthOptions): SynapseSetupConfig {
   }
   if (rpcUrl) config.rpcUrl = rpcUrl
   if (chain) config.chain = chain
+  if (!privateKey && !viewAddress && walletAddress && sessionKey) {
+    printSessionInUse(sessionKey, walletAddress)
+  }
   return config as SynapseSetupConfig
+}
+
+/**
+ * One gray line naming the session credential a command runs with (PRD
+ * section 5): the session address, where it came from when auto-loaded,
+ * and the owner. Skipped when the key is malformed; initializeSynapse
+ * reports that with the right flag name.
+ */
+function printSessionInUse(sessionKey: string, walletAddress: string): void {
+  let sessionAddress: string
+  try {
+    sessionAddress = privateKeyToAccount(sessionKey as `0x${string}`).address
+  } catch {
+    return
+  }
+  const source = getSessionCredentialSource()
+  const from = source === undefined ? '' : ` (from ${source})`
+  log.line(pc.gray(`  Using session ${shortAddress(sessionAddress)}${from} · owner ${shortAddress(walletAddress)}`))
 }
 
 /**

--- a/src/utils/cli-auth.ts
+++ b/src/utils/cli-auth.ts
@@ -15,7 +15,11 @@ import { initializeSynapse, isReadOnlyConfig, isSessionKeyConfig } from '../core
 import { createLogger } from '../logger.js'
 import { shortAddress } from '../login/format.js'
 import { log } from './cli-logger.js'
-import { getSessionCredentialSource } from './credential-source.js'
+import {
+  getSessionCredentialNetwork,
+  getSessionCredentialSource,
+  wasSessionSkippedForViewAddress,
+} from './credential-source.js'
 
 /**
  * Where a resolved auth option value came from. Mirrors Commander's
@@ -217,6 +221,9 @@ export function parseCLIAuth(options: CLIAuthOptions): SynapseSetupConfig {
     case 'readOnly':
       if (nonEmpty(viewAddress)) config.walletAddress = viewAddress
       config.readOnly = true
+      if (wasSessionSkippedForViewAddress()) {
+        log.line(pc.gray('  Saved login ignored because VIEW_ADDRESS is set (read-only mode)'))
+      }
       break
     case 'sessionKey':
       // Both halves are present (that is what made this a competing candidate).
@@ -243,8 +250,8 @@ export function parseCLIAuth(options: CLIAuthOptions): SynapseSetupConfig {
   }
   if (rpcUrl) config.rpcUrl = rpcUrl
   if (chain) config.chain = chain
-  if (!privateKey && !viewAddress && walletAddress && sessionKey) {
-    printSessionInUse(sessionKey, walletAddress)
+  if (mode === 'sessionKey' && nonEmpty(sessionKey) && nonEmpty(walletAddress)) {
+    printSessionInUse(sessionKey, walletAddress, network)
   }
   return config as SynapseSetupConfig
 }
@@ -252,10 +259,12 @@ export function parseCLIAuth(options: CLIAuthOptions): SynapseSetupConfig {
 /**
  * One gray line naming the session credential a command runs with (PRD
  * section 5): the session address, where it came from when auto-loaded,
- * and the owner. Skipped when the key is malformed; initializeSynapse
- * reports that with the right flag name.
+ * the owner, and the network the key was made for. Skipped when the key
+ * is malformed; initializeSynapse reports that with the right flag name.
+ * A saved login used on another network gets a warning: the grant cannot
+ * be there.
  */
-function printSessionInUse(sessionKey: string, walletAddress: string): void {
+function printSessionInUse(sessionKey: string, walletAddress: string, network: string | undefined): void {
   let sessionAddress: string
   try {
     sessionAddress = privateKeyToAccount(sessionKey as `0x${string}`).address
@@ -264,7 +273,16 @@ function printSessionInUse(sessionKey: string, walletAddress: string): void {
   }
   const source = getSessionCredentialSource()
   const from = source === undefined ? '' : ` (from ${source})`
-  log.line(pc.gray(`  Using session ${shortAddress(sessionAddress)}${from} · owner ${shortAddress(walletAddress)}`))
+  const saved = getSessionCredentialNetwork()
+  const on = saved === undefined ? '' : ` · ${saved}`
+  log.line(
+    pc.gray(`  Using session ${shortAddress(sessionAddress)}${from} · owner ${shortAddress(walletAddress)}${on}`)
+  )
+  if (saved !== undefined && network !== undefined && network !== saved) {
+    log.line(
+      `${pc.yellow('⚠')} The saved login is for ${saved}, but this command runs on ${network}. Pass --network ${saved}, or run \`filecoin-pin login --network ${network}\`.`
+    )
+  }
 }
 
 /**

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -10,8 +10,9 @@ import { MIN_RUNWAY_DAYS } from '../common/constants.js'
 import { normalizeNetworkName } from '../common/get-rpc-url.js'
 import { USDFC_DECIMALS } from '../core/payments/constants.js'
 import { SCOPE_IDS } from '../core/session/scopes.js'
-import type { AuthOptionSource, AuthOptionSources } from './cli-auth.js'
+import { AUTH_OPTION_SOURCES, type AuthOptionSource, type AuthOptionSources } from './cli-auth.js'
 import { log } from './cli-logger.js'
+import { applySessionFileCredentials } from './credential-source.js'
 import { CREDENTIALS_FILE_FLAG } from './credentials-file.js'
 
 /**
@@ -22,9 +23,9 @@ const AUTH_OPTION_NAMES = ['privateKey', 'walletAddress', 'sessionKey', 'viewAdd
 
 /**
  * Read each auth flag's provenance from a Commander command, narrowed to the
- * `cli` (explicit flag) vs `env` (environment variable) distinction that
- * precedence resolution cares about. Other sources (`default`, `config`,
- * `implied`, unset) are omitted so `parseCLIAuth` treats them as absent.
+ * sources precedence resolution ranks: `cli`, `env`, and the `file` and
+ * `session` sources the preAction loaders record. Other sources (`default`,
+ * `config`, `implied`, unset) are omitted so `parseCLIAuth` treats them as absent.
  *
  * None of the auth flags declare a Commander `.default()`, which matters:
  * parseCLIAuth's `sourceOf` treats a present value with no recorded source as an
@@ -37,7 +38,7 @@ export function collectAuthOptionSources(command: Command): AuthOptionSources {
   const sources: AuthOptionSources = {}
   for (const name of AUTH_OPTION_NAMES) {
     const source = command.getOptionValueSource(name)
-    if (source === 'cli' || source === 'env') {
+    if ((AUTH_OPTION_SOURCES as readonly unknown[]).includes(source)) {
       sources[name] = source as AuthOptionSource
     }
   }
@@ -67,15 +68,15 @@ export function scopesOption(description: string): Option {
 }
 
 /**
- * `--credentials-file <path>`: a dotenv-style file loaded into the
- * environment before Commander resolves env-backed options (see
- * `src/utils/credentials-file.ts`). Registered here so `--help` lists it
- * and Commander accepts it; the value itself is consumed pre-parse.
+ * `--credentials-file <path>`: a dotenv-style file the root program's
+ * preAction hook loads after flags and env vars are resolved (see
+ * `src/utils/credentials-file.ts`). Registered on subcommands too so their
+ * `--help` lists it.
  */
 export function credentialsFileOption(): Option {
   return new Option(
     `${CREDENTIALS_FILE_FLAG} <path>`,
-    'Load credentials (e.g. SESSION_KEY, WALLET_ADDRESS) from a dotenv-style file before other options are resolved. Does not override variables already set in the environment.'
+    'Load credentials (e.g. SESSION_KEY, WALLET_ADDRESS) from a dotenv-style file. Flags and environment variables always win over the file.'
   )
 }
 
@@ -144,12 +145,14 @@ export function addAuthOptions(command: Command): Command {
     )
   )
 
-  // Capture each auth flag's provenance (explicit flag vs env var) before the
-  // action runs, and stash it on the parsed options as `optionSources`. This is
-  // the only point where Commander's per-option source is available, so it lets
-  // parseCLIAuth() resolve precedence (explicit flag beats env) without every
-  // command action or runner having to thread the Command through.
+  // Fill the lowest tier (the saved login) once flags, env vars, and the
+  // credentials file (the root program's hook, which runs first) have had
+  // their say, then capture each auth flag's provenance on the parsed options
+  // as `optionSources`. This is the only point where Commander's per-option
+  // source is available, so it lets parseCLIAuth() rank the sources without
+  // every command action or runner having to thread the Command through.
   command.hook('preAction', (_thisCommand, actionCommand) => {
+    applySessionFileCredentials(actionCommand)
     actionCommand.setOptionValue('optionSources', collectAuthOptionSources(actionCommand))
   })
 

--- a/src/utils/credential-source.ts
+++ b/src/utils/credential-source.ts
@@ -1,0 +1,56 @@
+/**
+ * Credential auto-load: the lowest-priority credential source.
+ *
+ * Resolution order for every command (PRD section 5): explicit flags, then
+ * env vars (`PRIVATE_KEY`, or `SESSION_KEY` + `WALLET_ADDRESS`), then the
+ * session file `login` wrote, then the error that points at `login`.
+ *
+ * This runs before Commander parses argv. Commander already makes flags win
+ * over env vars, so the only job here is to load the session file into the
+ * environment when no flag and no env var supplied a credential. Explicit
+ * always beats implicit: a shell or CI that sets env vars is never
+ * surprised by a stale laptop file.
+ */
+
+import { getSessionFilePath, readSessionFile } from '../login/session-file.js'
+
+const AUTH_ENV_VARS = ['PRIVATE_KEY', 'SESSION_KEY', 'WALLET_ADDRESS', 'VIEW_ADDRESS'] as const
+const AUTH_FLAGS = ['--private-key', '--session-key', '--wallet-address', '--view-address'] as const
+
+let loadedFrom: string | undefined
+
+/** True when argv carries any auth flag, in `--flag value` or `--flag=value` form. */
+function hasAuthFlag(argv: readonly string[]): boolean {
+  return argv.some((arg) => AUTH_FLAGS.some((flag) => arg === flag || arg.startsWith(`${flag}=`)))
+}
+
+function hasAuthEnv(env: NodeJS.ProcessEnv): boolean {
+  return AUTH_ENV_VARS.some((name) => env[name] !== undefined && env[name] !== '')
+}
+
+/**
+ * Load `SESSION_KEY` and `WALLET_ADDRESS` from the session file into `env`
+ * when nothing else supplied a credential. A file without an owner address
+ * (login started but never authorized) is left alone, so the command hits
+ * the no-credentials error and points at `login`.
+ *
+ * @returns the file path when it was used, otherwise undefined
+ */
+export function applySessionFileCredentials(
+  argv: readonly string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env,
+  path: string = getSessionFilePath()
+): string | undefined {
+  if (hasAuthFlag(argv) || hasAuthEnv(env)) return undefined
+  const session = readSessionFile(path)
+  if (session?.walletAddress === undefined) return undefined
+  env.SESSION_KEY = session.sessionKey
+  env.WALLET_ADDRESS = session.walletAddress
+  loadedFrom = path
+  return path
+}
+
+/** Path of the session file the running command's credentials came from, if any. */
+export function getSessionCredentialSource(): string | undefined {
+  return loadedFrom
+}

--- a/src/utils/credential-source.ts
+++ b/src/utils/credential-source.ts
@@ -16,12 +16,24 @@ import { getSessionFilePath, readSessionFile } from '../login/session-file.js'
 
 const AUTH_ENV_VARS = ['PRIVATE_KEY', 'SESSION_KEY', 'WALLET_ADDRESS', 'VIEW_ADDRESS'] as const
 const AUTH_FLAGS = ['--private-key', '--session-key', '--wallet-address', '--view-address'] as const
+/**
+ * Commands that never auto-load: `login`/`logout` manage the file, and the
+ * pinning server is a daemon that must not silently bind to an interactive,
+ * expiring session key.
+ */
+const SKIPPED_COMMANDS = ['login', 'logout', 'server'] as const
 
 let loadedFrom: string | undefined
 
 /** True when argv carries any auth flag, in `--flag value` or `--flag=value` form. */
 function hasAuthFlag(argv: readonly string[]): boolean {
   return argv.some((arg) => AUTH_FLAGS.some((flag) => arg === flag || arg.startsWith(`${flag}=`)))
+}
+
+/** True when the first non-option argument names a command that never auto-loads. */
+function isSkippedCommand(argv: readonly string[]): boolean {
+  const command = argv.slice(2).find((arg) => !arg.startsWith('-'))
+  return command !== undefined && (SKIPPED_COMMANDS as readonly string[]).includes(command)
 }
 
 function hasAuthEnv(env: NodeJS.ProcessEnv): boolean {
@@ -32,7 +44,8 @@ function hasAuthEnv(env: NodeJS.ProcessEnv): boolean {
  * Load `SESSION_KEY` and `WALLET_ADDRESS` from the session file into `env`
  * when nothing else supplied a credential. A file without an owner address
  * (login started but never authorized) is left alone, so the command hits
- * the no-credentials error and points at `login`.
+ * the no-credentials error and points at `login`. `login`, `logout`, and
+ * `server` never auto-load.
  *
  * @returns the file path when it was used, otherwise undefined
  */
@@ -41,7 +54,7 @@ export function applySessionFileCredentials(
   env: NodeJS.ProcessEnv = process.env,
   path: string = getSessionFilePath()
 ): string | undefined {
-  if (hasAuthFlag(argv) || hasAuthEnv(env)) return undefined
+  if (isSkippedCommand(argv) || hasAuthFlag(argv) || hasAuthEnv(env)) return undefined
   const session = readSessionFile(path)
   if (session?.walletAddress === undefined) return undefined
   env.SESSION_KEY = session.sessionKey

--- a/src/utils/credential-source.ts
+++ b/src/utils/credential-source.ts
@@ -18,11 +18,11 @@ const AUTH_ENV_VARS = ['PRIVATE_KEY', 'SESSION_KEY', 'WALLET_ADDRESS', 'VIEW_ADD
 const AUTH_FLAGS = ['--private-key', '--session-key', '--wallet-address', '--view-address'] as const
 const NETWORK_FLAGS = ['--network', '--rpc-url'] as const
 /**
- * Commands that never auto-load: `login`/`logout` manage the file, and the
- * pinning server is a daemon that must not silently bind to an interactive,
- * expiring session key.
+ * Commands that never auto-load: `login`/`logout` manage the file, `dashboard`
+ * needs no credential and opens a browser, and the pinning server is a daemon
+ * that must not silently bind to an interactive, expiring session key.
  */
-const SKIPPED_COMMANDS = ['login', 'logout', 'server'] as const
+const SKIPPED_COMMANDS = ['login', 'logout', 'dashboard', 'server'] as const
 
 let loadedFrom: string | undefined
 let loadedNetwork: string | undefined

--- a/src/utils/credential-source.ts
+++ b/src/utils/credential-source.ts
@@ -1,7 +1,7 @@
 /**
  * Credential auto-load: the lowest-priority credential source.
  *
- * Resolution order for every command (PRD section 5): explicit flags, then
+ * Resolution order for every command: explicit flags, then
  * env vars (`PRIVATE_KEY`, or `SESSION_KEY` + `WALLET_ADDRESS`), then the
  * session file `login` wrote, then the error that points at `login`.
  *

--- a/src/utils/credential-source.ts
+++ b/src/utils/credential-source.ts
@@ -62,6 +62,10 @@ export function applySessionFileCredentials(
   env: NodeJS.ProcessEnv = process.env,
   path: string = getSessionFilePath()
 ): string | undefined {
+  // One process may call this more than once (tests, programmatic use); start clean each time.
+  loadedFrom = undefined
+  loadedNetwork = undefined
+  skippedForViewAddress = false
   if (isSkippedCommand(argv) || hasFlag(argv, AUTH_FLAGS)) return undefined
   if (hasAuthEnv(env)) {
     // Only VIEW_ADDRESS set: a usable login exists but read-only mode wins. Remembered so the

--- a/src/utils/credential-source.ts
+++ b/src/utils/credential-source.ts
@@ -15,7 +15,7 @@
  * that sets env vars is never surprised by a stale laptop file.
  */
 
-import type { Command } from 'commander'
+import type { Command, Option } from 'commander'
 import { getSessionFilePath, readSessionFile } from '../login/session-file.js'
 
 /** Env var name and Commander attribute for every variable the file sources may supply. */
@@ -54,11 +54,18 @@ function isSupplied(command: Command, env: NodeJS.ProcessEnv, name: LoadableEnvV
   return command.getOptionValue(OPTION_FOR_ENV[name]) !== undefined || isSet(env, name)
 }
 
+const SOURCE_LABELS = { file: 'the credentials file', session: 'the saved login' } as const
+
 /**
  * Supply `name` from a file source unless something higher already did.
  * The Commander option is set (with `source` as its provenance) only when
  * the command declares it, exactly as Commander binds env vars; the env var
  * is set for the code that reads `process.env` directly.
+ *
+ * Commander checks `.conflicts()` before preAction hooks run, so a value
+ * supplied here would slip past a conflict a flag or env var would have
+ * tripped (`--auto-fund` with VIEW_ADDRESS from a file). Re-check it here
+ * and fail the same way Commander would have.
  *
  * @returns whether the value was used
  */
@@ -71,7 +78,23 @@ export function supplyCredential(
 ): boolean {
   if (isSupplied(command, env, name)) return false
   const attribute = OPTION_FOR_ENV[name]
-  if (command.options.some((option) => option.attributeName() === attribute)) {
+  const declared = command.options.find((option) => option.attributeName() === attribute)
+  if (declared !== undefined) {
+    const chosen = (option: Option): boolean => {
+      const valueSource = command.getOptionValueSource(option.attributeName())
+      return valueSource !== undefined && valueSource !== 'default' && valueSource !== 'implied'
+    }
+    // `conflictsWith` is what `.conflicts()` records; Commander reads it the same way but does not type it.
+    const conflictsOf = (option: Option): string[] =>
+      (option as Option & { conflictsWith?: string[] }).conflictsWith ?? []
+    const conflict = command.options.find(
+      (option) =>
+        chosen(option) &&
+        (conflictsOf(option).includes(attribute) || conflictsOf(declared).includes(option.attributeName()))
+    )
+    if (conflict !== undefined) {
+      throw new Error(`option '${conflict.flags}' cannot be used with ${name} from ${SOURCE_LABELS[source]}`)
+    }
     command.setOptionValueWithSource(attribute, value, source)
   }
   env[name] = value

--- a/src/utils/credential-source.ts
+++ b/src/utils/credential-source.ts
@@ -1,72 +1,97 @@
 /**
  * Credential auto-load: the lowest-priority credential source.
  *
- * Resolution order for every command: explicit flags, then
- * env vars (`PRIVATE_KEY`, or `SESSION_KEY` + `WALLET_ADDRESS`), then the
- * session file `login` wrote, then the error that points at `login`.
+ * Resolution order for every command: explicit flags, then env vars
+ * (`PRIVATE_KEY`, or `SESSION_KEY` + `WALLET_ADDRESS`), then
+ * `--credentials-file`, then the session file `login` wrote, then the error
+ * that points at `login`.
  *
- * This runs before Commander parses argv. Commander already makes flags win
- * over env vars, so the only job here is to load the session file into the
- * environment when no flag and no env var supplied a credential. Explicit
- * always beats implicit: a shell or CI that sets env vars is never
- * surprised by a stale laptop file.
+ * Both file sources load from a Commander `preAction` hook, after parsing.
+ * By then every flag and env-backed option is resolved, so "did the user
+ * choose a credential or a network" is one option lookup rather than a
+ * hand-rolled scan of argv and the environment, and each loaded value is
+ * recorded with its own source (`file`, `session`) so `parseCLIAuth` can
+ * rank it below the shell. Explicit always beats implicit: a shell or CI
+ * that sets env vars is never surprised by a stale laptop file.
  */
 
+import type { Command } from 'commander'
 import { getSessionFilePath, readSessionFile } from '../login/session-file.js'
-import { CREDENTIALS_FILE_FLAG } from './credentials-file.js'
 
-const AUTH_ENV_VARS = ['PRIVATE_KEY', 'SESSION_KEY', 'WALLET_ADDRESS', 'VIEW_ADDRESS'] as const
-const AUTH_FLAGS = ['--private-key', '--session-key', '--wallet-address', '--view-address'] as const
-const NETWORK_FLAGS = ['--network', '--rpc-url'] as const
-/**
- * Commands that never auto-load: `login`/`logout` manage the file, `dashboard`
- * needs no credential and opens a browser, and the pinning server is a daemon
- * that must not silently bind to an interactive, expiring session key.
- */
-const SKIPPED_COMMANDS = ['login', 'logout', 'dashboard', 'server'] as const
+/** Env var name and Commander attribute for every variable the file sources may supply. */
+const OPTION_FOR_ENV = {
+  PRIVATE_KEY: 'privateKey',
+  SESSION_KEY: 'sessionKey',
+  WALLET_ADDRESS: 'walletAddress',
+  VIEW_ADDRESS: 'viewAddress',
+  NETWORK: 'network',
+} as const
+
+export type LoadableEnvVar = keyof typeof OPTION_FOR_ENV
+
+const AUTH_ENV_VARS = [
+  'PRIVATE_KEY',
+  'SESSION_KEY',
+  'WALLET_ADDRESS',
+  'VIEW_ADDRESS',
+] as const satisfies LoadableEnvVar[]
 
 let loadedFrom: string | undefined
 let loadedNetwork: string | undefined
 let skippedForViewAddress = false
 
-/** True when argv carries any of `flags`, in `--flag value` or `--flag=value` form. */
-function hasFlag(argv: readonly string[], flags: readonly string[]): boolean {
-  return argv.some((arg) => flags.some((flag) => arg === flag || arg.startsWith(`${flag}=`)))
-}
-
-/** Global options that take their value as the next word, so that word is not the command. */
-const VALUED_GLOBAL_OPTIONS = [CREDENTIALS_FILE_FLAG] as const
-
-/** True when the first non-option argument names a command that never auto-loads. */
-function isSkippedCommand(argv: readonly string[]): boolean {
-  const words = argv.slice(2)
-  const index = words.findIndex(
-    (arg, i) => !arg.startsWith('-') && !(VALUED_GLOBAL_OPTIONS as readonly string[]).includes(words[i - 1] ?? '')
-  )
-  const command = words[index]
-  return command !== undefined && (SKIPPED_COMMANDS as readonly string[]).includes(command)
-}
-
 function isSet(env: NodeJS.ProcessEnv, name: string): boolean {
   return env[name] !== undefined && env[name] !== ''
 }
 
-function hasAuthEnv(env: NodeJS.ProcessEnv): boolean {
-  return AUTH_ENV_VARS.some((name) => isSet(env, name))
+/**
+ * True when a flag, an env var, or an earlier loader already supplied
+ * `name`. `NETWORK` counts as supplied when an RPC URL was chosen too, since
+ * the two are mutually exclusive.
+ */
+function isSupplied(command: Command, env: NodeJS.ProcessEnv, name: LoadableEnvVar): boolean {
+  if (name === 'NETWORK' && (command.getOptionValue('rpcUrl') !== undefined || isSet(env, 'RPC_URL'))) return true
+  return command.getOptionValue(OPTION_FOR_ENV[name]) !== undefined || isSet(env, name)
 }
 
 /**
- * Load `SESSION_KEY` and `WALLET_ADDRESS` from the session file into `env`
- * when nothing else supplied a credential, plus `NETWORK` when neither a
- * flag nor the env chose one, since the grant lives on the chain the key
- * was made for. A file without an owner address (login started but never
+ * Supply `name` from a file source unless something higher already did.
+ * The Commander option is set (with `source` as its provenance) only when
+ * the command declares it, exactly as Commander binds env vars; the env var
+ * is set for the code that reads `process.env` directly.
+ *
+ * @returns whether the value was used
+ */
+export function supplyCredential(
+  command: Command,
+  env: NodeJS.ProcessEnv,
+  name: LoadableEnvVar,
+  value: string,
+  source: 'file' | 'session'
+): boolean {
+  if (isSupplied(command, env, name)) return false
+  const attribute = OPTION_FOR_ENV[name]
+  if (command.options.some((option) => option.attributeName() === attribute)) {
+    command.setOptionValueWithSource(attribute, value, source)
+  }
+  env[name] = value
+  return true
+}
+
+/**
+ * Load `SESSION_KEY` and `WALLET_ADDRESS` from the session file when nothing
+ * else supplied a credential, plus `NETWORK` when neither a flag, the env,
+ * nor an RPC URL chose one, since the grant lives on the chain the key was
+ * made for. A file without an owner address (login started but never
  * authorized) is left alone, so the command hits the no-credentials error
- * and points at `login`. `login`, `logout`, and `server` never auto-load.
+ * and points at `login`. Runs from the `addAuthOptions` preAction hook, so
+ * commands without auth options (`login`, `logout`, `dashboard`, `server`)
+ * never auto-load.
  *
  * @returns the file path when it was used, otherwise undefined
  */
 export function applySessionFileCredentials(
-  argv: readonly string[] = process.argv,
+  command: Command,
   env: NodeJS.ProcessEnv = process.env,
   path: string = getSessionFilePath()
 ): string | undefined {
@@ -74,21 +99,22 @@ export function applySessionFileCredentials(
   loadedFrom = undefined
   loadedNetwork = undefined
   skippedForViewAddress = false
-  if (isSkippedCommand(argv) || hasFlag(argv, AUTH_FLAGS)) return undefined
-  if (hasAuthEnv(env)) {
+  const supplied = AUTH_ENV_VARS.filter((name) => isSupplied(command, env, name))
+  if (supplied.length > 0) {
     // Only VIEW_ADDRESS set: a usable login exists but read-only mode wins. Remembered so the
     // command can say why the saved login was not used.
-    const onlyViewAddress = isSet(env, 'VIEW_ADDRESS') && !AUTH_ENV_VARS.slice(0, 3).some((n) => isSet(env, n))
-    skippedForViewAddress = onlyViewAddress && readSessionFile(path)?.walletAddress !== undefined
+    const onlyViewAddress = supplied.length === 1 && supplied[0] === 'VIEW_ADDRESS'
+    skippedForViewAddress =
+      onlyViewAddress &&
+      command.getOptionValueSource('viewAddress') === 'env' &&
+      readSessionFile(path)?.walletAddress !== undefined
     return undefined
   }
   const session = readSessionFile(path)
   if (session?.walletAddress === undefined) return undefined
-  env.SESSION_KEY = session.sessionKey
-  env.WALLET_ADDRESS = session.walletAddress
-  if (session.network !== undefined && !isSet(env, 'NETWORK') && !hasFlag(argv, NETWORK_FLAGS)) {
-    env.NETWORK = session.network
-  }
+  supplyCredential(command, env, 'SESSION_KEY', session.sessionKey, 'session')
+  supplyCredential(command, env, 'WALLET_ADDRESS', session.walletAddress, 'session')
+  if (session.network !== undefined) supplyCredential(command, env, 'NETWORK', session.network, 'session')
   loadedFrom = path
   loadedNetwork = session.network
   if (isSet(env, 'CI')) {

--- a/src/utils/credential-source.ts
+++ b/src/utils/credential-source.ts
@@ -79,6 +79,13 @@ export function applySessionFileCredentials(
   }
   loadedFrom = path
   loadedNetwork = session.network
+  if (isSet(env, 'CI')) {
+    // A runner that reuses its home directory keeps this file between jobs, so
+    // every later job would upload as this owner. Said before any output.
+    console.error(
+      `Warning: CI is set and credentials came from the saved login at ${path}. Set PRIVATE_KEY, or SESSION_KEY and WALLET_ADDRESS, explicitly on CI so a stale login is never picked up.`
+    )
+  }
   return path
 }
 

--- a/src/utils/credential-source.ts
+++ b/src/utils/credential-source.ts
@@ -13,6 +13,7 @@
  */
 
 import { getSessionFilePath, readSessionFile } from '../login/session-file.js'
+import { CREDENTIALS_FILE_FLAG } from './credentials-file.js'
 
 const AUTH_ENV_VARS = ['PRIVATE_KEY', 'SESSION_KEY', 'WALLET_ADDRESS', 'VIEW_ADDRESS'] as const
 const AUTH_FLAGS = ['--private-key', '--session-key', '--wallet-address', '--view-address'] as const
@@ -33,9 +34,16 @@ function hasFlag(argv: readonly string[], flags: readonly string[]): boolean {
   return argv.some((arg) => flags.some((flag) => arg === flag || arg.startsWith(`${flag}=`)))
 }
 
+/** Global options that take their value as the next word, so that word is not the command. */
+const VALUED_GLOBAL_OPTIONS = [CREDENTIALS_FILE_FLAG] as const
+
 /** True when the first non-option argument names a command that never auto-loads. */
 function isSkippedCommand(argv: readonly string[]): boolean {
-  const command = argv.slice(2).find((arg) => !arg.startsWith('-'))
+  const words = argv.slice(2)
+  const index = words.findIndex(
+    (arg, i) => !arg.startsWith('-') && !(VALUED_GLOBAL_OPTIONS as readonly string[]).includes(words[i - 1] ?? '')
+  )
+  const command = words[index]
   return command !== undefined && (SKIPPED_COMMANDS as readonly string[]).includes(command)
 }
 

--- a/src/utils/credential-source.ts
+++ b/src/utils/credential-source.ts
@@ -16,6 +16,7 @@ import { getSessionFilePath, readSessionFile } from '../login/session-file.js'
 
 const AUTH_ENV_VARS = ['PRIVATE_KEY', 'SESSION_KEY', 'WALLET_ADDRESS', 'VIEW_ADDRESS'] as const
 const AUTH_FLAGS = ['--private-key', '--session-key', '--wallet-address', '--view-address'] as const
+const NETWORK_FLAGS = ['--network', '--rpc-url'] as const
 /**
  * Commands that never auto-load: `login`/`logout` manage the file, and the
  * pinning server is a daemon that must not silently bind to an interactive,
@@ -24,10 +25,12 @@ const AUTH_FLAGS = ['--private-key', '--session-key', '--wallet-address', '--vie
 const SKIPPED_COMMANDS = ['login', 'logout', 'server'] as const
 
 let loadedFrom: string | undefined
+let loadedNetwork: string | undefined
+let skippedForViewAddress = false
 
-/** True when argv carries any auth flag, in `--flag value` or `--flag=value` form. */
-function hasAuthFlag(argv: readonly string[]): boolean {
-  return argv.some((arg) => AUTH_FLAGS.some((flag) => arg === flag || arg.startsWith(`${flag}=`)))
+/** True when argv carries any of `flags`, in `--flag value` or `--flag=value` form. */
+function hasFlag(argv: readonly string[], flags: readonly string[]): boolean {
+  return argv.some((arg) => flags.some((flag) => arg === flag || arg.startsWith(`${flag}=`)))
 }
 
 /** True when the first non-option argument names a command that never auto-loads. */
@@ -36,16 +39,21 @@ function isSkippedCommand(argv: readonly string[]): boolean {
   return command !== undefined && (SKIPPED_COMMANDS as readonly string[]).includes(command)
 }
 
+function isSet(env: NodeJS.ProcessEnv, name: string): boolean {
+  return env[name] !== undefined && env[name] !== ''
+}
+
 function hasAuthEnv(env: NodeJS.ProcessEnv): boolean {
-  return AUTH_ENV_VARS.some((name) => env[name] !== undefined && env[name] !== '')
+  return AUTH_ENV_VARS.some((name) => isSet(env, name))
 }
 
 /**
  * Load `SESSION_KEY` and `WALLET_ADDRESS` from the session file into `env`
- * when nothing else supplied a credential. A file without an owner address
- * (login started but never authorized) is left alone, so the command hits
- * the no-credentials error and points at `login`. `login`, `logout`, and
- * `server` never auto-load.
+ * when nothing else supplied a credential, plus `NETWORK` when neither a
+ * flag nor the env chose one, since the grant lives on the chain the key
+ * was made for. A file without an owner address (login started but never
+ * authorized) is left alone, so the command hits the no-credentials error
+ * and points at `login`. `login`, `logout`, and `server` never auto-load.
  *
  * @returns the file path when it was used, otherwise undefined
  */
@@ -54,16 +62,37 @@ export function applySessionFileCredentials(
   env: NodeJS.ProcessEnv = process.env,
   path: string = getSessionFilePath()
 ): string | undefined {
-  if (isSkippedCommand(argv) || hasAuthFlag(argv) || hasAuthEnv(env)) return undefined
+  if (isSkippedCommand(argv) || hasFlag(argv, AUTH_FLAGS)) return undefined
+  if (hasAuthEnv(env)) {
+    // Only VIEW_ADDRESS set: a usable login exists but read-only mode wins. Remembered so the
+    // command can say why the saved login was not used.
+    const onlyViewAddress = isSet(env, 'VIEW_ADDRESS') && !AUTH_ENV_VARS.slice(0, 3).some((n) => isSet(env, n))
+    skippedForViewAddress = onlyViewAddress && readSessionFile(path)?.walletAddress !== undefined
+    return undefined
+  }
   const session = readSessionFile(path)
   if (session?.walletAddress === undefined) return undefined
   env.SESSION_KEY = session.sessionKey
   env.WALLET_ADDRESS = session.walletAddress
+  if (session.network !== undefined && !isSet(env, 'NETWORK') && !hasFlag(argv, NETWORK_FLAGS)) {
+    env.NETWORK = session.network
+  }
   loadedFrom = path
+  loadedNetwork = session.network
   return path
 }
 
 /** Path of the session file the running command's credentials came from, if any. */
 export function getSessionCredentialSource(): string | undefined {
   return loadedFrom
+}
+
+/** Network recorded in the session file the credentials came from, if any. */
+export function getSessionCredentialNetwork(): string | undefined {
+  return loadedNetwork
+}
+
+/** True when a usable saved login was skipped only because VIEW_ADDRESS is set. */
+export function wasSessionSkippedForViewAddress(): boolean {
+  return skippedForViewAddress
 }

--- a/src/utils/credentials-file.ts
+++ b/src/utils/credentials-file.ts
@@ -55,19 +55,14 @@ export function loadCredentialsFile(path: string, env: NodeJS.ProcessEnv = proce
   }
 
   const parsed = parseEnv(contents)
-  if (Object.keys(parsed).length === 0) {
-    throw new Error(
-      `--credentials-file: no usable entries in "${path}". Expected dotenv-style lines like:\n` +
-        `  SESSION_KEY=0x<64 hex>\n  WALLET_ADDRESS=0x<40 hex>\n` +
-        `(# comments and blank lines are ignored; "export KEY=VALUE" also works)`
-    )
-  }
   const ignored: string[] = []
+  let usable = 0
   for (const [key, value] of Object.entries(parsed)) {
     if (!(CREDENTIALS_FILE_VARS as readonly string[]).includes(key)) {
       ignored.push(key)
       continue
     }
+    usable += 1
     if (env[key] === undefined) {
       env[key] = value
     }
@@ -75,6 +70,13 @@ export function loadCredentialsFile(path: string, env: NodeJS.ProcessEnv = proce
   if (ignored.length > 0) {
     console.error(
       `--credentials-file: ignored ${ignored.join(', ')} (only ${CREDENTIALS_FILE_VARS.join(', ')} are read)`
+    )
+  }
+  if (usable === 0) {
+    throw new Error(
+      `--credentials-file: no usable entries in "${path}". Expected dotenv-style lines like:\n` +
+        `  SESSION_KEY=0x<64 hex>\n  WALLET_ADDRESS=0x<40 hex>\n` +
+        `(# comments and blank lines are ignored; "export KEY=VALUE" also works)`
     )
   }
 }

--- a/src/utils/credentials-file.ts
+++ b/src/utils/credentials-file.ts
@@ -9,13 +9,16 @@
  * Node validates its own `--env-file` before our code runs, so a bad path
  * produced a Node error instead of ours.
  *
- * Values from the file are applied to `process.env` only when the variable
- * is not already set, so a pre-existing environment variable always wins
- * over the file, and a `--flag` (which Commander resolves after this runs)
- * always wins over both.
+ * The file loads from a Commander `preAction` hook, after flags and env
+ * vars are resolved, and only supplies what they left unset. Each value is
+ * recorded with source `file`, so a `--flag` or an env var always wins over
+ * the file, across auth modes too: `PRIVATE_KEY` in the shell beats a
+ * session key pair in the file (see `resolveAuthMode` in cli-auth.ts).
  */
 import { readFileSync } from 'node:fs'
 import { parseEnv } from 'node:util'
+import type { Command } from 'commander'
+import { type LoadableEnvVar, supplyCredential } from './credential-source.js'
 
 export const CREDENTIALS_FILE_FLAG = '--credentials-file'
 
@@ -35,18 +38,17 @@ export const CREDENTIALS_FILE_VARS = [
   'WALLET_ADDRESS',
   'VIEW_ADDRESS',
   'NETWORK',
-] as const
+] as const satisfies LoadableEnvVar[]
 
 /**
- * Load the credential variables of a dotenv-style file at `path` into
- * `env`, without overriding variables already present in `env`. Other
+ * Read the credential variables of the dotenv-style file at `path`. Other
  * variables are ignored and named on stderr: a file from the console or a
  * teammate must not be able to point CONSOLE_URL or RPC_URL elsewhere.
  *
  * Throws with a clear, path-naming error if the file cannot be read
- * (e.g. it doesn't exist).
+ * (e.g. it doesn't exist) or holds no usable entry.
  */
-export function loadCredentialsFile(path: string, env: NodeJS.ProcessEnv = process.env): void {
+export function readCredentialsFile(path: string): Partial<Record<LoadableEnvVar, string>> {
   let contents: string
   try {
     contents = readFileSync(path, 'utf8')
@@ -54,17 +56,13 @@ export function loadCredentialsFile(path: string, env: NodeJS.ProcessEnv = proce
     throw new Error(`--credentials-file: could not read "${path}": ${describeReadError(error)}`)
   }
 
-  const parsed = parseEnv(contents)
+  const credentials: Partial<Record<LoadableEnvVar, string>> = {}
   const ignored: string[] = []
-  let usable = 0
-  for (const [key, value] of Object.entries(parsed)) {
-    if (!(CREDENTIALS_FILE_VARS as readonly string[]).includes(key)) {
+  for (const [key, value] of Object.entries(parseEnv(contents))) {
+    if (value !== undefined && (CREDENTIALS_FILE_VARS as readonly string[]).includes(key)) {
+      credentials[key as LoadableEnvVar] = value
+    } else {
       ignored.push(key)
-      continue
-    }
-    usable += 1
-    if (env[key] === undefined) {
-      env[key] = value
     }
   }
   if (ignored.length > 0) {
@@ -72,43 +70,25 @@ export function loadCredentialsFile(path: string, env: NodeJS.ProcessEnv = proce
       `--credentials-file: ignored ${ignored.join(', ')} (only ${CREDENTIALS_FILE_VARS.join(', ')} are read)`
     )
   }
-  if (usable === 0) {
+  if (Object.keys(credentials).length === 0) {
     throw new Error(
       `--credentials-file: no usable entries in "${path}". Expected dotenv-style lines like:\n` +
         `  SESSION_KEY=0x<64 hex>\n  WALLET_ADDRESS=0x<40 hex>\n` +
         `(# comments and blank lines are ignored; "export KEY=VALUE" also works)`
     )
   }
+  return credentials
 }
 
 /**
- * Scan `argv` for a position-independent `--credentials-file <path>` or
- * `--credentials-file=<path>` and return the path, or `undefined` if not present.
+ * preAction hook body: when `--credentials-file` was given (in any position,
+ * since the root program declares it), supply its variables at file
+ * precedence. No-op when the flag is absent.
  */
-export function findCredentialsFileArg(argv: string[]): string | undefined {
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i]
-    if (arg === undefined) {
-      continue
-    }
-    if (arg === CREDENTIALS_FILE_FLAG) {
-      return argv[i + 1]
-    }
-    if (arg.startsWith(`${CREDENTIALS_FILE_FLAG}=`)) {
-      return arg.slice(CREDENTIALS_FILE_FLAG.length + 1)
-    }
-  }
-  return undefined
-}
-
-/**
- * Pre-parse step: if `--credentials-file <path>` (or `=<path>`) appears anywhere in
- * `argv`, load it into `env` before Commander resolves env-backed options.
- * No-op when the flag is absent. Must run before `program.parse(...)`.
- */
-export function applyCredentialsFileArg(argv: string[] = process.argv, env: NodeJS.ProcessEnv = process.env): void {
-  const path = findCredentialsFileArg(argv)
-  if (path !== undefined) {
-    loadCredentialsFile(path, env)
+export function applyCredentialsFile(actionCommand: Command, env: NodeJS.ProcessEnv = process.env): void {
+  const path = actionCommand.optsWithGlobals<{ credentialsFile?: string }>().credentialsFile
+  if (path === undefined) return
+  for (const [name, value] of Object.entries(readCredentialsFile(path))) {
+    supplyCredential(actionCommand, env, name as LoadableEnvVar, value, 'file')
   }
 }

--- a/src/utils/credentials-file.ts
+++ b/src/utils/credentials-file.ts
@@ -28,9 +28,20 @@ function describeReadError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+/** The only variables a credentials file may set: anything else could steer the CLI, not authenticate it. */
+export const CREDENTIALS_FILE_VARS = [
+  'PRIVATE_KEY',
+  'SESSION_KEY',
+  'WALLET_ADDRESS',
+  'VIEW_ADDRESS',
+  'NETWORK',
+] as const
+
 /**
- * Load a dotenv-style file at `path` into `env`, without overriding
- * variables already present in `env`.
+ * Load the credential variables of a dotenv-style file at `path` into
+ * `env`, without overriding variables already present in `env`. Other
+ * variables are ignored and named on stderr: a file from the console or a
+ * teammate must not be able to point CONSOLE_URL or RPC_URL elsewhere.
  *
  * Throws with a clear, path-naming error if the file cannot be read
  * (e.g. it doesn't exist).
@@ -51,10 +62,20 @@ export function loadCredentialsFile(path: string, env: NodeJS.ProcessEnv = proce
         `(# comments and blank lines are ignored; "export KEY=VALUE" also works)`
     )
   }
+  const ignored: string[] = []
   for (const [key, value] of Object.entries(parsed)) {
+    if (!(CREDENTIALS_FILE_VARS as readonly string[]).includes(key)) {
+      ignored.push(key)
+      continue
+    }
     if (env[key] === undefined) {
       env[key] = value
     }
+  }
+  if (ignored.length > 0) {
+    console.error(
+      `--credentials-file: ignored ${ignored.join(', ')} (only ${CREDENTIALS_FILE_VARS.join(', ')} are read)`
+    )
   }
 }
 


### PR DESCRIPTION
Stacked on #700 (`feat/login-command`).

Implements credential resolution from PRD section 5 and the wall and expiry messages from section 6.

For every command the order is: explicit flags, then env vars (`PRIVATE_KEY`, or `SESSION_KEY` + `WALLET_ADDRESS`), then `--credentials-file`, then the session file `login` wrote, then the `No credentials found` wall pointing at `login`. `applySessionFileCredentials` runs in `cli.ts` before Commander parses and loads the file only when no auth flag is on argv and no auth env var is set. A file without an owner address is ignored. `login`, `logout`, `dashboard`, and `server` never auto-load.

The saved login's network applies when neither `--network` nor `NETWORK` chose one; using it under another network prints a warning naming the fix. The `Using session …` line names the key, its source, the owner, and the network. When `VIEW_ADDRESS` alone keeps a usable login out, the command says so. When `CI` is set and the saved login supplied the credentials, a stderr warning tells the job to set credentials explicitly.

A credentials file may set only `PRIVATE_KEY`, `SESSION_KEY`, `WALLET_ADDRESS`, `VIEW_ADDRESS`, and `NETWORK`; anything else is ignored and named, so a file from a console or a teammate cannot point `CONSOLE_URL` or `RPC_URL` elsewhere.

Expired grants fail with `Session expired` and point at `login`. Top-level help has a CREDENTIALS block with the full order.

Tests: env beats file, flags beat both, unfinished login ignored, network export and precedence, VIEW_ADDRESS skip, CI warning, allowlist, expired wording, wall text.

Part of #697.
