### PR TITLE
refactor: use env-paths for data dirs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ src/
 
 **Optional**: `NETWORK`, `RPC_URL`, `EGRESS_PROVIDER`, `FOC_DEVNET_BASEDIR`, `DEVNET_INFO_PATH`, `DEVNET_USER_INDEX`, `PORT`, `HOST`, `DATABASE_PATH`, `CAR_STORAGE_PATH`, `LOG_LEVEL`
 
-**Default data dirs for pinning server**: Linux `~/.local/share/filecoin-pin/`, macOS `~/Library/Application Support/filecoin-pin/`, Windows `%APPDATA%/filecoin-pin/`
+**Default data dirs for pinning server** (via `env-paths`): Linux `~/.local/share/filecoin-pin/`, macOS `~/Library/Application Support/filecoin-pin/`, Windows `%LOCALAPPDATA%\filecoin-pin\Data\`
 
 ## Git Policy
 

--- a/README.md
+++ b/README.md
@@ -291,10 +291,10 @@ DO_NOT_TRACK=1                              # Standard cross-tool opt-out
 
 ### Default Data Directories
 
-When `DATABASE_PATH` and `CAR_STORAGE_PATH` are not specified, data is stored in platform-specific locations:
-- **Linux**: `~/.local/share/filecoin-pin/`
+When `DATABASE_PATH` and `CAR_STORAGE_PATH` are not specified, data is stored in platform-specific locations (via [`env-paths`](https://github.com/sindresorhus/env-paths)):
+- **Linux**: `~/.local/share/filecoin-pin/` (or `$XDG_DATA_HOME/filecoin-pin/`)
 - **macOS**: `~/Library/Application Support/filecoin-pin/`
-- **Windows**: `%APPDATA%/filecoin-pin/`
+- **Windows**: `%LOCALAPPDATA%\filecoin-pin\Data\`
 
 ### Local Development with foc-devnet
 

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@sentry/node": "^10.49.0",
     "commander": "^15.0.0",
     "datastore-core": "^11.0.4",
+    "env-paths": "3.0.0",
     "fastify": "^5.8.5",
     "interface-blockstore": "^7.0.1",
     "interface-store": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       datastore-core:
         specifier: ^11.0.4
         version: 11.0.4
+      env-paths:
+        specifier: 3.0.0
+        version: 3.0.0
       fastify:
         specifier: ^5.8.5
         version: 5.11.3

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
-import { homedir, platform } from 'node:os'
 import { join } from 'node:path'
 import type { FilecoinChain } from '@filoz/synapse-sdk'
+import envPaths from 'env-paths'
 import { getRpcUrl, NETWORK_CHAINS, normalizeNetworkName, resolveDevnetConfig } from './common/get-rpc-url.js'
 import type { Config } from './core/synapse/index.js'
 
@@ -12,29 +12,6 @@ function resolveChain(network: string | undefined, hasExplicitRpcUrl: boolean): 
   // overrode RPC_URL — they may just have a stale NETWORK=devnet and the file may not exist.
   if (normalized === 'devnet' && !hasExplicitRpcUrl) return resolveDevnetConfig().chain
   return undefined
-}
-
-function getDataDirectory(): string {
-  const home = homedir()
-  const plat = platform()
-
-  // Follow XDG Base Directory Specification on Linux
-  if (plat === 'linux') {
-    return process.env.XDG_DATA_HOME ?? join(home, '.local', 'share', 'filecoin-pin')
-  }
-
-  // macOS uses ~/Library/Application Support (same as config)
-  if (plat === 'darwin') {
-    return join(home, 'Library', 'Application Support', 'filecoin-pin')
-  }
-
-  // Windows uses %APPDATA%
-  if (plat === 'win32') {
-    return join(process.env.APPDATA ?? join(home, 'AppData', 'Roaming'), 'filecoin-pin')
-  }
-
-  // Fallback for other platforms
-  return join(home, '.filecoin-pin')
 }
 
 /**
@@ -49,7 +26,7 @@ function getDataDirectory(): string {
  * - NETWORK: Filecoin network name (mainnet, calibration, devnet) — used if RPC_URL not set
  */
 export function createConfig(): Config {
-  const dataDir = getDataDirectory()
+  const dataDir = envPaths('filecoin-pin', { suffix: '' }).data
 
   // NETWORK and RPC_URL are mutually exclusive. The CLI enforces this via Commander, but library
   // consumers calling createConfig() bypass that check, so guard explicitly here as well.

--- a/src/test/unit/config.test.ts
+++ b/src/test/unit/config.test.ts
@@ -1,6 +1,6 @@
-import { homedir, platform } from 'node:os'
 import { join } from 'node:path'
 import { calibration, mainnet } from '@filoz/synapse-sdk'
+import envPaths from 'env-paths'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createConfig } from '../../config.js'
 
@@ -41,20 +41,7 @@ describe('Config', () => {
   it('should create default config', () => {
     const config = createConfig()
 
-    // Get expected data directory based on platform
-    const home = homedir()
-    const plat = platform()
-    let expectedDataDir: string
-
-    if (plat === 'linux') {
-      expectedDataDir = process.env.XDG_DATA_HOME ?? join(home, '.local', 'share', 'filecoin-pin')
-    } else if (plat === 'darwin') {
-      expectedDataDir = join(home, 'Library', 'Application Support', 'filecoin-pin')
-    } else if (plat === 'win32') {
-      expectedDataDir = join(process.env.APPDATA ?? join(home, 'AppData', 'Roaming'), 'filecoin-pin')
-    } else {
-      expectedDataDir = join(home, '.filecoin-pin')
-    }
+    const expectedDataDir = envPaths('filecoin-pin', { suffix: '' }).data
 
     const expectedRpcUrl = mainnet.rpcUrls.default.webSocket?.[0] ?? mainnet.rpcUrls.default.http[0]
 


### PR DESCRIPTION
just swapping to env-paths instead of rolling our own.